### PR TITLE
feat(io): align reader and fixtures with real TOYO format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ htmlcov/
 coverage.xml
 .tox/
 .nox/
+data/
 
 # Type checking
 .mypy_cache/

--- a/src/toyo_battery/core/chdis.py
+++ b/src/toyo_battery/core/chdis.py
@@ -8,12 +8,14 @@ with a 3-level column MultiIndex:
     level 1  side     — "ch" or "dis"
     level 2  quantity — "電気量"/"電圧" (or EN equivalents) as in the input
 
-Capacity sign: within a segment, ``電気量`` may be either monotone-positive
-(real TOYO 連続データ format, where the tester resets to 0 per segment) or
-signed (output of the reader's raw-6-digit path, where discharge current
-is negative and capacity accumulates negatively). The reversal filter
-operates on the **absolute** capacity so it works under either convention:
-rows where ``|電気量|.diff() < 0`` are dropped as tester-side glitches.
+Capacity sign: real TOYO data has ``電気量`` reset to 0 at the start of each
+segment and accumulate monotone-non-decreasing within it — the native
+``連続データ.csv`` supplies such values inline, and the raw-6-digit path
+reproduces the same convention because its ``経過時間[Sec]`` resets at
+state transitions and its ``電流[mA]`` is unsigned. The reversal filter
+nonetheless takes ``|電気量|`` so that *any* signed input (e.g. a
+hand-crafted dataset with polarity applied) segments correctly. Rows
+where ``|電気量|.diff() < 0`` are dropped as tester-side glitches.
 
 First-cycle-is-charge normalization: if cycle 1 begins with 放電 (discharge),
 *all* 状態 labels in the frame are swapped (充電 ↔ 放電). This is the TOYO

--- a/src/toyo_battery/io/reader.py
+++ b/src/toyo_battery/io/reader.py
@@ -2,31 +2,42 @@
 
 Discovery priority for a given cell directory ``path``:
 
-1. ``連続データ.csv``              — native export from the tester (header=3, skiprows=[4,5,6])
+1. ``連続データ.csv``              — native export from the tester
+   (7-line header: 3 metadata rows, then column-name row, channel row,
+   separator row, units row; ``header=3, skiprows=[4,5,6]``)
 2. ``連続データ_py.csv``           — already-normalized output from a previous run
 3. 6-digit raw file(s) + ``*.PTN`` — factory raw; 電気量 is computed from mass
 
 All three paths converge on the same canonical schema (canonical columns first;
-any extra source columns such as 経過時間[Sec] / 電流[mA] are preserved after
-them so downstream P1 phases can use them):
+any extra source columns such as 経過時間[Sec] / 電流[mA] / 日付 / 時刻 /
+総ｻｲｸﾙ are preserved after them so downstream P1 phases can use them):
 
     Canonical columns: サイクル, モード, 状態, 電圧, 電気量
-    状態 values: {"休止", "充電", "放電"} (or NaN where the source had no value)
-
-The column count therefore differs from legacy v2.01, which dropped the raw
-measurement columns after computing 電気量. Numerical parity with v2.01 holds
-on the canonical 5-column subset; tests that compare whole DataFrames must
-project to that subset first.
+    状態 values:
+      - Native 連続データ.csv:  {"充電", "放電", "充電休止", "放電休止"}
+      - Raw 6-digit (int→JA):   {"充電", "放電", "休止"}
+      - 連続データ_py.csv:       whatever was persisted (usually the 3-value set)
 
 When ``column_lang="en"`` is requested, only column *names* are translated.
 状態 cell values stay JP — translate via ``schema.STATE_JA_TO_EN`` downstream
 if needed.
 
-The active-material mass (grams) is required to compute 電気量 when the source
-file does not already contain it. It comes from (in order): the ``mass=``
-argument, or a single top-level ``*.PTN`` file in the directory (third
-whitespace token on line 0). If multiple ``.PTN`` files are present, the
-caller must disambiguate via ``mass=`` — the reader refuses to guess.
+The active-material mass (grams) is resolved in this priority order:
+
+1. Explicit ``mass=`` argument (grams)
+2. ``重量[mg]`` from ``連続データ.csv`` metadata row 3 (converted mg → g)
+3. A ``*.PTN`` file whose first line's 3rd whitespace-separated token parses
+   as float (grams). Other ``.PTN`` files (e.g. ``*_OPTION.PTN`` config
+   files shipped alongside the main pattern file) are skipped automatically.
+
+On the raw 6-digit path the formula is::
+
+    電気量 = 経過時間[Sec] / 3600  * 電流[mA] / mass
+
+Real TOYO raw files set ``経過時間[Sec]`` to reset at each state transition
+and emit ``電流[mA]`` as an unsigned magnitude, so this formula produces
+per-segment monotone-non-decreasing 電気量 (matching the convention that
+``連続データ.csv`` already uses inline).
 """
 
 from __future__ import annotations
@@ -53,13 +64,28 @@ PTN_SUFFIX = ".ptn"  # matched case-insensitively (Linux CI is case-sensitive)
 RENZOKU_DATA = "連続データ.csv"
 RENZOKU_DATA_PY = "連続データ_py.csv"
 
+# Half-width → full-width canonical rename. The raw 6-digit header row uses
+# half-width katakana for the cycle/mode columns.
 _RAW_TO_CANONICAL = {"ｻｲｸﾙ": "サイクル", "ﾓｰﾄﾞ": "モード", "電圧[V]": "電圧"}
+
+# Metadata key used by the native 連続データ.csv to carry active-material mass.
+_METADATA_MASS_KEY = "重量[mg]"
+
+# Number of metadata rows to scan when looking for 重量[mg]. The real file
+# has exactly 3 metadata rows before the column-header row (index 3), so
+# a scan of the first 4 rows is generous.
+_METADATA_SCAN_ROWS = 4
 
 
 def read_ptn_mass(ptn_path: str | Path) -> float:
     """Extract active-material mass (grams) from a ``.PTN`` file.
 
-    TOYO convention: the mass is the third whitespace-separated token on line 0.
+    TOYO convention: the mass is the third whitespace-separated token on
+    line 0 of a main pattern file. Auxiliary ``.PTN`` files that TOYO ships
+    alongside the main one (``*_OPTION.PTN``, ``*_Option2.PTN``, etc.)
+    carry INI- or CSV-style configuration, not a mass; calling this on
+    them will raise ``ValueError``, which :func:`_resolve_mass_from_ptn`
+    relies on to skip them.
     """
     path = Path(ptn_path)
     with path.open(encoding="shift_jis", errors="replace") as f:
@@ -89,11 +115,12 @@ def read_cell_dir(
     df : DataFrame
         Canonical columns first (see :data:`schema.CANONICAL_COLUMNS_JA` or
         the EN equivalent when ``column_lang="en"``), followed by any extra
-        columns present in the source file (e.g. 経過時間[Sec], 電流[mA]).
+        columns present in the source file (e.g. 経過時間[Sec], 電流[mA],
+        日付, 時刻, 総ｻｲｸﾙ).
     mass_g : float
         Active-material mass used for the capacity calculation, in grams.
         ``math.nan`` if the source already had 電気量 precomputed and no
-        ``.PTN`` was found at the top level of the directory.
+        mass information was available anywhere.
     """
     p = Path(path)
     if not p.exists():
@@ -103,7 +130,7 @@ def read_cell_dir(
 
     native = p / RENZOKU_DATA
     if native.exists():
-        resolved_mass = _resolve_mass(mass, p)
+        resolved_mass = _resolve_mass(mass, p, native_csv=native, encoding=encoding)
         df = _read_renzoku_data(native, resolved_mass, encoding, column_lang)
         return df, _nan_if_none(resolved_mass)
 
@@ -147,6 +174,10 @@ def _read_renzoku_data_py(path: Path, encoding: str, column_lang: ColumnLang) ->
 def _read_raw_6digit(
     raw_files: list[Path], mass: float, encoding: str, column_lang: ColumnLang
 ) -> tuple[pd.DataFrame, float]:
+    # Real-format raw files have: line 0 = "0,0,0,..." summary marker,
+    # blank line(s), then the column-header row. pandas' default
+    # skip_blank_lines=True collapses the blanks, so header=1 selects the
+    # real header (the summary line is row 0 post-blank-skip).
     frames = [pd.read_csv(f, header=1, encoding=encoding) for f in raw_files]
     base_cols = list(frames[0].columns)
     for f, frame in zip(raw_files[1:], frames[1:]):
@@ -157,6 +188,7 @@ def _read_raw_6digit(
             )
     df = pd.concat(frames, axis=0, ignore_index=True)
     df = _clean_columns(df)
+    df = _drop_unnamed(df)
     df = _ensure_capacity(df, mass)
     return _finalize(df, column_lang), mass
 
@@ -168,8 +200,26 @@ def _clean_columns(df: pd.DataFrame) -> pd.DataFrame:
     return cast("pd.DataFrame", df.rename(columns=_RAW_TO_CANONICAL))
 
 
+def _drop_unnamed(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop columns pandas auto-labels ``Unnamed: N``.
+
+    Raw TOYO 6-digit files have 6-7 empty separator columns between the
+    sensor block (``経過時間[Sec]/電圧[V]/電流[mA]``) and the per-row
+    metadata block (``状態/ﾓｰﾄﾞ/ｻｲｸﾙ/総ｻｲｸﾙ``). pandas names them
+    ``Unnamed: 5``, ``Unnamed: 6``, ... — noise, never useful downstream.
+    """
+    keep = [c for c in df.columns if not str(c).startswith("Unnamed:")]
+    return cast("pd.DataFrame", df.loc[:, keep])
+
+
 def _ensure_capacity(df: pd.DataFrame, mass: float | None) -> pd.DataFrame:
-    """Add 電気量 = elapsed_s / 3600 * current_mA / mass, if missing."""
+    """Add 電気量 = elapsed_s / 3600 * current_mA / mass, if missing.
+
+    The TOYO raw 6-digit format emits ``経過時間[Sec]`` reset at each
+    state transition and ``電流[mA]`` as an unsigned magnitude, so the
+    formula produces per-segment monotone-non-decreasing 電気量 matching
+    the convention that 連続データ.csv uses inline.
+    """
     if COL_CAPACITY in df.columns:
         return df
     if mass is None or not math.isfinite(mass) or mass <= 0:
@@ -220,21 +270,78 @@ def _find_raw_files(cell_dir: Path) -> list[Path]:
     )
 
 
-def _resolve_mass(explicit: float | None, cell_dir: Path) -> float | None:
+def _resolve_mass(
+    explicit: float | None,
+    cell_dir: Path,
+    *,
+    native_csv: Path | None = None,
+    encoding: str = "shift_jis",
+) -> float | None:
+    """Resolve active-material mass (grams) with the documented priority order.
+
+    1. Explicit ``mass=`` argument.
+    2. ``重量[mg]`` from native 連続データ.csv metadata (if ``native_csv`` given).
+    3. First ``.PTN`` whose first line carries a parseable mass at token[2].
+    """
     if explicit is not None:
         return explicit
+    if native_csv is not None:
+        metadata_mass = _extract_mass_from_renzoku_metadata(native_csv, encoding)
+        if metadata_mass is not None:
+            return metadata_mass
+    return _resolve_mass_from_ptn(cell_dir)
+
+
+def _resolve_mass_from_ptn(cell_dir: Path) -> float | None:
+    """Scan top-level ``*.PTN`` files and return the single parseable mass.
+
+    Raises ``ValueError`` if *more than one* ``.PTN`` yields a parseable
+    mass — the caller must disambiguate with ``mass=``. A ``.PTN`` whose
+    first line is INI-style (``[BaseCellCapacity]``), CSV-style, or simply
+    doesn't have a float at token[2] is silently skipped; this is how a
+    dir with both a main pattern and ``*_OPTION.PTN`` / ``*_Option2.PTN``
+    resolves unambiguously.
+    """
     ptn_files = sorted(
         p for p in cell_dir.iterdir() if p.is_file() and p.suffix.lower() == PTN_SUFFIX
     )
-    if not ptn_files:
-        return None
-    if len(ptn_files) > 1:
-        names = [p.name for p in ptn_files]
+    masses: list[tuple[Path, float]] = []
+    for ptn in ptn_files:
+        try:
+            masses.append((ptn, read_ptn_mass(ptn)))
+        except ValueError:
+            continue
+    if len(masses) == 1:
+        return masses[0][1]
+    if len(masses) > 1:
+        names = [p.name for p, _ in masses]
         raise ValueError(
-            f"multiple .PTN files found in {cell_dir} ({names}); "
+            f"multiple .PTN files with parseable mass in {cell_dir} ({names}); "
             "pass `mass=<grams>` to disambiguate"
         )
-    return read_ptn_mass(ptn_files[0])
+    return None
+
+
+def _extract_mass_from_renzoku_metadata(path: Path, encoding: str) -> float | None:
+    """Return mass (grams) from the ``重量[mg]`` metadata row, or ``None``.
+
+    Native 連続データ.csv has 3 metadata rows before the column-name row;
+    the 3rd carries ``,重量[mg],<value>`` where <value> is in milligrams.
+    """
+    with path.open(encoding=encoding, errors="replace") as f:
+        for _ in range(_METADATA_SCAN_ROWS):
+            line = f.readline()
+            if not line:
+                return None
+            fields = [c.strip() for c in line.rstrip("\r\n").split(",")]
+            for i, cell in enumerate(fields):
+                if cell == _METADATA_MASS_KEY and i + 1 < len(fields):
+                    try:
+                        mg = float(fields[i + 1])
+                    except ValueError:
+                        return None
+                    return mg * 1e-3
+    return None
 
 
 def _nan_if_none(value: float | None) -> float:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 """Shared fixtures for the test suite.
 
-`make_cell_dir` builds a synthetic TOYO-style cell directory in tmp_path for
-each of the three supported on-disk layouts.
+``make_cell_dir`` builds a synthetic TOYO-style cell directory in ``tmp_path``
+for each of the three supported on-disk layouts. Fixture layouts mirror what
+real TOYO testers emit (column order, state value convention, mass
+location) so tests actually exercise the same codepaths as real data.
 """
 
 from __future__ import annotations
@@ -13,10 +15,33 @@ import pytest
 
 Layout = Literal["renzoku", "renzoku_py", "raw_6digit"]
 
-# Used by the renzoku fixture when include_capacity=True. Picked to be
-# distinguishable from any plausible recompute output (formula would give
-# values like 0, 500, 0, -527.78, -1027.78 for the row sequence below).
-SENTINEL_CAPACITY_BASE: float = 100.0
+# Row template shared between layouts so the three fixtures stay in sync.
+# Each tuple: (cycle, mode, state_int, voltage, elapsed_s, current_mA,
+# capacity_mAh_per_g). state_int uses the raw-6-digit convention (0=rest,
+# 1=charge, 2=discharge); the renzoku fixture translates these to JP state
+# strings including the 充電休止/放電休止 substate distinction.
+#
+# 経過時間 resets at each state transition and 電流 is unsigned (both match
+# real TOYO raw files), so capacity = elapsed/3600 * current / mass_g gives
+# the per-segment monotone-non-decreasing values in the 7th tuple slot for
+# the default mass of 1 mg (0.001 g).
+_DEFAULT_MASS_G: float = 0.001  # 1 mg
+_ROWS_SHARED: tuple[tuple[int, str, int, float, float, float, float], ...] = (
+    (1, "1", 1, 3.50, 0.0, 1.0, 0.0),  # charge start
+    (1, "1", 1, 3.60, 3600.0, 1.0, 1000.0),  # charge end
+    (1, "1", 0, 3.61, 0.0, 0.0, 0.0),  # rest (elapsed resets at transition)
+    (1, "1", 2, 3.40, 0.0, 1.0, 0.0),  # discharge start (elapsed resets)
+    (1, "1", 2, 3.20, 3600.0, 1.0, 1000.0),  # discharge end
+)
+
+_STATE_INT_TO_RENZOKU_JA: dict[int, tuple[str, str]] = {
+    # state_int -> (start-of-segment JP string, continuation JP string).
+    # In real 連続データ.csv the tester relabels the 0=rest state as either
+    # 充電休止 (rest after a charge) or 放電休止 (rest after a discharge).
+    # This helper just maps by integer; the caller tracks which preceded.
+    1: ("充電", "充電"),
+    2: ("放電", "放電"),
+}
 
 
 @pytest.fixture
@@ -27,17 +52,16 @@ def make_cell_dir(tmp_path: Path) -> Callable[..., Path]:
         layout: Layout,
         *,
         name: str = "cell_A",
-        mass: float = 0.002,  # 2 mg
-        include_capacity_col: bool = True,
+        mass: float = _DEFAULT_MASS_G,
     ) -> Path:
         d = tmp_path / name
         d.mkdir()
         if layout == "renzoku":
-            _write_renzoku(d, mass=mass, include_capacity=include_capacity_col)
+            _write_renzoku(d, mass_g=mass)
         elif layout == "renzoku_py":
             _write_renzoku_py(d)
         elif layout == "raw_6digit":
-            _write_raw_6digit(d, mass=mass)
+            _write_raw_6digit(d, mass_g=mass)
         else:
             raise ValueError(f"unknown layout: {layout}")
         return d
@@ -45,69 +69,99 @@ def make_cell_dir(tmp_path: Path) -> Callable[..., Path]:
     return _make
 
 
-def _write_renzoku(cell_dir: Path, *, mass: float, include_capacity: bool) -> None:
-    """Write a 連続データ.csv with header=3, skiprows=[4,5,6]."""
-    lines = [
-        "# metadata line 0",
-        "# metadata line 1",
-        "# metadata line 2",
-    ]
-    if include_capacity:
-        lines.append("ｻｲｸﾙ,ﾓｰﾄﾞ,状態,電圧[V],経過時間[Sec],電流[mA],電気量")
-    else:
-        lines.append("ｻｲｸﾙ,ﾓｰﾄﾞ,状態,電圧[V],経過時間[Sec],電流[mA]")
-    lines.extend(["# skip 4", "# skip 5", "# skip 6"])
+def _write_renzoku(cell_dir: Path, *, mass_g: float) -> None:
+    """Write a native-format 連続データ.csv.
 
-    rows = [
-        (1, "CC", 1, 3.50, 0.0, 1.0),
-        (1, "CC", 1, 3.60, 3600.0, 1.0),
-        (1, "CC", 0, 3.61, 3700.0, 0.0),
-        (1, "CC", 2, 3.40, 3800.0, -1.0),
-        (1, "CC", 2, 3.20, 7400.0, -1.0),
+    Real format:
+      - Row 0: test-name + directory + start-time metadata
+      - Row 1: 測定備考 (remarks)
+      - Row 2: ``,重量[mg],<float>`` — mass source
+      - Row 3: header ``サイクル,モード,状態,電圧,電気量`` (full-width JP)
+      - Row 4: channel identifier (e.g. ``72ch,72ch,...``)
+      - Row 5: ``-`` separator row
+      - Row 6: units (``[],[],[],[V],[mAh/g]``)
+      - Row 7+: data rows with state as JP strings including
+        ``充電休止``/``放電休止`` substates and pre-computed 電気量.
+    """
+    mass_mg = mass_g * 1e3
+    lines = [
+        ",試験名,C:¥synthetic¥test¥path,,,,開始日時,2026-01-01 00:00:00",
+        ",測定備考,",
+        f",重量[mg],{mass_mg:.3f}",
+        "サイクル,モード,状態,電圧,電気量",
+        "1ch,1ch,1ch,1ch,1ch",
+        "-,-,-,-,-",
+        "[],[],[],[V],[mAh/g]",
     ]
-    for idx, (cycle, mode, state, voltage, t_sec, current_ma) in enumerate(rows):
-        fields = [
-            str(cycle),
-            mode,
-            str(state),
-            f"{voltage:.3f}",
-            f"{t_sec:.1f}",
-            f"{current_ma:.3f}",
-        ]
-        if include_capacity:
-            # Distinct sentinel per row, deliberately NOT matching the recompute
-            # formula t/3600·I/mass. A regression where the reader recomputes
-            # an already-present 電気量 column would be visible as the sentinel
-            # being overwritten.
-            sentinel_capacity = SENTINEL_CAPACITY_BASE + idx
-            fields.append(f"{sentinel_capacity:.6f}")
-        lines.append(",".join(fields))
+    # State-string bookkeeping: translate 0 into either 充電休止 or 放電休止
+    # based on which non-rest state preceded it.
+    last_active_state = 1
+    for cycle, mode, state_int, voltage, _elapsed, _current, capacity in _ROWS_SHARED:
+        if state_int == 0:
+            state_ja = "充電休止" if last_active_state == 1 else "放電休止"
+        else:
+            state_ja = _STATE_INT_TO_RENZOKU_JA[state_int][0]
+            last_active_state = state_int
+        lines.append(f"{cycle},{mode},{state_ja},{voltage:.4f},{capacity:.6f}")
     (cell_dir / "連続データ.csv").write_text("\n".join(lines) + "\n", encoding="shift_jis")
 
 
 def _write_renzoku_py(cell_dir: Path) -> None:
-    """Write an already-normalized 連続データ_py.csv (header=0)."""
-    lines = [
-        "サイクル,モード,状態,電圧,電気量",
-        "1,CC,充電,3.50,0.000",
-        "1,CC,充電,3.60,500.000",
-        "1,CC,休止,3.61,500.000",
-        "1,CC,放電,3.40,0.000",
-        "1,CC,放電,3.20,-500.000",
-    ]
+    """Write an already-normalized 連続データ_py.csv (header=0).
+
+    The legacy v2.01 pipeline writes this file with the simpler 3-state
+    convention (state ∈ {充電, 放電, 休止}) — no substate distinction.
+    """
+    state_int_to_simple_ja = {0: "休止", 1: "充電", 2: "放電"}
+    lines = ["サイクル,モード,状態,電圧,電気量"]
+    for cycle, mode, state_int, voltage, _elapsed, _current, capacity in _ROWS_SHARED:
+        state_ja = state_int_to_simple_ja[state_int]
+        lines.append(f"{cycle},{mode},{state_ja},{voltage:.4f},{capacity:.6f}")
     (cell_dir / "連続データ_py.csv").write_text("\n".join(lines) + "\n", encoding="shift_jis")
 
 
-def _write_raw_6digit(cell_dir: Path, *, mass: float) -> None:
-    """Write one 6-digit raw file (header=1) plus a .PTN mass file."""
-    raw_lines = [
-        "# summary line 0",
-        "ｻｲｸﾙ,ﾓｰﾄﾞ,状態,電圧[V],経過時間[Sec],電流[mA]",
-        "1,CC,1,3.50,0.0,1.0",
-        "1,CC,1,3.60,3600.0,1.0",
-        "1,CC,0,3.61,3700.0,0.0",
-        "1,CC,2,3.40,3800.0,-1.0",
-        "1,CC,2,3.20,7400.0,-1.0",
+def _write_raw_6digit(cell_dir: Path, *, mass_g: float) -> None:
+    """Write a real-format 6-digit raw file plus ``.PTN`` mass files.
+
+    Real format:
+      - Line 0: ``0,0,0,0,0,0,0`` (summary marker, not data)
+      - Lines 1-2: blank (pandas ``skip_blank_lines=True`` collapses these)
+      - Line 3: header ``日付,時刻,経過時間[Sec],電圧[V],電流[mA],<6 empty>,
+        状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ``
+      - Line 4+: data rows; 経過時間 resets per state transition, 電流 is
+        an unsigned magnitude.
+
+    Also writes *two* ``.PTN`` files: the main pattern with the mass, and a
+    ``*_OPTION.PTN`` companion mirroring what real TOYO dirs ship. The
+    reader must pick the main one automatically (the OPTION file's first
+    line starts with ``[`` so ``read_ptn_mass`` raises and it is skipped).
+    """
+    empty_sep = ",,,,,,"  # 6 empty columns
+    lines = [
+        "0,0,0,0,0,0,0",
+        "",
+        "",
+        f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ",
     ]
-    (cell_dir / "000001").write_text("\n".join(raw_lines) + "\n", encoding="shift_jis")
-    (cell_dir / "pattern.PTN").write_text(f"ACTIVE_MATERIAL WEIGHT {mass}\n", encoding="shift_jis")
+    date = "2026/01/01"
+    time = "00:00:00"
+    total_cycle = 1
+    for cycle, mode, state_int, voltage, elapsed, current, _capacity in _ROWS_SHARED:
+        lines.append(
+            f"{date},{time},{int(elapsed):08d},+{voltage:.4f},{current:.6f}{empty_sep}"
+            f",{state_int:d}, {mode},  {cycle:d},     {total_cycle:d}"
+        )
+    (cell_dir / "000001").write_text("\n".join(lines) + "\n", encoding="shift_jis")
+
+    # Main PTN: fixed-column. ``split()[2]`` extracts the mass in grams.
+    ptn_main = (
+        f" 1Synthetic                                 2 {mass_g:09.6f}       1{mass_g:09.6f}"
+        f"TestCell                                 24 00000"
+    )
+    (cell_dir / "pattern.PTN").write_text(ptn_main + "\n", encoding="shift_jis")
+
+    # Companion PTN: INI-style header, no mass. `read_ptn_mass` raises on this
+    # and the reader falls through to the main PTN.
+    (cell_dir / "pattern_OPTION.PTN").write_text(
+        "[BaseCellCapacity]\nCapacity=0.1\n", encoding="shift_jis"
+    )

--- a/tests/test_chdis.py
+++ b/tests/test_chdis.py
@@ -152,7 +152,7 @@ def test_only_rest_rows_returns_empty() -> None:
 
 def test_cell_chdis_df_is_cached(make_cell_dir: Callable[..., Path]) -> None:
     """Cell.chdis_df is a cached_property — second access returns the same object."""
-    cell_dir = make_cell_dir("renzoku", include_capacity_col=True)
+    cell_dir = make_cell_dir("renzoku")
     cell = Cell.from_dir(cell_dir)
 
     first = cell.chdis_df
@@ -163,7 +163,7 @@ def test_cell_chdis_df_is_cached(make_cell_dir: Callable[..., Path]) -> None:
 
 
 def test_cell_chdis_df_respects_column_lang(make_cell_dir: Callable[..., Path]) -> None:
-    cell_dir = make_cell_dir("renzoku", include_capacity_col=True)
+    cell_dir = make_cell_dir("renzoku")
     cell = Cell.from_dir(cell_dir, column_lang="en")
     out = cell.chdis_df
     assert set(out.columns.get_level_values("quantity")) == {"capacity", "voltage"}

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -13,140 +13,97 @@ from toyo_battery.core.cell import Cell
 from toyo_battery.io.reader import read_cell_dir, read_ptn_mass
 from toyo_battery.io.schema import CANONICAL_COLUMNS_EN, CANONICAL_COLUMNS_JA
 
-# Mirrored from conftest.SENTINEL_CAPACITY_BASE. We do not `from conftest import`
-# because pytest does not add the conftest directory to sys.path (the project
-# uses no tests/__init__.py and no pythonpath= config). Change both if you
-# change either.
-SENTINEL_CAPACITY_BASE: float = 100.0
+
+def _write_fixed_column_ptn(path: Path, mass_g: float) -> None:
+    """Write a TOYO-style fixed-column PTN whose first line has the mass at token[2]."""
+    line = (
+        f" 1TestName                                 2 {mass_g:09.6f}       1{mass_g:09.6f}"
+        f"TestCell                                 24 00000"
+    )
+    path.write_text(line + "\n", encoding="shift_jis")
 
 
-def test_read_renzoku_with_capacity_column(make_cell_dir: Callable[..., Path]) -> None:
-    d = make_cell_dir("renzoku", mass=0.002, include_capacity_col=True)
+# ---- renzoku (native 連続データ.csv) path ----------------------------------
+
+
+def test_read_renzoku_uses_precomputed_capacity(make_cell_dir: Callable[..., Path]) -> None:
+    """連続データ.csv carries 電気量 inline. Reader must pass it through, not recompute."""
+    d = make_cell_dir("renzoku", mass=0.001)
     df, mass_g = read_cell_dir(d)
-    assert list(df.columns[: len(CANONICAL_COLUMNS_JA)]) == list(CANONICAL_COLUMNS_JA)
-    # extras (経過時間[Sec], 電流[mA]) preserved after the canonical block
-    assert "経過時間[Sec]" in df.columns
-    assert "電流[mA]" in df.columns
+    assert list(df.columns) == list(CANONICAL_COLUMNS_JA)  # no extras in native CSV
     assert len(df) == 5
-    # value-level state mapping: rows are written as integer codes 1,1,0,2,2
-    assert df["状態"].tolist() == ["充電", "充電", "休止", "放電", "放電"]
-    # precomputed sentinel survives — reader must NOT recompute when 電気量 is present
-    expected_sentinels = [SENTINEL_CAPACITY_BASE + i for i in range(5)]
-    assert df["電気量"].tolist() == pytest.approx(expected_sentinels)
-    assert math.isnan(mass_g)  # no .PTN for this layout
+    # Fixture capacity values (per-segment monotone non-decreasing, as in real data)
+    assert df["電気量"].tolist() == pytest.approx([0.0, 1000.0, 0.0, 0.0, 1000.0])
+    # Mass comes from the 重量[mg] metadata row (1.0 mg → 0.001 g)
+    assert mass_g == pytest.approx(0.001)
 
 
-def test_read_renzoku_without_capacity_requires_mass(
-    make_cell_dir: Callable[..., Path],
-) -> None:
-    d = make_cell_dir("renzoku", include_capacity_col=False)
-    with pytest.raises(ValueError, match="電気量"):
-        read_cell_dir(d)
+def test_read_renzoku_exposes_four_state_substates(make_cell_dir: Callable[..., Path]) -> None:
+    """Real 連続データ.csv distinguishes 充電休止 / 放電休止 from each other."""
+    d = make_cell_dir("renzoku", mass=0.001)
+    df, _ = read_cell_dir(d)
+    # Row after charge (before discharge) is 充電休止, not just 休止
+    assert df["状態"].tolist() == ["充電", "充電", "充電休止", "放電", "放電"]
 
 
-def test_read_renzoku_without_capacity_computes_with_mass(
-    make_cell_dir: Callable[..., Path],
-) -> None:
-    d = make_cell_dir("renzoku", mass=0.002, include_capacity_col=False)
-    df, mass_g = read_cell_dir(d, mass=0.002)
-    assert mass_g == 0.002
-    # Row at t=3600s, I=1mA, mass=0.002g → capacity = 1*1/0.002 = 500 mAh/g
-    charge_row = df[(df["電圧"] == 3.60) & (df["状態"] == "充電")].iloc[0]
-    assert charge_row["電気量"] == pytest.approx(500.0)
+def test_read_renzoku_metadata_mass_is_in_milligrams(make_cell_dir: Callable[..., Path]) -> None:
+    """``重量[mg]`` in metadata is milligrams; reader must convert to grams."""
+    d = make_cell_dir("renzoku", mass=0.002)  # 2 mg
+    _, mass_g = read_cell_dir(d)
+    assert mass_g == pytest.approx(0.002)
+
+
+def test_explicit_mass_overrides_renzoku_metadata(make_cell_dir: Callable[..., Path]) -> None:
+    d = make_cell_dir("renzoku", mass=0.001)
+    _, mass_g = read_cell_dir(d, mass=0.005)
+    assert mass_g == pytest.approx(0.005)
+
+
+def test_read_renzoku_falls_back_to_ptn_when_metadata_missing(tmp_path: Path) -> None:
+    """If 重量[mg] is not in metadata, reader falls back to a .PTN file."""
+    d = tmp_path / "cell"
+    d.mkdir()
+    # Write a renzoku CSV with metadata rows that do NOT carry 重量[mg].
+    lines = [
+        ",試験名,synthetic,,,,開始日時,-",
+        ",測定備考,",
+        ",備考2,-",
+        "サイクル,モード,状態,電圧,電気量",
+        "1ch,1ch,1ch,1ch,1ch",
+        "-,-,-,-,-",
+        "[],[],[],[V],[mAh/g]",
+        "1,1,充電,3.5000,0.000000",
+        "1,1,放電,3.4000,10.000000",
+    ]
+    (d / "連続データ.csv").write_text("\n".join(lines) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(d / "pattern.PTN", 0.004)
+    _, mass_g = read_cell_dir(d)
+    assert mass_g == pytest.approx(0.004)
+
+
+# ---- renzoku_py (normalized output) path ----------------------------------
 
 
 def test_read_renzoku_py(make_cell_dir: Callable[..., Path]) -> None:
     d = make_cell_dir("renzoku_py")
     df, mass_g = read_cell_dir(d)
     assert list(df.columns) == list(CANONICAL_COLUMNS_JA)
-    assert math.isnan(mass_g)
-    assert df["状態"].iloc[0] == "充電"
-
-
-def test_read_raw_6digit_with_ptn(make_cell_dir: Callable[..., Path]) -> None:
-    d = make_cell_dir("raw_6digit", mass=0.002)
-    df, mass_g = read_cell_dir(d)
-    assert mass_g == pytest.approx(0.002)
-    assert list(df.columns[: len(CANONICAL_COLUMNS_JA)]) == list(CANONICAL_COLUMNS_JA)
-    assert set(df["状態"].unique()) <= {"休止", "充電", "放電"}
-    # Same capacity formula as above
-    assert df.loc[df["電圧"] == 3.60, "電気量"].iloc[0] == pytest.approx(500.0)
-
-
-def test_multiple_ptn_files_raises(make_cell_dir: Callable[..., Path]) -> None:
-    d = make_cell_dir("raw_6digit", mass=0.002)
-    (d / "pattern2.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.003\n", encoding="shift_jis")
-    with pytest.raises(ValueError, match=r"multiple \.PTN"):
-        read_cell_dir(d)
-
-
-def test_multiple_ptn_files_disambiguated_by_explicit_mass(
-    make_cell_dir: Callable[..., Path],
-) -> None:
-    d = make_cell_dir("raw_6digit", mass=0.002)
-    (d / "pattern2.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.003\n", encoding="shift_jis")
-    df, mass_g = read_cell_dir(d, mass=0.002)
-    assert mass_g == 0.002
-    assert df.loc[df["電圧"] == 3.60, "電気量"].iloc[0] == pytest.approx(500.0)
-
-
-def test_ptn_in_subdir_is_ignored(make_cell_dir: Callable[..., Path]) -> None:
-    """A stale .PTN in a subdirectory must not silently determine mass."""
-    d = make_cell_dir("renzoku", mass=0.002, include_capacity_col=False)
-    sub = d / "backup"
-    sub.mkdir()
-    (sub / "stale.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.999\n", encoding="shift_jis")
-    with pytest.raises(ValueError, match="電気量"):
-        read_cell_dir(d)
-
-
-def test_unknown_state_code_raises(tmp_path: Path) -> None:
-    """An unrecognized integer 状態 code must not silently pass through."""
-    cell_dir = tmp_path / "bad_state"
-    cell_dir.mkdir()
-    raw = [
-        "# summary line 0",
-        "ｻｲｸﾙ,ﾓｰﾄﾞ,状態,電圧[V],経過時間[Sec],電流[mA]",
-        "1,CC,1,3.50,0.0,1.0",
-        "1,CC,9,3.60,3600.0,1.0",
-    ]
-    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
-    (cell_dir / "pattern.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.002\n", encoding="shift_jis")
-    with pytest.raises(ValueError, match="unknown 状態 codes"):
-        read_cell_dir(cell_dir)
-
-
-def test_nan_state_is_preserved(tmp_path: Path) -> None:
-    """A row with empty 状態 should survive — NaN preserved, not raised."""
-    cell_dir = tmp_path / "nan_state"
-    cell_dir.mkdir()
-    raw = [
-        "# summary line 0",
-        "ｻｲｸﾙ,ﾓｰﾄﾞ,状態,電圧[V],経過時間[Sec],電流[mA]",
-        "1,CC,1,3.50,0.0,1.0",
-        "1,CC,,3.55,1800.0,1.0",
-        "1,CC,1,3.60,3600.0,1.0",
-    ]
-    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
-    (cell_dir / "pattern.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.002\n", encoding="shift_jis")
-    df, _ = read_cell_dir(cell_dir)
-    assert df["状態"].iloc[0] == "充電"
-    assert pd.isna(df["状態"].iloc[1])
-    assert df["状態"].iloc[2] == "充電"
+    assert math.isnan(mass_g)  # no mass source available
+    assert df["状態"].tolist() == ["充電", "充電", "休止", "放電", "放電"]
 
 
 def test_renzoku_py_honors_ptn_mass(make_cell_dir: Callable[..., Path]) -> None:
-    """The _py branch must also resolve mass from a top-level .PTN, like the native branch."""
     d = make_cell_dir("renzoku_py")
-    (d / "pattern.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.005\n", encoding="shift_jis")
+    _write_fixed_column_ptn(d / "pattern.PTN", 0.005)
     _, mass_g = read_cell_dir(d)
-    assert mass_g == 0.005
+    assert mass_g == pytest.approx(0.005)
 
 
-def test_renzoku_py_with_multiple_ptn_raises(make_cell_dir: Callable[..., Path]) -> None:
+def test_renzoku_py_with_two_valid_ptn_masses_raises(make_cell_dir: Callable[..., Path]) -> None:
+    """Two .PTN files both yielding parseable masses must force disambiguation."""
     d = make_cell_dir("renzoku_py")
-    (d / "p1.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.005\n", encoding="shift_jis")
-    (d / "p2.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.003\n", encoding="shift_jis")
+    _write_fixed_column_ptn(d / "p1.PTN", 0.005)
+    _write_fixed_column_ptn(d / "p2.PTN", 0.003)
     with pytest.raises(ValueError, match=r"multiple \.PTN"):
         read_cell_dir(d)
 
@@ -154,42 +111,100 @@ def test_renzoku_py_with_multiple_ptn_raises(make_cell_dir: Callable[..., Path])
 def test_lowercase_ptn_extension_is_discovered(make_cell_dir: Callable[..., Path]) -> None:
     """Linux CI is case-sensitive; `.ptn` (lowercase) must still resolve mass."""
     d = make_cell_dir("renzoku_py")
-    (d / "pattern.ptn").write_text("ACTIVE_MATERIAL WEIGHT 0.007\n", encoding="shift_jis")
+    _write_fixed_column_ptn(d / "pattern.ptn", 0.007)
     _, mass_g = read_cell_dir(d)
-    assert mass_g == 0.007
+    assert mass_g == pytest.approx(0.007)
 
 
-def test_path_is_a_file_raises_not_a_directory(tmp_path: Path) -> None:
-    f = tmp_path / "not_a_dir.csv"
-    f.write_text("x", encoding="shift_jis")
-    with pytest.raises(NotADirectoryError):
-        read_cell_dir(f)
+# ---- 6-digit raw path -----------------------------------------------------
 
 
-def test_6digit_in_subdir_is_ignored(tmp_path: Path) -> None:
-    """A stale 6-digit raw file in a subdirectory must not be auto-discovered."""
-    cell_dir = tmp_path / "with_backup"
-    cell_dir.mkdir()
-    sub = cell_dir / "old_run"
-    sub.mkdir()
-    (sub / "999999").write_text(
-        "# summary\nｻｲｸﾙ,ﾓｰﾄﾞ,状態,電圧[V],経過時間[Sec],電流[mA]\n1,CC,1,3.50,0.0,1.0\n",
-        encoding="shift_jis",
-    )
-    (cell_dir / "pattern.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.002\n", encoding="shift_jis")
-    with pytest.raises(FileNotFoundError, match="no TOYO data"):
-        read_cell_dir(cell_dir)
+def test_read_raw_6digit_computes_per_segment_positive_capacity(
+    make_cell_dir: Callable[..., Path],
+) -> None:
+    """Real raw convention: 経過時間 resets per segment, 電流 is unsigned.
+
+    The formula ``elapsed/3600 * current / mass`` therefore produces
+    per-segment monotone-non-decreasing 電気量.
+    """
+    d = make_cell_dir("raw_6digit", mass=0.001)
+    df, mass_g = read_cell_dir(d)
+    assert mass_g == pytest.approx(0.001)
+    assert list(df.columns[: len(CANONICAL_COLUMNS_JA)]) == list(CANONICAL_COLUMNS_JA)
+    # Extras preserved (date, time, elapsed, current, total cycle)
+    assert "経過時間[Sec]" in df.columns
+    assert "電流[mA]" in df.columns
+    # No 'Unnamed: *' noise from pandas' handling of empty separator columns
+    assert not any(str(c).startswith("Unnamed:") for c in df.columns)
+    # Per-segment positive: [0, 1000, 0, 0, 1000] for this fixture
+    assert df["電気量"].tolist() == pytest.approx([0.0, 1000.0, 0.0, 0.0, 1000.0])
+    # State codes mapped to simple 3-value set (no substates in raw format)
+    assert df["状態"].tolist() == ["充電", "充電", "休止", "放電", "放電"]
+
+
+def test_raw_6digit_main_ptn_picked_when_option_ptn_present(
+    make_cell_dir: Callable[..., Path],
+) -> None:
+    """conftest ships both ``pattern.PTN`` and ``pattern_OPTION.PTN``.
+
+    The option file starts with ``[BaseCellCapacity]`` which `read_ptn_mass`
+    cannot parse, so `_resolve_mass_from_ptn` skips it and picks the main.
+    """
+    d = make_cell_dir("raw_6digit", mass=0.0008)
+    _, mass_g = read_cell_dir(d)
+    assert mass_g == pytest.approx(0.0008)
+    # Sanity: the OPTION file really is there, so the test is meaningful
+    assert (d / "pattern_OPTION.PTN").exists()
+
+
+def test_raw_6digit_multiple_valid_ptn_masses_raises(
+    make_cell_dir: Callable[..., Path],
+) -> None:
+    d = make_cell_dir("raw_6digit", mass=0.001)
+    _write_fixed_column_ptn(d / "pattern2.PTN", 0.003)
+    with pytest.raises(ValueError, match=r"multiple \.PTN"):
+        read_cell_dir(d)
+
+
+def test_raw_6digit_explicit_mass_overrides_ptn(make_cell_dir: Callable[..., Path]) -> None:
+    d = make_cell_dir("raw_6digit", mass=0.001)
+    df, mass_g = read_cell_dir(d, mass=0.004)
+    assert mass_g == pytest.approx(0.004)
+    # Row at elapsed=3600, I=1mA, mass=0.004 → capacity = 1*1/0.004 = 250 mAh/g
+    assert df.loc[1, "電気量"] == pytest.approx(250.0)
+
+
+def test_raw_6digit_without_mass_and_no_ptn(make_cell_dir: Callable[..., Path]) -> None:
+    d = make_cell_dir("raw_6digit", mass=0.001)
+    (d / "pattern.PTN").unlink()
+    (d / "pattern_OPTION.PTN").unlink()
+    with pytest.raises(ValueError, match="mass"):
+        read_cell_dir(d)
 
 
 def test_read_raw_6digit_multi_file(tmp_path: Path) -> None:
+    """Multiple 000NNN files are concatenated in sorted order."""
     cell_dir = tmp_path / "multi"
     cell_dir.mkdir()
-    header = "ｻｲｸﾙ,ﾓｰﾄﾞ,状態,電圧[V],経過時間[Sec],電流[mA]"
-    file_a = ["# summary line 0", header, "1,CC,1,3.50,0.0,1.0", "1,CC,1,3.55,1800.0,1.0"]
-    file_b = ["# summary line 0", header, "2,CC,2,3.40,3600.0,-1.0", "2,CC,2,3.20,5400.0,-1.0"]
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    file_a = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        f"2025/01/01,00:30:00,00001800,+3.5500,1.000000{empty_sep},1, 1,  1,     1",
+    ]
+    file_b = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,01:00:00,00000000,+3.4000,1.000000{empty_sep},2, 1,  2,     2",
+        f"2025/01/01,01:30:00,00001800,+3.2000,1.000000{empty_sep},2, 1,  2,     2",
+    ]
     (cell_dir / "000001").write_text("\n".join(file_a) + "\n", encoding="shift_jis")
     (cell_dir / "000002").write_text("\n".join(file_b) + "\n", encoding="shift_jis")
-    (cell_dir / "pattern.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.002\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
     df, _ = read_cell_dir(cell_dir)
     assert len(df) == 4
     assert df["サイクル"].tolist() == [1, 1, 2, 2]
@@ -198,52 +213,116 @@ def test_read_raw_6digit_multi_file(tmp_path: Path) -> None:
 def test_read_raw_6digit_mismatched_columns_raises(tmp_path: Path) -> None:
     cell_dir = tmp_path / "mismatch"
     cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header_full = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    header_short = "日付,時刻,経過時間[Sec],電圧[V]"
     file_a = [
-        "# summary line 0",
-        "ｻｲｸﾙ,ﾓｰﾄﾞ,状態,電圧[V],経過時間[Sec],電流[mA]",
-        "1,CC,1,3.50,0.0,1.0",
+        "0,0,0,0,0,0,0",
+        "",
+        header_full,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
     ]
     file_b = [
-        "# summary line 0",
-        "ｻｲｸﾙ,ﾓｰﾄﾞ,状態,電圧[V]",
-        "1,CC,1,3.50",
+        "0,0,0,0,0,0,0",
+        "",
+        header_short,
+        "2025/01/01,00:00:00,00000000,+3.5000",
     ]
     (cell_dir / "000001").write_text("\n".join(file_a) + "\n", encoding="shift_jis")
     (cell_dir / "000002").write_text("\n".join(file_b) + "\n", encoding="shift_jis")
-    (cell_dir / "pattern.PTN").write_text("ACTIVE_MATERIAL WEIGHT 0.002\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
     with pytest.raises(ValueError, match="columns differing"):
         read_cell_dir(cell_dir)
 
 
-def test_read_raw_6digit_without_mass_and_no_ptn(
-    make_cell_dir: Callable[..., Path], tmp_path: Path
-) -> None:
-    d = make_cell_dir("raw_6digit", mass=0.002)
-    (d / "pattern.PTN").unlink()
-    with pytest.raises(ValueError, match="mass"):
-        read_cell_dir(d)
+def test_unknown_state_code_raises(tmp_path: Path) -> None:
+    """An unrecognized integer 状態 code must not silently pass through."""
+    cell_dir = tmp_path / "bad_state"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    raw = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},9, 1,  1,     1",
+    ]
+    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    with pytest.raises(ValueError, match="unknown 状態 codes"):
+        read_cell_dir(cell_dir)
 
 
-def test_read_raw_6digit_with_explicit_mass_overrides_ptn(
-    make_cell_dir: Callable[..., Path],
-) -> None:
-    d = make_cell_dir("raw_6digit", mass=0.002)
-    df, mass_g = read_cell_dir(d, mass=0.004)
-    assert mass_g == 0.004
-    # capacity halves when mass doubles
-    assert df.loc[df["電圧"] == 3.60, "電気量"].iloc[0] == pytest.approx(250.0)
+def test_nan_state_is_preserved(tmp_path: Path) -> None:
+    """A row with empty 状態 should survive — NaN preserved, not raised."""
+    cell_dir = tmp_path / "nan_state"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    raw = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        # Middle row: empty state field (no character between commas, not a
+        # space). pandas reads this as NaN; see also the non-space column
+        # alignment required to keep the numeric dtype of the whole column.
+        f"2025/01/01,00:15:00,00000900,+3.5500,1.000000{empty_sep},, 1,  1,     1",
+        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},1, 1,  1,     1",
+    ]
+    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    df, _ = read_cell_dir(cell_dir)
+    assert df["状態"].iloc[0] == "充電"
+    assert pd.isna(df["状態"].iloc[1])
+    assert df["状態"].iloc[2] == "充電"
 
 
-def test_column_lang_en(make_cell_dir: Callable[..., Path]) -> None:
-    d = make_cell_dir("raw_6digit", mass=0.002)
-    df, _ = read_cell_dir(d, column_lang="en")
-    assert list(df.columns[: len(CANONICAL_COLUMNS_EN)]) == list(CANONICAL_COLUMNS_EN)
-    # extras translated via schema.JA_TO_EN
-    assert "elapsed_time_s" in df.columns
-    assert "current_ma" in df.columns
-    # state values are NOT translated here — that is schema.STATE_JA_TO_EN's job
-    # when needed by downstream consumers
-    assert set(df["state"].unique()) <= {"休止", "充電", "放電"}
+# ---- discovery and file-system plumbing -----------------------------------
+
+
+def test_ptn_in_subdir_is_ignored(make_cell_dir: Callable[..., Path]) -> None:
+    """A stale .PTN in a subdirectory must not silently determine mass."""
+    d = make_cell_dir("renzoku_py")  # no top-level mass source
+    sub = d / "backup"
+    sub.mkdir()
+    _write_fixed_column_ptn(sub / "stale.PTN", 0.999)
+    _, mass_g = read_cell_dir(d)
+    # No top-level .PTN, no renzoku metadata → mass_g is NaN (not 0.999)
+    assert math.isnan(mass_g)
+
+
+def test_6digit_in_subdir_is_ignored(tmp_path: Path) -> None:
+    """A stale 6-digit raw file in a subdirectory must not be auto-discovered."""
+    cell_dir = tmp_path / "with_backup"
+    cell_dir.mkdir()
+    sub = cell_dir / "old_run"
+    sub.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    (sub / "999999").write_text(
+        "\n".join(
+            [
+                "0,0,0,0,0,0,0",
+                "",
+                header,
+                f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+            ]
+        )
+        + "\n",
+        encoding="shift_jis",
+    )
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    with pytest.raises(FileNotFoundError, match="no TOYO data"):
+        read_cell_dir(cell_dir)
+
+
+def test_path_is_a_file_raises_not_a_directory(tmp_path: Path) -> None:
+    f = tmp_path / "not_a_dir.csv"
+    f.write_text("x", encoding="shift_jis")
+    with pytest.raises(NotADirectoryError):
+        read_cell_dir(f)
 
 
 def test_missing_directory_raises() -> None:
@@ -258,10 +337,21 @@ def test_empty_directory_raises(tmp_path: Path) -> None:
         read_cell_dir(empty)
 
 
+# ---- read_ptn_mass unit tests --------------------------------------------
+
+
 def test_read_ptn_mass_happy(tmp_path: Path) -> None:
     ptn = tmp_path / "x.PTN"
+    _write_fixed_column_ptn(ptn, 1.234)
+    assert read_ptn_mass(ptn) == pytest.approx(1.234)
+
+
+def test_read_ptn_mass_simple_whitespace_format(tmp_path: Path) -> None:
+    """Legacy tests used to write ``ACTIVE_MATERIAL WEIGHT <float>``; that
+    format also works because ``split()[2]`` still picks the float."""
+    ptn = tmp_path / "x.PTN"
     ptn.write_text("ACTIVE_MATERIAL WEIGHT 1.234\n", encoding="shift_jis")
-    assert read_ptn_mass(ptn) == 1.234
+    assert read_ptn_mass(ptn) == pytest.approx(1.234)
 
 
 def test_read_ptn_mass_malformed_raises(tmp_path: Path) -> None:
@@ -278,15 +368,44 @@ def test_read_ptn_mass_non_numeric_raises(tmp_path: Path) -> None:
         read_ptn_mass(ptn)
 
 
+def test_read_ptn_mass_ini_style_raises(tmp_path: Path) -> None:
+    """An `[BaseCellCapacity]` INI-header PTN (TOYO OPTION files) is unparseable.
+
+    `_resolve_mass_from_ptn` relies on this raising to skip companion files.
+    """
+    ptn = tmp_path / "OPTION.PTN"
+    ptn.write_text("[BaseCellCapacity]\nCapacity=0.1\n", encoding="shift_jis")
+    with pytest.raises(ValueError):
+        read_ptn_mass(ptn)
+
+
+# ---- column_lang translation ---------------------------------------------
+
+
+def test_column_lang_en(make_cell_dir: Callable[..., Path]) -> None:
+    d = make_cell_dir("raw_6digit", mass=0.001)
+    df, _ = read_cell_dir(d, column_lang="en")
+    assert list(df.columns[: len(CANONICAL_COLUMNS_EN)]) == list(CANONICAL_COLUMNS_EN)
+    # extras translated via schema.JA_TO_EN
+    assert "elapsed_time_s" in df.columns
+    assert "current_ma" in df.columns
+    # state values are NOT translated here — that is schema.STATE_JA_TO_EN's job
+    # when needed by downstream consumers
+    assert set(df["state"].unique()) <= {"休止", "充電", "放電"}
+
+
+# ---- Cell.from_dir wiring -----------------------------------------------
+
+
 @pytest.mark.parametrize("layout", ["renzoku", "renzoku_py", "raw_6digit"])
 def test_cell_from_dir_wires_reader(make_cell_dir: Callable[..., Path], layout: str) -> None:
-    d = make_cell_dir(layout, mass=0.002, name="mycell")
+    d = make_cell_dir(layout, mass=0.001, name="mycell")
     cell = Cell.from_dir(d)
     assert cell.name == "mycell"
     assert isinstance(cell.raw_df, pd.DataFrame)
     assert len(cell.raw_df) == 5
-    # only raw_6digit ships a .PTN by default; the renzoku layouts return NaN
-    if layout == "raw_6digit":
-        assert cell.mass_g == pytest.approx(0.002)
-    else:
+    # renzoku carries mass inline (metadata); raw_6digit has main PTN; _py has nothing
+    if layout == "renzoku_py":
         assert math.isnan(cell.mass_g)
+    else:
+        assert cell.mass_g == pytest.approx(0.001)


### PR DESCRIPTION
## Summary

Real TOYO file samples (a native `連続データ.csv` and a 100-cycle 6-digit raw directory) showed that the initial P1 reader and its fixtures were drifting from the actual format in ways that would silently corrupt data on real user input. This PR brings both in line.

### Key real-format findings
- **`連続データ.csv` carries `重量[mg]` on metadata row 3** — no `.PTN` required for native files.
- **Native CSV uses 4 JP states**: `充電 / 放電 / 充電休止 / 放電休止` (rest is a substate of the preceding charge or discharge).
- **Raw 6-digit format**: line 0 `0,0,…`, blanks, then a 15-column header `日付,時刻,経過時間[Sec],電圧[V],電流[mA],<6 empty>,状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ`. `経過時間` **resets at each state transition** and `電流` is **unsigned** — so `elapsed/3600 * current / mass` naturally produces per-segment monotone-non-decreasing 電気量. The suspected "sign problem" never existed in real data; the old fixtures were wrong.
- A real cell dir **often ships multiple `.PTN`** (main pattern + `*_OPTION.PTN` + `*_Option2.PTN`). Only the main has mass at `split()[2]`.

### Changes
- `reader.py`: new `_extract_mass_from_renzoku_metadata` + `_resolve_mass_from_ptn`; mass resolution priority is `explicit > 重量[mg] > .PTN`; raw parser drops the `Unnamed:*` noise columns.
- `conftest.py`: all three fixtures rewritten to the real formats (metadata+units rows in renzoku, 4-state substates, real column order in raw_6digit, companion `_OPTION.PTN`).
- `test_reader.py`: new coverage for metadata mg→g, metadata-missing fallback, multi-PTN disambiguation, INI-style PTN rejection, 15-column layout.
- `test_chdis.py`: two tests updated to drop the removed `include_capacity_col` fixture parameter.
- `chdis.py` docstring: `abs().diff()` reframed as defensive (reader output is no longer signed).
- `.gitignore`: `data/` excluded so local real samples stay off the repo.

### Verified end-to-end on real data
- Native `CTH404-.../連続データ.csv` → mass `0.000591 g` from metadata, 8 cycles, 4-substate states.
- `data/22/` 100-cycle raw → mass `0.000721 g` (OPTION/Option2 PTNs auto-skipped); cycle 1 ch=159.2 / dis=131.5 mAh/g (CE ~83%); cycle 100 ch=101.5 / dis=100.7 mAh/g (retention 64%, CE ~99%).

## Test plan
- [x] `uv run ruff check .` + `ruff format --check .`
- [x] `uv run mypy` (strict, 20 src files)
- [x] `uv run pytest` — 52 passed, 88% coverage (100% on core/cell & core/chdis, 95% on io/reader)
- [x] Manual verification against native `連続データ.csv` and 6-digit raw directories

Refs milestone `0.1.0 — P1 core port`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)