### PR TITLE
feat(core): capacity — per-cycle Q_ch/Q_dis and CE

### DIFF
--- a/src/toyo_battery/core/capacity.py
+++ b/src/toyo_battery/core/capacity.py
@@ -26,6 +26,8 @@ import pandas as pd
 
 from toyo_battery.io.schema import JA_TO_EN, ColumnLang
 
+# Single-entry today; retained in dict form to match the chdis/dqdv pattern
+# and keep the door open for adding voltage or current when stats.py joins.
 _JA_COLS: dict[str, str] = {
     "capacity": "電気量",
 }
@@ -74,14 +76,20 @@ def get_cap_df(chdis_df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.
     Raises
     ------
     KeyError
-        If ``chdis_df``'s ``quantity`` level does not contain the
-        capacity label for the requested ``column_lang``.
+        If ``chdis_df.columns`` is not a 3-level ``(cycle, side, quantity)``
+        MultiIndex (structural violation), or if the ``quantity`` level
+        does not contain the capacity label for the requested
+        ``column_lang`` (missing-quantity violation).
     """
     cols = _resolve_cols(column_lang)
     cap_col = cols["capacity"]
 
-    # Empty / no-column input → empty result with correct schema.
-    if chdis_df.empty and chdis_df.columns.empty:
+    # Empty on either axis → empty result with correct schema. Using ``or``
+    # so a frame with column structure but zero rows (e.g. chdis after
+    # every segment was reversal-filtered clean) also short-circuits,
+    # rather than producing a frame with cycle rows of all-NaN that would
+    # surprise callers expecting ``cap_df.empty`` to track input-emptiness.
+    if chdis_df.empty or chdis_df.columns.empty:
         return _empty_result()
 
     # Validate that the chdis_df has the expected 3-level MultiIndex and
@@ -106,7 +114,10 @@ def get_cap_df(chdis_df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.
     cap_only = chdis_df.xs(cap_col, axis=1, level="quantity")
 
     # Max per segment, skipping NaN. Result indexed by (cycle, side).
-    per_segment_max = cap_only.max(axis=0, skipna=True)
+    # Explicit cast to float64: for an all-NaN or 0-row input, pandas may
+    # return a Series with dtype=object which would poison downstream
+    # arithmetic; the cast pins the numeric contract end-to-end.
+    per_segment_max = cap_only.max(axis=0, skipna=True).astype("float64")
 
     # Unstack side → rows=cycle, columns=side. Reindex to ensure both
     # "ch" and "dis" exist even if only one side has any data globally.
@@ -121,10 +132,10 @@ def get_cap_df(chdis_df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.
     q_dis = wide["dis"].astype("float64")
 
     # Coulombic efficiency — guard q_ch == 0 as NaN (not inf / not error).
-    # `where(cond, other=NaN)` keeps the value where cond is True and
-    # substitutes NaN elsewhere; cast q_ch to a safe divisor first.
-    with np.errstate(divide="ignore", invalid="ignore"):
-        ce = 100.0 * q_dis / q_ch
+    # pandas Series division returns ``inf`` without raising for float
+    # divide-by-zero, so no ``np.errstate`` wrapper is needed; the
+    # ``where(q_ch != 0, NaN)`` below overrides ``inf`` to NaN.
+    ce = 100.0 * q_dis / q_ch
     ce = ce.where(q_ch != 0, other=np.nan)
 
     out = pd.DataFrame(

--- a/src/toyo_battery/core/capacity.py
+++ b/src/toyo_battery/core/capacity.py
@@ -9,6 +9,12 @@ The derived column names are **fixed English** (``q_ch``, ``q_dis``,
 ``column_lang`` selects which *input* quantity label (JA ``電気量`` or EN
 ``capacity``) to read from, not the output schema.
 
+Sign convention: ``ce`` inherits its sign arithmetically from
+``q_dis / q_ch``. The :mod:`chdis` contract guarantees
+``|capacity|`` is monotone non-decreasing per segment, so for well-formed
+real data both maxes are non-negative and ``ce`` sits in roughly
+``[0, 100 + epsilon]``.
+
 Rewrite note (vs. legacy TOYO_Origin_2.01): v2.01's ``get_cap_df`` pivoted
 through ``df.query('状態 in [...]')`` on the raw frame and used
 ``df["状態"][1]`` to decide whether the first cycle was charge- or
@@ -26,7 +32,7 @@ import pandas as pd
 
 from toyo_battery.io.schema import JA_TO_EN, ColumnLang
 
-# Single-entry today; retained in dict form to match the chdis/dqdv pattern
+# Single-entry today; retained in dict form to match the :mod:`chdis` pattern
 # and keep the door open for adding voltage or current when stats.py joins.
 _JA_COLS: dict[str, str] = {
     "capacity": "電気量",
@@ -71,7 +77,11 @@ def get_cap_df(chdis_df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.
         Index is ``cycle`` (int). Columns are ``["q_ch", "q_dis", "ce"]``
         (all float). ``ce`` is in percent. ``ce`` is ``NaN`` when
         ``q_ch == 0`` (not ``inf``). Missing ch or dis for a cycle yields
-        ``NaN`` for that column; the cycle row is preserved.
+        ``NaN`` for that column; the cycle row is preserved — including
+        the degenerate case where both sides are all-NaN (e.g. a cycle
+        whose columns exist but whose values were wiped by the reversal
+        filter), which produces a row of ``NaN`` values rather than being
+        dropped.
 
     Raises
     ------
@@ -125,7 +135,10 @@ def get_cap_df(chdis_df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.
     wide = wide.reindex(columns=["ch", "dis"])
 
     # Preserve every cycle from the input, including ones with only one side.
-    cycles = sorted(set(chdis_df.columns.get_level_values("cycle")))
+    # chdis already sorts by cycle via ``groupby(..., sort=True)``, but
+    # ``.unique().sort_values()`` is explicit and enforces the ``int64``
+    # contract on the index dtype in one pass.
+    cycles = chdis_df.columns.get_level_values("cycle").unique().astype("int64").sort_values()
     wide = wide.reindex(index=cycles)
 
     q_ch = wide["ch"].astype("float64")
@@ -135,15 +148,10 @@ def get_cap_df(chdis_df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.
     # pandas Series division returns ``inf`` without raising for float
     # divide-by-zero, so no ``np.errstate`` wrapper is needed; the
     # ``where(q_ch != 0, NaN)`` below overrides ``inf`` to NaN.
-    ce = 100.0 * q_dis / q_ch
-    ce = ce.where(q_ch != 0, other=np.nan)
+    ce = (100.0 * q_dis / q_ch).where(q_ch != 0, other=np.nan)
 
-    out = pd.DataFrame(
-        {
-            "q_ch": q_ch.to_numpy(dtype="float64"),
-            "q_dis": q_dis.to_numpy(dtype="float64"),
-            "ce": ce.to_numpy(dtype="float64"),
-        },
-        index=pd.Index([int(c) for c in cycles], name="cycle", dtype="int64"),
-    )
+    # Build DataFrame directly from the Series trio so dtypes round-trip
+    # without a numpy detour; name the index in place.
+    out = pd.DataFrame({"q_ch": q_ch, "q_dis": q_dis, "ce": ce})
+    out.index.name = "cycle"
     return out

--- a/src/toyo_battery/core/capacity.py
+++ b/src/toyo_battery/core/capacity.py
@@ -94,6 +94,23 @@ def get_cap_df(chdis_df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.
     cols = _resolve_cols(column_lang)
     cap_col = cols["capacity"]
 
+    # Structural check runs *before* the empty short-circuit so a
+    # flat-columns empty frame surfaces the same ``KeyError`` as a
+    # flat-columns populated frame — the error surface for a given bug
+    # should not depend on whether the input happened to contain rows.
+    if not isinstance(chdis_df.columns, pd.MultiIndex) or chdis_df.columns.nlevels != 3:
+        # Exception: a truly empty frame (no rows, no columns — `pd.DataFrame()`)
+        # is the one shape we accept without a 3-level MultiIndex, because
+        # ``chdis._empty_result`` is the canonical empty contract and we want
+        # ``get_cap_df(empty) -> empty`` to round-trip.
+        if chdis_df.empty and chdis_df.columns.empty:
+            return _empty_result()
+        raise KeyError(
+            "chdis_df.columns must be a 3-level MultiIndex "
+            "(cycle, side, quantity); "
+            f"got {chdis_df.columns!r}"
+        )
+
     # Empty on either axis → empty result with correct schema. Using ``or``
     # so a frame with column structure but zero rows (e.g. chdis after
     # every segment was reversal-filtered clean) also short-circuits,
@@ -101,17 +118,6 @@ def get_cap_df(chdis_df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.
     # surprise callers expecting ``cap_df.empty`` to track input-emptiness.
     if chdis_df.empty or chdis_df.columns.empty:
         return _empty_result()
-
-    # Validate that the chdis_df has the expected 3-level MultiIndex and
-    # carries the requested capacity quantity label. We check against the
-    # quantity level rather than attempting a cross-section so the error
-    # message is explicit about the column_lang mismatch.
-    if not isinstance(chdis_df.columns, pd.MultiIndex) or chdis_df.columns.nlevels != 3:
-        raise KeyError(
-            "chdis_df.columns must be a 3-level MultiIndex "
-            "(cycle, side, quantity); "
-            f"got {chdis_df.columns!r}"
-        )
 
     quantity_values = set(chdis_df.columns.get_level_values("quantity"))
     if cap_col not in quantity_values:

--- a/src/toyo_battery/core/capacity.py
+++ b/src/toyo_battery/core/capacity.py
@@ -1,1 +1,138 @@
-"""Per-cycle capacity and Coulombic efficiency. P1 scope — scaffold only."""
+"""Per-cycle charge/discharge capacity and Coulombic efficiency.
+
+Computes, from a :mod:`toyo_battery.core.chdis` output, one row per cycle
+with the maximum charge capacity (``q_ch``), maximum discharge capacity
+(``q_dis``), and Coulombic efficiency ``ce = 100 * q_dis / q_ch`` (in %).
+
+The derived column names are **fixed English** (``q_ch``, ``q_dis``,
+``ce``) regardless of the ``column_lang`` used for the input frame —
+``column_lang`` selects which *input* quantity label (JA ``電気量`` or EN
+``capacity``) to read from, not the output schema.
+
+Rewrite note (vs. legacy TOYO_Origin_2.01): v2.01's ``get_cap_df`` pivoted
+through ``df.query('状態 in [...]')`` on the raw frame and used
+``df["状態"][1]`` to decide whether the first cycle was charge- or
+discharge-first. That check is positionally brittle (row index 1 can be a
+rest row) and ties capacity computation to raw-state string semantics.
+Here we operate on the already-segmented ``chdis_df``, whose
+charge-first normalization is resolved once in :mod:`chdis`. This frees
+``get_cap_df`` from ever touching raw state labels.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from toyo_battery.io.schema import JA_TO_EN, ColumnLang
+
+_JA_COLS: dict[str, str] = {
+    "capacity": "電気量",
+}
+
+
+def _resolve_cols(column_lang: ColumnLang) -> dict[str, str]:
+    if column_lang == "ja":
+        return _JA_COLS
+    return {k: JA_TO_EN[v] for k, v in _JA_COLS.items()}
+
+
+def _empty_result() -> pd.DataFrame:
+    idx = pd.Index([], dtype="int64", name="cycle")
+    return pd.DataFrame(
+        {
+            "q_ch": pd.Series([], dtype="float64"),
+            "q_dis": pd.Series([], dtype="float64"),
+            "ce": pd.Series([], dtype="float64"),
+        },
+        index=idx,
+    )
+
+
+def get_cap_df(chdis_df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.DataFrame:
+    """Per-cycle charge/discharge capacity and Coulombic efficiency.
+
+    Parameters
+    ----------
+    chdis_df
+        Output of :func:`toyo_battery.core.chdis.get_chdis_df`. Must have a
+        3-level column MultiIndex ``(cycle, side, quantity)`` where
+        ``side`` is in ``{"ch", "dis"}`` and ``quantity`` contains the
+        capacity label (``電気量`` or ``capacity``).
+    column_lang
+        Language of the input's ``quantity`` level. Does *not* affect the
+        output column names — those are always English.
+
+    Returns
+    -------
+    DataFrame
+        Index is ``cycle`` (int). Columns are ``["q_ch", "q_dis", "ce"]``
+        (all float). ``ce`` is in percent. ``ce`` is ``NaN`` when
+        ``q_ch == 0`` (not ``inf``). Missing ch or dis for a cycle yields
+        ``NaN`` for that column; the cycle row is preserved.
+
+    Raises
+    ------
+    KeyError
+        If ``chdis_df``'s ``quantity`` level does not contain the
+        capacity label for the requested ``column_lang``.
+    """
+    cols = _resolve_cols(column_lang)
+    cap_col = cols["capacity"]
+
+    # Empty / no-column input → empty result with correct schema.
+    if chdis_df.empty and chdis_df.columns.empty:
+        return _empty_result()
+
+    # Validate that the chdis_df has the expected 3-level MultiIndex and
+    # carries the requested capacity quantity label. We check against the
+    # quantity level rather than attempting a cross-section so the error
+    # message is explicit about the column_lang mismatch.
+    if not isinstance(chdis_df.columns, pd.MultiIndex) or chdis_df.columns.nlevels != 3:
+        raise KeyError(
+            "chdis_df.columns must be a 3-level MultiIndex "
+            "(cycle, side, quantity); "
+            f"got {chdis_df.columns!r}"
+        )
+
+    quantity_values = set(chdis_df.columns.get_level_values("quantity"))
+    if cap_col not in quantity_values:
+        raise KeyError(
+            f"chdis_df missing required quantity {cap_col!r} "
+            f"for column_lang={column_lang!r}; got quantities={sorted(quantity_values)}"
+        )
+
+    # Cross-section the capacity quantity → columns become (cycle, side).
+    cap_only = chdis_df.xs(cap_col, axis=1, level="quantity")
+
+    # Max per segment, skipping NaN. Result indexed by (cycle, side).
+    per_segment_max = cap_only.max(axis=0, skipna=True)
+
+    # Unstack side → rows=cycle, columns=side. Reindex to ensure both
+    # "ch" and "dis" exist even if only one side has any data globally.
+    wide = per_segment_max.unstack(level="side")
+    wide = wide.reindex(columns=["ch", "dis"])
+
+    # Preserve every cycle from the input, including ones with only one side.
+    cycles = sorted(set(chdis_df.columns.get_level_values("cycle")))
+    wide = wide.reindex(index=cycles)
+
+    q_ch = wide["ch"].astype("float64")
+    q_dis = wide["dis"].astype("float64")
+
+    # Coulombic efficiency — guard q_ch == 0 as NaN (not inf / not error).
+    # `where(cond, other=NaN)` keeps the value where cond is True and
+    # substitutes NaN elsewhere; cast q_ch to a safe divisor first.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ce = 100.0 * q_dis / q_ch
+    ce = ce.where(q_ch != 0, other=np.nan)
+
+    out = pd.DataFrame(
+        {
+            "q_ch": q_ch.to_numpy(dtype="float64"),
+            "q_dis": q_dis.to_numpy(dtype="float64"),
+            "ce": ce.to_numpy(dtype="float64"),
+        },
+        index=pd.Index([int(c) for c in cycles], name="cycle", dtype="int64"),
+    )
+    return out

--- a/src/toyo_battery/core/cell.py
+++ b/src/toyo_battery/core/cell.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from toyo_battery.core.capacity import get_cap_df
 from toyo_battery.core.chdis import get_chdis_df
 from toyo_battery.io.reader import read_cell_dir
 from toyo_battery.io.schema import ColumnLang
@@ -48,3 +49,7 @@ class Cell:
     @cached_property
     def chdis_df(self) -> pd.DataFrame:
         return get_chdis_df(self.raw_df, column_lang=self.column_lang)
+
+    @cached_property
+    def cap_df(self) -> pd.DataFrame:
+        return get_cap_df(self.chdis_df, column_lang=self.column_lang)

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -1,0 +1,214 @@
+"""Tests for :mod:`toyo_battery.core.capacity`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from toyo_battery.core.capacity import get_cap_df
+from toyo_battery.core.cell import Cell
+
+
+def _chdis(
+    segments: dict[tuple[int, str], list[tuple[float, float]]],
+    *,
+    quantity_cap: str = "電気量",
+    quantity_v: str = "電圧",
+) -> pd.DataFrame:
+    """Build a minimal chdis_df from ``(cycle, side) -> [(voltage, capacity)]``.
+
+    Output mirrors the shape produced by :func:`toyo_battery.core.chdis.get_chdis_df`:
+    a 3-level column MultiIndex ``(cycle, side, quantity)`` with NaN-padded
+    rows so all segments share a row axis.
+    """
+    pieces: dict[tuple[int, str], pd.DataFrame] = {}
+    for (cycle, side), rows in segments.items():
+        if rows:
+            df = pd.DataFrame(rows, columns=[quantity_v, quantity_cap])
+        else:
+            df = pd.DataFrame(columns=[quantity_v, quantity_cap])
+        pieces[(cycle, side)] = df
+    out = pd.concat(pieces, axis=1) if pieces else pd.DataFrame()
+    out.columns = out.columns.set_names(["cycle", "side", "quantity"])
+    return out
+
+
+def _empty_chdis(*, lang: str = "ja") -> pd.DataFrame:
+    """Return an empty chdis_df with the expected 3-level MultiIndex."""
+    # Match the shape produced by chdis._empty_result.
+    _ = lang  # Empty frames carry no quantity labels so lang is not material.
+    idx = pd.MultiIndex.from_tuples([], names=["cycle", "side", "quantity"])
+    return pd.DataFrame(columns=idx)
+
+
+def test_three_cycle_monotone_pinned() -> None:
+    """3-cycle fixture with distinct q_ch / q_dis per cycle.
+
+    Pinned values: q_ch=[500, 480, 460], q_dis=[495, 475, 455],
+    ce = 100 * q_dis / q_ch per cycle.
+    """
+    segments: dict[tuple[int, str], list[tuple[float, float]]] = {
+        (1, "ch"): [(3.50, 0.0), (3.60, 500.0)],
+        (1, "dis"): [(3.60, 0.0), (3.40, 495.0)],
+        (2, "ch"): [(3.50, 0.0), (3.60, 480.0)],
+        (2, "dis"): [(3.60, 0.0), (3.40, 475.0)],
+        (3, "ch"): [(3.50, 0.0), (3.60, 460.0)],
+        (3, "dis"): [(3.60, 0.0), (3.40, 455.0)],
+    }
+    cap = get_cap_df(_chdis(segments))
+
+    assert list(cap.columns) == ["q_ch", "q_dis", "ce"]
+    assert cap.index.name == "cycle"
+    assert cap.index.tolist() == [1, 2, 3]
+    assert cap["q_ch"].tolist() == [500.0, 480.0, 460.0]
+    assert cap["q_dis"].tolist() == [495.0, 475.0, 455.0]
+    np.testing.assert_allclose(
+        cap["ce"].to_numpy(),
+        np.array([100.0 * 495.0 / 500.0, 100.0 * 475.0 / 480.0, 100.0 * 455.0 / 460.0]),
+    )
+    # All columns float64
+    for col in ("q_ch", "q_dis", "ce"):
+        assert cap[col].dtype == np.float64
+
+
+def test_cycle_with_only_ch_side_has_nan_dis_and_ce() -> None:
+    """A cycle without a dis segment has q_dis=NaN, ce=NaN, row preserved."""
+    segments: dict[tuple[int, str], list[tuple[float, float]]] = {
+        (1, "ch"): [(3.50, 0.0), (3.60, 500.0)],
+        (1, "dis"): [(3.60, 0.0), (3.40, 495.0)],
+        (2, "ch"): [(3.50, 0.0), (3.60, 480.0)],
+        # Note: no (2, "dis")
+    }
+    cap = get_cap_df(_chdis(segments))
+
+    assert cap.index.tolist() == [1, 2]
+    # Cycle 2 dis missing → NaN
+    assert cap.loc[2, "q_ch"] == 480.0
+    assert pd.isna(cap.loc[2, "q_dis"])
+    assert pd.isna(cap.loc[2, "ce"])
+    # Cycle 1 intact
+    assert cap.loc[1, "q_ch"] == 500.0
+    assert cap.loc[1, "q_dis"] == 495.0
+
+
+def test_cycle_with_only_dis_side_has_nan_ch_and_ce() -> None:
+    """Symmetric: a cycle without a ch segment has q_ch=NaN, ce=NaN."""
+    segments: dict[tuple[int, str], list[tuple[float, float]]] = {
+        (1, "ch"): [(3.50, 0.0), (3.60, 500.0)],
+        (1, "dis"): [(3.60, 0.0), (3.40, 495.0)],
+        (2, "dis"): [(3.60, 0.0), (3.40, 475.0)],
+    }
+    cap = get_cap_df(_chdis(segments))
+
+    assert cap.index.tolist() == [1, 2]
+    assert pd.isna(cap.loc[2, "q_ch"])
+    assert cap.loc[2, "q_dis"] == 475.0
+    assert pd.isna(cap.loc[2, "ce"])
+
+
+def test_q_ch_zero_yields_nan_ce_not_inf() -> None:
+    """q_ch == 0 → ce = NaN (neither inf nor raise)."""
+    segments: dict[tuple[int, str], list[tuple[float, float]]] = {
+        (1, "ch"): [(3.50, 0.0), (3.60, 0.0)],  # zero-capacity charge
+        (1, "dis"): [(3.60, 0.0), (3.40, 10.0)],
+    }
+    cap = get_cap_df(_chdis(segments))
+
+    assert cap.loc[1, "q_ch"] == 0.0
+    assert cap.loc[1, "q_dis"] == 10.0
+    assert pd.isna(cap.loc[1, "ce"])
+    assert not np.isinf(cap.loc[1, "ce"])
+
+
+def test_empty_chdis_returns_empty_frame_with_correct_columns_and_dtypes() -> None:
+    """Empty chdis_df → empty cap_df with correct schema."""
+    cap = get_cap_df(_empty_chdis())
+    assert cap.empty
+    assert list(cap.columns) == ["q_ch", "q_dis", "ce"]
+    assert cap.index.name == "cycle"
+    # Index dtype is int for consistency with the non-empty case.
+    assert cap.index.dtype == np.int64
+    for col in ("q_ch", "q_dis", "ce"):
+        assert cap[col].dtype == np.float64
+
+
+def test_column_lang_en_input_produces_same_english_output() -> None:
+    """EN-labeled input quantity → same output shape & column names."""
+    segments: dict[tuple[int, str], list[tuple[float, float]]] = {
+        (1, "ch"): [(3.50, 0.0), (3.60, 500.0)],
+        (1, "dis"): [(3.60, 0.0), (3.40, 495.0)],
+        (2, "ch"): [(3.50, 0.0), (3.60, 480.0)],
+        (2, "dis"): [(3.60, 0.0), (3.40, 475.0)],
+    }
+    chdis_en = _chdis(segments, quantity_cap="capacity", quantity_v="voltage")
+    cap = get_cap_df(chdis_en, column_lang="en")
+
+    assert list(cap.columns) == ["q_ch", "q_dis", "ce"]
+    assert cap.index.name == "cycle"
+    assert cap["q_ch"].tolist() == [500.0, 480.0]
+    assert cap["q_dis"].tolist() == [495.0, 475.0]
+
+
+def test_missing_required_quantity_raises_helpful_error() -> None:
+    """Missing capacity label in the quantity level raises KeyError."""
+    # Frame with 'voltage' only, no 電気量 / capacity.
+    segments: dict[tuple[int, str], list[tuple[float, float]]] = {
+        (1, "ch"): [(3.50, 0.0), (3.60, 500.0)],
+    }
+    chdis = _chdis(segments)
+    # Rename the quantity level to something else so capacity is absent.
+    chdis.columns = pd.MultiIndex.from_tuples(
+        [(c, s, "まちがい") for (c, s, _q) in chdis.columns],
+        names=["cycle", "side", "quantity"],
+    )
+    with pytest.raises(KeyError, match="電気量"):
+        get_cap_df(chdis)
+
+
+def test_wrong_column_lang_raises_with_context() -> None:
+    """Passing JA-labeled chdis with column_lang='en' surfaces a helpful error."""
+    segments: dict[tuple[int, str], list[tuple[float, float]]] = {
+        (1, "ch"): [(3.50, 0.0), (3.60, 500.0)],
+        (1, "dis"): [(3.60, 0.0), (3.40, 495.0)],
+    }
+    chdis = _chdis(segments)  # default JA quantity labels
+    with pytest.raises(KeyError, match="column_lang='en'"):
+        get_cap_df(chdis, column_lang="en")
+
+
+def test_cell_cap_df_cached_and_columns(make_cell_dir: Callable[..., Path]) -> None:
+    """Cell.cap_df integrates the capacity function and is cached."""
+    cell = Cell.from_dir(make_cell_dir("renzoku"))
+    first = cell.cap_df
+    second = cell.cap_df
+    assert first is second
+    assert (cell.cap_df.columns == ["q_ch", "q_dis", "ce"]).all()
+    assert cell.cap_df.index.name == "cycle"
+
+
+def test_cell_cap_df_values_from_shared_fixture(make_cell_dir: Callable[..., Path]) -> None:
+    """Shared fixture: one cycle, q_ch=q_dis=1000, ce=100%.
+
+    The fixture's single cycle has elapsed=3600s, current=1mA, mass=1mg
+    → capacity = 1·3600/(3600·0.001·1000) · 1000 = 1000 mAh/g at each
+    segment end; the 電気量 column is pre-filled with exactly these values
+    (renzoku) or derived from elapsed·current/mass (raw_6digit), so both
+    paths produce q_ch = q_dis = 1000 and ce = 100.
+    """
+    cell = Cell.from_dir(make_cell_dir("renzoku"))
+    cap = cell.cap_df
+    assert cap.index.tolist() == [1]
+    np.testing.assert_allclose(cap.loc[1, "q_ch"], 1000.0)
+    np.testing.assert_allclose(cap.loc[1, "q_dis"], 1000.0)
+    np.testing.assert_allclose(cap.loc[1, "ce"], 100.0)
+
+
+def test_cell_cap_df_respects_column_lang(make_cell_dir: Callable[..., Path]) -> None:
+    """Output column names are EN-fixed even when input column_lang='en'."""
+    cell = Cell.from_dir(make_cell_dir("renzoku"), column_lang="en")
+    cap = cell.cap_df
+    assert list(cap.columns) == ["q_ch", "q_dis", "ce"]

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -17,20 +17,20 @@ def _chdis(
     segments: dict[tuple[int, str], list[tuple[float, float]]],
     *,
     quantity_cap: str = "電気量",
-    quantity_v: str = "電圧",
 ) -> pd.DataFrame:
     """Build a minimal chdis_df from ``(cycle, side) -> [(voltage, capacity)]``.
 
     Output mirrors the shape produced by :func:`toyo_battery.core.chdis.get_chdis_df`:
     a 3-level column MultiIndex ``(cycle, side, quantity)`` with NaN-padded
-    rows so all segments share a row axis.
+    rows so all segments share a row axis. ``get_cap_df`` only reads the
+    capacity quantity, so the voltage label is hardcoded (``"電圧"``).
     """
     pieces: dict[tuple[int, str], pd.DataFrame] = {}
     for (cycle, side), rows in segments.items():
         if rows:
-            df = pd.DataFrame(rows, columns=[quantity_v, quantity_cap])
+            df = pd.DataFrame(rows, columns=["電圧", quantity_cap])
         else:
-            df = pd.DataFrame(columns=[quantity_v, quantity_cap])
+            df = pd.DataFrame(columns=["電圧", quantity_cap])
         pieces[(cycle, side)] = df
     out = pd.concat(pieces, axis=1) if pieces else pd.DataFrame()
     out.columns = out.columns.set_names(["cycle", "side", "quantity"])
@@ -146,7 +146,7 @@ def test_column_lang_en_input_produces_same_english_output() -> None:
         (2, "ch"): [(3.50, 0.0), (3.60, 480.0)],
         (2, "dis"): [(3.60, 0.0), (3.40, 475.0)],
     }
-    chdis_en = _chdis(segments, quantity_cap="capacity", quantity_v="voltage")
+    chdis_en = _chdis(segments, quantity_cap="capacity")
     cap = get_cap_df(chdis_en, column_lang="en")
 
     assert list(cap.columns) == ["q_ch", "q_dis", "ce"]

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -37,10 +37,12 @@ def _chdis(
     return out
 
 
-def _empty_chdis(*, lang: str = "ja") -> pd.DataFrame:
-    """Return an empty chdis_df with the expected 3-level MultiIndex."""
-    # Match the shape produced by chdis._empty_result.
-    _ = lang  # Empty frames carry no quantity labels so lang is not material.
+def _empty_chdis() -> pd.DataFrame:
+    """Return an empty chdis_df with the expected 3-level MultiIndex.
+
+    Matches the shape produced by :func:`chdis._empty_result`. Empty frames
+    carry no quantity labels so ``column_lang`` is not material here.
+    """
     idx = pd.MultiIndex.from_tuples([], names=["cycle", "side", "quantity"])
     return pd.DataFrame(columns=idx)
 
@@ -218,21 +220,47 @@ def test_cell_cap_df_cached_and_columns(make_cell_dir: Callable[..., Path]) -> N
     assert cell.cap_df.index.name == "cycle"
 
 
-def test_cell_cap_df_values_from_shared_fixture(make_cell_dir: Callable[..., Path]) -> None:
-    """Shared fixture: one cycle, q_ch=q_dis=1000, ce=100%.
+@pytest.mark.parametrize("layout", ["renzoku", "renzoku_py", "raw_6digit"])
+def test_cell_cap_df_values_from_shared_fixture(
+    make_cell_dir: Callable[..., Path], layout: str
+) -> None:
+    """All three on-disk layouts yield the same q_ch / q_dis / ce values.
 
-    The fixture's single cycle has elapsed=3600s, current=1mA, mass=1mg
-    → capacity = 1·3600/(3600·0.001·1000) · 1000 = 1000 mAh/g at each
-    segment end; the 電気量 column is pre-filled with exactly these values
-    (renzoku) or derived from elapsed·current/mass (raw_6digit), so both
-    paths produce q_ch = q_dis = 1000 and ce = 100.
+    The shared fixture's single cycle has elapsed=3600s, current=1mA,
+    mass=1mg → capacity = 1·3600/(3600·0.001·1000) · 1000 = 1000 mAh/g at
+    each segment end. The 電気量 column is pre-filled with exactly these
+    values (renzoku / renzoku_py) or derived from elapsed·current/mass
+    (raw_6digit), so all three paths produce q_ch = q_dis = 1000 and
+    ce = 100.
     """
-    cell = Cell.from_dir(make_cell_dir("renzoku"))
+    cell = Cell.from_dir(make_cell_dir(layout))
     cap = cell.cap_df
     assert cap.index.tolist() == [1]
     np.testing.assert_allclose(cap.loc[1, "q_ch"], 1000.0)
     np.testing.assert_allclose(cap.loc[1, "q_dis"], 1000.0)
     np.testing.assert_allclose(cap.loc[1, "ce"], 100.0)
+
+
+def test_zero_row_populated_columns_short_circuits_to_empty() -> None:
+    """Columns present but zero rows → empty cap_df (not a row of NaN).
+
+    Pins the behavior installed by the early-return ``or`` gate: a chdis
+    frame with column structure but zero rows (e.g. every segment was
+    wiped by the reversal filter) short-circuits to the empty result,
+    keeping ``cap_df.empty`` a reliable proxy for input-emptiness.
+    """
+    segments: dict[tuple[int, str], list[tuple[float, float]]] = {
+        (1, "ch"): [],
+        (1, "dis"): [],
+    }
+    chdis = _chdis(segments)
+    # Confirm the fixture hits the targeted path: has columns, zero rows.
+    assert not chdis.columns.empty
+    assert len(chdis) == 0
+
+    cap = get_cap_df(chdis)
+    assert cap.empty
+    assert list(cap.columns) == ["q_ch", "q_dis", "ce"]
 
 
 def test_cell_cap_df_respects_column_lang(make_cell_dir: Callable[..., Path]) -> None:

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -170,14 +170,42 @@ def test_missing_required_quantity_raises_helpful_error() -> None:
 
 
 def test_wrong_column_lang_raises_with_context() -> None:
-    """Passing JA-labeled chdis with column_lang='en' surfaces a helpful error."""
+    """Passing JA-labeled chdis with column_lang='en' surfaces a helpful error.
+
+    The regex matches on structural tokens (``missing required quantity``)
+    rather than an exact reproduction of the f-string formatting, so
+    rewording the error message does not break this test.
+    """
     segments: dict[tuple[int, str], list[tuple[float, float]]] = {
         (1, "ch"): [(3.50, 0.0), (3.60, 500.0)],
         (1, "dis"): [(3.60, 0.0), (3.40, 495.0)],
     }
     chdis = _chdis(segments)  # default JA quantity labels
-    with pytest.raises(KeyError, match="column_lang='en'"):
+    with pytest.raises(KeyError, match="missing required quantity"):
         get_cap_df(chdis, column_lang="en")
+
+
+def test_cycle_with_all_nan_ch_side_preserves_row_as_nan() -> None:
+    """A cycle whose ch column exists but holds only NaN still produces a
+    row, with q_ch / ce = NaN and q_dis populated.
+
+    Mirrors the chdis post-filter shape where a segment's column is present
+    but its values were all wiped by the reversal filter.
+    """
+    segments: dict[tuple[int, str], list[tuple[float, float]]] = {
+        (1, "ch"): [],  # empty rows → column exists, all NaN after concat
+        (1, "dis"): [(3.60, 0.0), (3.40, 495.0)],
+    }
+    chdis = _chdis(segments)
+    # Confirm the fixture shape: the ch column exists but holds only NaN.
+    assert (1, "ch", "電気量") in chdis.columns
+    assert chdis[(1, "ch", "電気量")].isna().all()
+
+    cap = get_cap_df(chdis)
+    assert cap.index.tolist() == [1]
+    assert pd.isna(cap.loc[1, "q_ch"])
+    assert cap.loc[1, "q_dis"] == 495.0
+    assert pd.isna(cap.loc[1, "ce"])
 
 
 def test_cell_cap_df_cached_and_columns(make_cell_dir: Callable[..., Path]) -> None:


### PR DESCRIPTION
## Summary

- Implements `get_cap_df(chdis_df, *, column_lang="ja") -> pd.DataFrame` producing a per-cycle frame with columns `["q_ch", "q_dis", "ce"]` (float, EN-fixed; `ce` in %). Built by taking the per-segment `max()` of the `(cycle, side)` capacity slices of the input `chdis_df`.
- Adds `Cell.cap_df` as a `cached_property` mirroring the existing `chdis_df` integration.
- `ce` is NaN-guarded against `q_ch == 0` (neither inf nor raise). Missing `ch` or `dis` for a cycle → that column is NaN, cycle row preserved.
- Empty `chdis_df` → empty frame with correct schema and dtypes (`int64` index, `float64` columns).

## Deviations from v2.01

v2.01's `get_cap_df` (TOYO_Origin_2_01.py:317) operates on the raw frame, branching on `df["状態"][1]` to decide whether the first cycle is charge- or discharge-first. That check is positionally brittle — row 1 may be a rest row — and ties capacity to raw-state string semantics. This implementation consumes `chdis_df`, which has already resolved the first-cycle-swap in `chdis.py` once and for all. `capacity.py` therefore never touches raw `状態` values. Output column names are `q_ch`/`q_dis`/`ce` (EN-fixed, `ce` in %) rather than v2.01's `電気量ch`/`電気量dis`/`Coulombic efficiency`, per the package's "derived statistics are EN-fixed" design rule.

## Test plan

- [x] `uv run pytest tests/test_capacity.py -v` — 11 tests pass
- [x] `uv run pytest tests/ -x` — full suite 63 tests pass (52 prior + 11 new)
- [x] `uv run mypy` — no issues
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] 3-cycle monotone fixture → pinned q_ch/q_dis/ce values
- [x] Cycle with only ch / only dis → correct NaN propagation, row preserved
- [x] `q_ch == 0` → ce = NaN (not inf, no raise)
- [x] Empty chdis_df → empty frame with correct columns and dtypes
- [x] `column_lang="en"` input → same EN-fixed output
- [x] Missing capacity quantity + wrong column_lang → helpful `KeyError`
- [x] `Cell.cap_df` caching (`cell.cap_df is cell.cap_df`) and fixture integration

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)