### PR TITLE
feat(core): chdis — charge/discharge segmentation

### DIFF
--- a/src/toyo_battery/core/cell.py
+++ b/src/toyo_battery/core/cell.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
 
 import pandas as pd
 
+from toyo_battery.core.chdis import get_chdis_df
 from toyo_battery.io.reader import read_cell_dir
 from toyo_battery.io.schema import ColumnLang
 
@@ -15,8 +17,9 @@ from toyo_battery.io.schema import ColumnLang
 class Cell:
     """Single-cell measurement + derived quantities.
 
-    P1: holds the normalized raw DataFrame. Derived tables (chdis, capacity,
-    dQ/dV, stats) land in subsequent P1 branches.
+    ``raw_df`` is the normalized source frame. Derived tables (``chdis_df``
+    and, in subsequent branches, capacity / dQ-dV / stats) are exposed as
+    ``cached_property`` so they materialize on first access and are reused.
     """
 
     name: str
@@ -36,3 +39,7 @@ class Cell:
         p = Path(path)
         df, mass_g = read_cell_dir(p, mass=mass, encoding=encoding, column_lang=column_lang)
         return cls(name=p.name, mass_g=mass_g, raw_df=df, column_lang=column_lang)
+
+    @cached_property
+    def chdis_df(self) -> pd.DataFrame:
+        return get_chdis_df(self.raw_df, column_lang=self.column_lang)

--- a/src/toyo_battery/core/cell.py
+++ b/src/toyo_battery/core/cell.py
@@ -20,6 +20,11 @@ class Cell:
     ``raw_df`` is the normalized source frame. Derived tables (``chdis_df``
     and, in subsequent branches, capacity / dQ-dV / stats) are exposed as
     ``cached_property`` so they materialize on first access and are reused.
+
+    ``raw_df`` is treated as immutable after construction. Mutating it in
+    place (e.g. ``cell.raw_df.drop(...)``) will leave any already-accessed
+    cached properties stale. Build a new ``Cell`` from the modified frame
+    instead.
     """
 
     name: str

--- a/src/toyo_battery/core/chdis.py
+++ b/src/toyo_battery/core/chdis.py
@@ -1,1 +1,106 @@
-"""Charge/discharge segmentation. P1 scope — scaffold only."""
+"""Charge/discharge segmentation.
+
+Splits a raw DataFrame (from :func:`toyo_battery.io.reader.read_cell_dir`)
+into per-cycle charge/discharge segments. The output is a wide DataFrame
+with a 3-level column MultiIndex:
+
+    level 0  cycle    — int cycle number (1, 2, 3, ...)
+    level 1  side     — "ch" or "dis"
+    level 2  quantity — "電気量"/"電圧" (or EN equivalents) as in the input
+
+The TOYO 連続データ format has 電気量 reset to 0 at the start of each
+segment and accumulate monotonically within it (positive for both charge
+and discharge). Rows where 電気量 reverses within a segment
+(``diff() < 0``) are dropped — these typically come from tester-side
+bookkeeping glitches.
+
+First-cycle-is-charge normalization: if cycle 1 begins with 放電
+(discharge), *all* 状態 labels in the frame are swapped (充電 ↔ 放電).
+This is the convention used by TOYO workflows where half-cells can be
+characterized in either direction.
+
+Rewrite note (vs. legacy TOYO_Origin_2.01): the original used string
+MultiIndex labels like ``"1-ch"`` and checked the first-cycle direction
+from ``df.at[1, "状態"]`` (row *1*, not row 0). This implementation uses
+tuple labels ``(1, "ch", "電気量")`` and checks the first row of the
+first cycle. Numerical values are unchanged.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from toyo_battery.io.schema import JA_TO_EN, ColumnLang
+
+_CHARGE = "充電"
+_DISCHARGE = "放電"
+_STATE_TO_SIDE = {_CHARGE: "ch", _DISCHARGE: "dis"}
+
+_JA_COLS: dict[str, str] = {
+    "cycle": "サイクル",
+    "state": "状態",
+    "voltage": "電圧",
+    "capacity": "電気量",
+}
+
+
+def _resolve_cols(column_lang: ColumnLang) -> dict[str, str]:
+    if column_lang == "ja":
+        return _JA_COLS
+    return {k: JA_TO_EN[v] for k, v in _JA_COLS.items()}
+
+
+def _empty_result() -> pd.DataFrame:
+    idx = pd.MultiIndex.from_tuples([], names=["cycle", "side", "quantity"])
+    return pd.DataFrame(columns=idx)
+
+
+def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.DataFrame:
+    """Segment a raw cell DataFrame into per-cycle ch/dis pairs.
+
+    Parameters
+    ----------
+    df
+        Output of :func:`toyo_battery.io.reader.read_cell_dir`. Must contain
+        サイクル/状態/電圧/電気量 columns (or their EN equivalents when
+        ``column_lang="en"``). ``状態`` cell values are always JA
+        (``充電``/``放電``/``休止``) regardless of ``column_lang``.
+    column_lang
+        Language of the input column names and the ``quantity`` level of
+        the returned MultiIndex.
+
+    Returns
+    -------
+    DataFrame
+        Columns: MultiIndex with levels ``cycle``, ``side``, ``quantity``.
+        For missing pairs (e.g. a cycle that only has a charge segment),
+        rows are padded with NaN so all segments share a single row axis.
+    """
+    cols = _resolve_cols(column_lang)
+    cap_col, v_col, cycle_col, state_col = (
+        cols["capacity"],
+        cols["voltage"],
+        cols["cycle"],
+        cols["state"],
+    )
+
+    working = df.loc[df[state_col].isin([_CHARGE, _DISCHARGE])].reset_index(drop=True)
+    if working.empty:
+        return _empty_result()
+
+    first_cycle = working[cycle_col].min()
+    first_state = working.loc[working[cycle_col] == first_cycle, state_col].iloc[0]
+    if first_state == _DISCHARGE:
+        working = working.assign(
+            **{state_col: working[state_col].map({_CHARGE: _DISCHARGE, _DISCHARGE: _CHARGE})}
+        )
+
+    pieces: dict[tuple[int, str], pd.DataFrame] = {}
+    for (cycle_val, state_val), g in working.groupby([cycle_col, state_col], sort=True):
+        side = _STATE_TO_SIDE[str(state_val)]
+        segment = g[[cap_col, v_col]].loc[~(g[cap_col].diff() < 0)].reset_index(drop=True)
+        pieces[(int(cycle_val), side)] = segment
+
+    out = pd.concat(pieces, axis=1)
+    out.columns = out.columns.set_names(["cycle", "side", "quantity"])
+    return out

--- a/src/toyo_battery/core/chdis.py
+++ b/src/toyo_battery/core/chdis.py
@@ -8,22 +8,27 @@ with a 3-level column MultiIndex:
     level 1  side     — "ch" or "dis"
     level 2  quantity — "電気量"/"電圧" (or EN equivalents) as in the input
 
-The TOYO 連続データ format has 電気量 reset to 0 at the start of each
-segment and accumulate monotonically within it (positive for both charge
-and discharge). Rows where 電気量 reverses within a segment
-(``diff() < 0``) are dropped — these typically come from tester-side
-bookkeeping glitches.
+Capacity sign: within a segment, ``電気量`` may be either monotone-positive
+(real TOYO 連続データ format, where the tester resets to 0 per segment) or
+signed (output of the reader's raw-6-digit path, where discharge current
+is negative and capacity accumulates negatively). The reversal filter
+operates on the **absolute** capacity so it works under either convention:
+rows where ``|電気量|.diff() < 0`` are dropped as tester-side glitches.
 
-First-cycle-is-charge normalization: if cycle 1 begins with 放電
-(discharge), *all* 状態 labels in the frame are swapped (充電 ↔ 放電).
-This is the convention used by TOYO workflows where half-cells can be
-characterized in either direction.
+First-cycle-is-charge normalization: if cycle 1 begins with 放電 (discharge),
+*all* 状態 labels in the frame are swapped (充電 ↔ 放電). This is the TOYO
+convention for half-cells characterized discharge-first. Callers with an
+unusual dataset where only cycle 1 is discharge-first (e.g. a one-off
+formation discharge followed by normal charge-first cycles) must relabel
+before calling this function. A test pins the global-swap behavior so
+regressions are visible.
 
 Rewrite note (vs. legacy TOYO_Origin_2.01): the original used string
 MultiIndex labels like ``"1-ch"`` and checked the first-cycle direction
 from ``df.at[1, "状態"]`` (row *1*, not row 0). This implementation uses
-tuple labels ``(1, "ch", "電気量")`` and checks the first row of the
-first cycle. Numerical values are unchanged.
+tuple labels ``(1, "ch", "電気量")`` and checks the first row of the first
+cycle, which is also more robust against a rest row at position 0 that
+v2.01 could misread.
 """
 
 from __future__ import annotations
@@ -75,8 +80,22 @@ def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.Data
         Columns: MultiIndex with levels ``cycle``, ``side``, ``quantity``.
         For missing pairs (e.g. a cycle that only has a charge segment),
         rows are padded with NaN so all segments share a single row axis.
+
+    Raises
+    ------
+    KeyError
+        If the input frame is missing any of the required columns for the
+        requested ``column_lang``.
     """
     cols = _resolve_cols(column_lang)
+    required = [cols[k] for k in ("cycle", "state", "voltage", "capacity")]
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise KeyError(
+            f"input missing required columns {missing} "
+            f"for column_lang={column_lang!r}; got columns={list(df.columns)}"
+        )
+
     cap_col, v_col, cycle_col, state_col = (
         cols["capacity"],
         cols["voltage"],
@@ -98,7 +117,9 @@ def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.Data
     pieces: dict[tuple[int, str], pd.DataFrame] = {}
     for (cycle_val, state_val), g in working.groupby([cycle_col, state_col], sort=True):
         side = _STATE_TO_SIDE[str(state_val)]
-        segment = g[[cap_col, v_col]].loc[~(g[cap_col].diff() < 0)].reset_index(drop=True)
+        # abs() so the filter works whether capacity is monotone-positive
+        # (real 連続データ) or signed (reader's raw-6-digit formula output).
+        segment = g[[cap_col, v_col]].loc[~(g[cap_col].abs().diff() < 0)].reset_index(drop=True)
         pieces[(int(cycle_val), side)] = segment
 
     out = pd.concat(pieces, axis=1)

--- a/tests/test_chdis.py
+++ b/tests/test_chdis.py
@@ -171,11 +171,54 @@ def test_cell_chdis_df_respects_column_lang(make_cell_dir: Callable[..., Path]) 
 
 @pytest.mark.parametrize("layout", ["renzoku", "renzoku_py", "raw_6digit"])
 def test_cell_chdis_df_from_all_layouts(make_cell_dir: Callable[..., Path], layout: str) -> None:
-    """Sanity check: Cell.from_dir → chdis_df works for every supported layout."""
-    # renzoku layout with sentinel 電気量 values (100..104, monotone) preserves
-    # both charge and discharge segments; the other two layouts round-trip
-    # through the reader's signed-capacity formula and may drop reversal rows,
-    # but cycle 1 ch must always be present.
+    """All three reader layouts produce a 2+2 row ch/dis shape for the shared fixture.
+
+    Each fixture writes exactly 2 charge rows + 1 rest + 2 discharge rows (plus 1
+    extra leading/trailing row in some variants). The reversal filter runs on
+    ``|電気量|`` so the signed-capacity output of the raw-6-digit and
+    renzoku-without-precomputed-capacity paths is preserved, not silently dropped.
+    """
     cell = Cell.from_dir(make_cell_dir(layout))
     out = cell.chdis_df
-    assert (1, "ch", "電気量") in out.columns
+    assert out[(1, "ch", "電気量")].notna().sum() == 2
+    assert out[(1, "dis", "電気量")].notna().sum() == 2
+
+
+def test_missing_required_column_raises_helpful_error() -> None:
+    df = pd.DataFrame([(1, "充電", 3.5, 0.0)], columns=["サイクル", "状態", "電圧", "まちがい"])
+    with pytest.raises(KeyError, match="電気量"):
+        get_chdis_df(df)
+
+
+def test_wrong_column_lang_raises_with_context() -> None:
+    """Passing JA columns with ``column_lang='en'`` surfaces a helpful error."""
+    df = _raw([(1, "充電", 3.5, 0.0)], lang="ja")
+    with pytest.raises(KeyError, match="column_lang='en'"):
+        get_chdis_df(df, column_lang="en")
+
+
+def test_first_cycle_discharge_swaps_all_cycles_globally() -> None:
+    """If cycle 1 starts with 放電, *every* cycle's labels are swapped.
+
+    This is the TOYO half-cell convention. Half-cell data where cycles 2+ are
+    also naturally "discharge-first" get normalized consistently. Callers with
+    a one-off formation-discharge on cycle 1 and normal cycles 2+ must relabel
+    before calling get_chdis_df — this test pins the current semantics so
+    regressions are loud.
+    """
+    rows = []
+    for cycle in (1, 2, 3):
+        rows.extend(
+            [
+                (cycle, "放電", 3.60, 0.0),
+                (cycle, "放電", 3.40, 500.0),
+                (cycle, "充電", 3.40, 0.0),
+                (cycle, "充電", 3.60, 500.0),
+            ]
+        )
+    out = get_chdis_df(_raw(rows))
+
+    # All cycles: originally-放電 voltages (3.60, 3.40) land under the "ch" side.
+    for cycle in (1, 2, 3):
+        assert out[(cycle, "ch", "電圧")].dropna().tolist() == [3.60, 3.40]
+        assert out[(cycle, "dis", "電圧")].dropna().tolist() == [3.40, 3.60]

--- a/tests/test_chdis.py
+++ b/tests/test_chdis.py
@@ -1,0 +1,181 @@
+"""Tests for :mod:`toyo_battery.core.chdis`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pandas as pd
+import pytest
+
+from toyo_battery.core.cell import Cell
+from toyo_battery.core.chdis import get_chdis_df
+
+
+def _raw(
+    rows: list[tuple[int, str, float, float]],
+    *,
+    lang: str = "ja",
+) -> pd.DataFrame:
+    """Build a minimal canonical raw frame. Row tuple = (cycle, state, voltage, capacity)."""
+    if lang == "ja":
+        columns = ["サイクル", "状態", "電圧", "電気量"]
+    else:
+        columns = ["cycle", "state", "voltage", "capacity"]
+    return pd.DataFrame(rows, columns=columns)
+
+
+def test_single_cycle_charge_then_discharge() -> None:
+    df = _raw(
+        [
+            (1, "充電", 3.50, 0.0),
+            (1, "充電", 3.60, 500.0),
+            (1, "休止", 3.61, 500.0),
+            (1, "放電", 3.60, 0.0),
+            (1, "放電", 3.40, 500.0),
+        ]
+    )
+    out = get_chdis_df(df)
+    assert list(out.columns.names) == ["cycle", "side", "quantity"]
+    assert set(out.columns.get_level_values("cycle")) == {1}
+    assert set(out.columns.get_level_values("side")) == {"ch", "dis"}
+
+    ch_cap = out[(1, "ch", "電気量")].dropna().tolist()
+    assert ch_cap == [0.0, 500.0]
+    dis_cap = out[(1, "dis", "電気量")].dropna().tolist()
+    assert dis_cap == [0.0, 500.0]
+
+
+def test_rest_rows_filtered_out() -> None:
+    df = _raw(
+        [
+            (1, "休止", 3.00, 0.0),
+            (1, "充電", 3.50, 0.0),
+            (1, "充電", 3.60, 500.0),
+            (1, "休止", 3.61, 500.0),
+            (1, "放電", 3.60, 0.0),
+            (1, "放電", 3.40, 500.0),
+            (1, "休止", 3.40, 500.0),
+        ]
+    )
+    out = get_chdis_df(df)
+    assert out[(1, "ch", "電気量")].notna().sum() == 2
+    assert out[(1, "dis", "電気量")].notna().sum() == 2
+
+
+def test_capacity_reversal_rows_dropped() -> None:
+    df = _raw(
+        [
+            (1, "充電", 3.50, 0.0),
+            (1, "充電", 3.60, 500.0),
+            (1, "充電", 3.55, 400.0),  # reversal — drop
+            (1, "充電", 3.65, 600.0),
+        ]
+    )
+    out = get_chdis_df(df)
+    assert out[(1, "ch", "電気量")].dropna().tolist() == [0.0, 500.0, 600.0]
+    assert out[(1, "ch", "電圧")].dropna().tolist() == [3.50, 3.60, 3.65]
+
+
+def test_discharge_first_triggers_state_swap() -> None:
+    """If the first cycle starts with 放電, all state labels are swapped so
+    the cell is treated as charge-first."""
+    df = _raw(
+        [
+            (1, "放電", 3.60, 0.0),
+            (1, "放電", 3.40, 500.0),
+            (1, "充電", 3.40, 0.0),
+            (1, "充電", 3.60, 500.0),
+        ]
+    )
+    out = get_chdis_df(df)
+    # After the swap, the original 放電 rows are treated as "ch" (charge).
+    ch_v = out[(1, "ch", "電圧")].dropna().tolist()
+    assert ch_v == [3.60, 3.40]
+    dis_v = out[(1, "dis", "電圧")].dropna().tolist()
+    assert dis_v == [3.40, 3.60]
+
+
+def test_multi_cycle_multiindex_shape() -> None:
+    rows = []
+    for cycle in (1, 2, 3):
+        rows.extend(
+            [
+                (cycle, "充電", 3.50, 0.0),
+                (cycle, "充電", 3.60, 500.0),
+                (cycle, "放電", 3.60, 0.0),
+                (cycle, "放電", 3.40, 500.0 - cycle * 10),  # mild fade
+            ]
+        )
+    out = get_chdis_df(_raw(rows))
+
+    assert sorted(set(out.columns.get_level_values("cycle"))) == [1, 2, 3]
+    for cycle in (1, 2, 3):
+        assert (cycle, "ch", "電気量") in out.columns
+        assert (cycle, "dis", "電気量") in out.columns
+        assert (cycle, "ch", "電圧") in out.columns
+        assert (cycle, "dis", "電圧") in out.columns
+
+
+def test_column_lang_en() -> None:
+    df = _raw(
+        [
+            (1, "充電", 3.50, 0.0),
+            (1, "充電", 3.60, 500.0),
+            (1, "放電", 3.60, 0.0),
+            (1, "放電", 3.40, 500.0),
+        ],
+        lang="en",
+    )
+    out = get_chdis_df(df, column_lang="en")
+    assert set(out.columns.get_level_values("quantity")) == {"capacity", "voltage"}
+    assert (1, "ch", "capacity") in out.columns
+    assert out[(1, "dis", "voltage")].dropna().tolist() == [3.60, 3.40]
+
+
+def test_empty_frame_returns_empty_multiindex() -> None:
+    out = get_chdis_df(_raw([]))
+    assert out.empty
+    assert list(out.columns.names) == ["cycle", "side", "quantity"]
+
+
+def test_only_rest_rows_returns_empty() -> None:
+    df = _raw(
+        [
+            (1, "休止", 3.00, 0.0),
+            (1, "休止", 3.01, 0.0),
+        ]
+    )
+    out = get_chdis_df(df)
+    assert out.empty
+
+
+def test_cell_chdis_df_is_cached(make_cell_dir: Callable[..., Path]) -> None:
+    """Cell.chdis_df is a cached_property — second access returns the same object."""
+    cell_dir = make_cell_dir("renzoku", include_capacity_col=True)
+    cell = Cell.from_dir(cell_dir)
+
+    first = cell.chdis_df
+    second = cell.chdis_df
+    assert first is second
+    assert (1, "ch", "電気量") in first.columns
+    assert (1, "dis", "電気量") in first.columns
+
+
+def test_cell_chdis_df_respects_column_lang(make_cell_dir: Callable[..., Path]) -> None:
+    cell_dir = make_cell_dir("renzoku", include_capacity_col=True)
+    cell = Cell.from_dir(cell_dir, column_lang="en")
+    out = cell.chdis_df
+    assert set(out.columns.get_level_values("quantity")) == {"capacity", "voltage"}
+
+
+@pytest.mark.parametrize("layout", ["renzoku", "renzoku_py", "raw_6digit"])
+def test_cell_chdis_df_from_all_layouts(make_cell_dir: Callable[..., Path], layout: str) -> None:
+    """Sanity check: Cell.from_dir → chdis_df works for every supported layout."""
+    # renzoku layout with sentinel 電気量 values (100..104, monotone) preserves
+    # both charge and discharge segments; the other two layouts round-trip
+    # through the reader's signed-capacity formula and may drop reversal rows,
+    # but cycle 1 ch must always be present.
+    cell = Cell.from_dir(make_cell_dir(layout))
+    out = cell.chdis_df
+    assert (1, "ch", "電気量") in out.columns


### PR DESCRIPTION
## Summary
- Port `get_chdis_df` from `TOYO_Origin_2.01` as a rewrite, not a bug-for-bug port: tuple MultiIndex columns `(cycle, side, quantity)` replace the legacy `"{n}-ch"` string labels, and the first-cycle-is-charge check now reads row 0 of the first cycle instead of `df.at[1, ...]` (likely a legacy bug).
- Expose `Cell.chdis_df` as a `cached_property`, so the segmented frame is shared across subsequent P1 phases (capacity / dQ-dV / stats) without recompute.
- Preserve the `diff() < 0` reversal-row filter — real TOYO 連続データ has 電気量 reset per segment and accumulate monotonically, so reversal rows are tester glitches.

## Test plan
- [x] `uv run ruff check .` / `ruff format --check .`
- [x] `uv run mypy` (strict, 20 src files)
- [x] `uv run pytest` — 45 passed, 88% coverage (chdis.py at 100%)
- [x] All three reader layouts (renzoku / renzoku_py / raw_6digit) round-trip through `Cell.chdis_df`
- [x] First-cycle-discharge input swaps 充電 ↔ 放電 as documented
- [x] `cached_property` identity: `cell.chdis_df is cell.chdis_df`

Closes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)