### PR TITLE
feat(core): dqdv — interp + Savitzky-Golay derivative

### DIFF
--- a/src/toyo_battery/core/cell.py
+++ b/src/toyo_battery/core/cell.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from toyo_battery.core.capacity import get_cap_df
 from toyo_battery.core.chdis import get_chdis_df
+from toyo_battery.core.dqdv import get_dqdv_df
 from toyo_battery.io.reader import read_cell_dir
 from toyo_battery.io.schema import ColumnLang
 
@@ -53,3 +54,12 @@ class Cell:
     @cached_property
     def cap_df(self) -> pd.DataFrame:
         return get_cap_df(self.chdis_df, column_lang=self.column_lang)
+
+    @cached_property
+    def dqdv_df(self) -> pd.DataFrame:
+        """dQ/dV with default parameters. For non-default ``inter_num`` /
+        ``window_length`` / ``polyorder``, call
+        :func:`toyo_battery.core.dqdv.get_dqdv_df` directly on
+        ``cell.chdis_df``.
+        """
+        return get_dqdv_df(self.chdis_df, column_lang=self.column_lang)

--- a/src/toyo_battery/core/dqdv.py
+++ b/src/toyo_battery/core/dqdv.py
@@ -1,1 +1,216 @@
-"""dQ/dV computation (interpolation + Savitzky-Golay). P1 scope — scaffold only."""
+"""dQ/dV computation via interpolation + Savitzky-Golay derivative.
+
+For each ``(cycle, side)`` segment in a ``chdis_df`` (produced by
+:func:`toyo_battery.core.chdis.get_chdis_df`), this module:
+
+1. Extracts the voltage and capacity series, drops NaN rows, sorts by V,
+   and removes duplicate V values.
+2. Linearly interpolates Q onto a uniform V grid
+   (``np.linspace(V.min(), V.max(), ipnum)`` with
+   ``ipnum = max(int(inter_num * (V.max() - V.min())), 2)``).
+3. Applies :func:`scipy.signal.savgol_filter` with ``deriv=1`` to compute
+   ``dQ/dV`` on the resampled curve.
+
+Output shape: a wide DataFrame whose column MultiIndex mirrors ``chdis_df``
+(levels ``cycle``, ``side``, ``quantity``). The ``quantity`` level holds
+``{"電圧", "dQ/dV"}`` when ``column_lang="ja"`` and
+``{"voltage", "dq_dv"}`` when ``column_lang="en"``. The row axis is a
+``RangeIndex`` shared across all segments; shorter segments are NaN-padded
+to the longest.
+
+Rewrite note (vs. legacy TOYO_Origin_2.01 L378 ``plot_dQdV_curve``): the
+original read the voltage bounds via ``chdis_df[cycle].at[1, "電圧"]`` and
+``chdis_df[cycle].at[len(...)-1, "電圧"]``. ``.at[1, ...]`` reads the
+*second* row, not the first, so the original implicitly skipped the first
+sample and was sensitive to whichever row landed at position 1 before
+sorting. This rewrite uses ``V.min()`` and ``V.max()`` after an explicit
+ascending sort with duplicate removal — deterministic, monotone, and works
+whether the source segment is a charge or a discharge.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+from scipy.interpolate import interp1d
+from scipy.signal import savgol_filter
+
+from toyo_battery.io.schema import JA_TO_EN, ColumnLang
+
+_JA_COLS: dict[str, str] = {
+    "voltage": "電圧",
+    "capacity": "電気量",
+    "dqdv": "dQ/dV",
+}
+
+# Per-segment result: (V-grid, dQ/dV samples), both same length.
+_SegPair = tuple[NDArray[np.float64], NDArray[np.float64]]
+
+
+def _resolve_cols(column_lang: ColumnLang) -> dict[str, str]:
+    if column_lang == "ja":
+        return _JA_COLS
+    # Input voltage/capacity follow JA_TO_EN; the dqdv output name is fixed EN.
+    return {
+        "voltage": JA_TO_EN[_JA_COLS["voltage"]],
+        "capacity": JA_TO_EN[_JA_COLS["capacity"]],
+        "dqdv": "dq_dv",
+    }
+
+
+def _empty_result() -> pd.DataFrame:
+    idx = pd.MultiIndex.from_tuples([], names=["cycle", "side", "quantity"])
+    return pd.DataFrame(columns=idx)
+
+
+def get_dqdv_df(
+    chdis_df: pd.DataFrame,
+    *,
+    inter_num: int = 100,
+    window_length: int = 11,
+    polyorder: int = 2,
+    column_lang: ColumnLang = "ja",
+) -> pd.DataFrame:
+    """Compute dQ/dV per (cycle, side) segment from a chdis DataFrame.
+
+    Parameters
+    ----------
+    chdis_df
+        Output of :func:`toyo_battery.core.chdis.get_chdis_df`. Its column
+        MultiIndex must have levels ``cycle``, ``side``, ``quantity`` with
+        the ``quantity`` level using the names resolved by ``column_lang``
+        (voltage + capacity).
+    inter_num
+        Interpolation density. The number of samples on the uniform V grid
+        is ``max(int(inter_num * (V.max() - V.min())), 2)`` per segment.
+        Segments whose interpolated length is below ``window_length`` yield
+        all-NaN columns (Savitzky-Golay requires at least ``window_length``
+        samples).
+    window_length
+        Savitzky-Golay window length (must be odd and > ``polyorder``; the
+        caller is responsible for satisfying the scipy constraints).
+    polyorder
+        Savitzky-Golay polynomial order.
+    column_lang
+        Language of the ``quantity`` level on both input and output. When
+        ``"ja"`` the output uses ``{"電圧", "dQ/dV"}``; when ``"en"`` it
+        uses ``{"voltage", "dq_dv"}``.
+
+    Returns
+    -------
+    DataFrame
+        Columns: MultiIndex with levels ``cycle``, ``side``, ``quantity``.
+        Row axis: ``RangeIndex`` sized to the longest segment; shorter
+        segments are NaN-padded.
+
+    Notes
+    -----
+    Non-default ``inter_num`` / ``window_length`` / ``polyorder`` must be
+    passed by calling this function directly —
+    :attr:`toyo_battery.core.cell.Cell.dqdv_df` uses the defaults.
+    """
+    cols = _resolve_cols(column_lang)
+    v_name, q_name, dqdv_name = cols["voltage"], cols["capacity"], cols["dqdv"]
+
+    if chdis_df.empty or chdis_df.columns.empty:
+        return _empty_result()
+
+    cols_tuples = cast("list[tuple[int, str, str]]", list(chdis_df.columns))
+    cycle_side_pairs: list[tuple[int, str]] = sorted(
+        {(int(c), str(s)) for c, s, _q in cols_tuples},
+        key=lambda t: (t[0], 0 if t[1] == "ch" else 1),
+    )
+
+    per_segment: dict[tuple[int, str], _SegPair | None] = {}
+    for cycle, side in cycle_side_pairs:
+        try:
+            v_series = chdis_df[(cycle, side, v_name)]
+            q_series = chdis_df[(cycle, side, q_name)]
+        except KeyError:
+            per_segment[(cycle, side)] = None
+            continue
+
+        frame = pd.concat({"v": v_series, "q": q_series}, axis=1).dropna()
+        if frame.empty:
+            per_segment[(cycle, side)] = None
+            continue
+
+        frame = (
+            frame.sort_values("v", kind="mergesort")
+            .drop_duplicates(subset="v", keep="first")
+            .reset_index(drop=True)
+        )
+        if len(frame) < 2:
+            per_segment[(cycle, side)] = None
+            continue
+
+        v_arr: NDArray[np.float64] = frame["v"].to_numpy(dtype=float)
+        q_arr: NDArray[np.float64] = frame["q"].to_numpy(dtype=float)
+        v_min, v_max = float(v_arr.min()), float(v_arr.max())
+        ipnum = max(int(inter_num * (v_max - v_min)), 2)
+
+        if ipnum < window_length:
+            per_segment[(cycle, side)] = None
+            continue
+
+        x_latent: NDArray[np.float64] = np.linspace(v_min, v_max, ipnum)
+        dx = float(x_latent[1] - x_latent[0])
+        ip = interp1d(v_arr, q_arr, fill_value="extrapolate")
+        q_latent: NDArray[np.float64] = np.asarray(ip(x_latent), dtype=float)
+        # ``delta=dx`` makes savgol return d(Q)/d(V) in the physical units of
+        # the input (mAh/g per V), not d(Q)/d(sample-index). v2.01 omitted
+        # this and the legacy plots showed a slope-scaled axis; the rewrite
+        # fixes it.
+        dy: NDArray[np.float64] = np.asarray(
+            savgol_filter(
+                q_latent,
+                window_length=window_length,
+                polyorder=polyorder,
+                deriv=1,
+                delta=dx,
+                mode="nearest",
+            ),
+            dtype=float,
+        )
+        per_segment[(cycle, side)] = (x_latent, dy)
+
+    longest = max(
+        (len(pair[0]) for pair in per_segment.values() if pair is not None),
+        default=0,
+    )
+    if longest == 0:
+        # All segments degenerate — still return a frame whose columns mirror
+        # the input so downstream consumers can detect the empty case without
+        # KeyErrors. Rows are empty.
+        empty_data: dict[tuple[int, str, str], NDArray[np.float64]] = {}
+        for cycle, side in cycle_side_pairs:
+            empty_data[(cycle, side, v_name)] = np.array([], dtype=float)
+            empty_data[(cycle, side, dqdv_name)] = np.array([], dtype=float)
+        out = pd.DataFrame(empty_data)
+        out.columns = pd.MultiIndex.from_tuples(
+            cast("list[tuple[int, str, str]]", list(out.columns)),
+            names=["cycle", "side", "quantity"],
+        )
+        return out
+
+    columns: dict[tuple[int, str, str], NDArray[np.float64]] = {}
+    for cycle, side in cycle_side_pairs:
+        pair = per_segment[(cycle, side)]
+        v_col: NDArray[np.float64] = np.full(longest, np.nan, dtype=float)
+        d_col: NDArray[np.float64] = np.full(longest, np.nan, dtype=float)
+        if pair is not None:
+            x_latent, dy = pair
+            v_col[: len(x_latent)] = x_latent
+            d_col[: len(dy)] = dy
+        columns[(cycle, side, v_name)] = v_col
+        columns[(cycle, side, dqdv_name)] = d_col
+
+    out = pd.DataFrame(columns)
+    out.columns = pd.MultiIndex.from_tuples(
+        cast("list[tuple[int, str, str]]", list(out.columns)),
+        names=["cycle", "side", "quantity"],
+    )
+    return out

--- a/src/toyo_battery/core/dqdv.py
+++ b/src/toyo_battery/core/dqdv.py
@@ -90,12 +90,17 @@ def _validate_savgol_params(inter_num: int, window_length: int, polyorder: int) 
     """Validate Savitzky-Golay preconditions up-front for a helpful error.
 
     scipy raises from deep inside ``savgol_filter`` otherwise, which is
-    harder to correlate with a caller's actual input.
+    harder to correlate with a caller's actual input. ``window_length``
+    is required to be odd here — scipy 1.13+ accepts even, but the
+    project floor is ``scipy>=1.10`` where even values raise. Enforcing
+    odd uniformly keeps behaviour consistent across the supported range.
     """
     if inter_num < 1:
         raise ValueError(f"inter_num must be >= 1, got {inter_num}")
     if window_length < 1:
         raise ValueError(f"window_length must be >= 1, got {window_length}")
+    if window_length % 2 == 0:
+        raise ValueError(f"window_length must be odd, got {window_length}")
     if polyorder < 0:
         raise ValueError(f"polyorder must be >= 0, got {polyorder}")
     if polyorder >= window_length:
@@ -126,10 +131,10 @@ def get_dqdv_df(
         all-NaN columns (Savitzky-Golay requires at least ``window_length``
         samples). Must be ``>= 1``.
     window_length
-        Savitzky-Golay window length. Must be a positive integer strictly
-        greater than ``polyorder``. scipy ``< 1.13`` additionally requires
-        an odd value; 1.13+ accepts even. The module does not enforce
-        odd-ness to stay compatible with modern scipy.
+        Savitzky-Golay window length. Must be a positive odd integer
+        strictly greater than ``polyorder``. (scipy 1.13+ accepts even,
+        but the project floor is ``scipy>=1.10`` where odd is required;
+        enforcing odd uniformly avoids a version-dependent failure mode.)
     polyorder
         Savitzky-Golay polynomial order. Must be ``>= 0`` and strictly
         less than ``window_length``.
@@ -166,19 +171,25 @@ def get_dqdv_df(
     cols = _resolve_cols(column_lang)
     v_name, q_name, dqdv_name = cols["voltage"], cols["capacity"], cols["dqdv"]
 
-    if chdis_df.empty or chdis_df.columns.empty:
-        return _empty_result()
-
-    # Structural check: the 3-level MultiIndex is part of the chdis contract.
-    # Anything else is a caller bug; raise with the same framing as the
-    # missing-quantity error below so both failure modes are catchable
-    # under ``except KeyError``.
+    # Structural check runs *before* the empty short-circuit so a
+    # flat-columns empty frame surfaces the same ``KeyError`` as a
+    # flat-columns populated frame — the error surface for a given bug
+    # should not depend on whether the input happened to contain rows.
     if not isinstance(chdis_df.columns, pd.MultiIndex) or chdis_df.columns.nlevels != 3:
+        # Exception: a truly empty frame (no rows, no columns — `pd.DataFrame()`)
+        # is the one shape we accept without a 3-level MultiIndex, because
+        # ``chdis._empty_result`` is the canonical empty contract and we want
+        # ``get_dqdv_df(empty) -> empty`` to round-trip.
+        if chdis_df.empty and chdis_df.columns.empty:
+            return _empty_result()
         raise KeyError(
             "chdis_df.columns must be a 3-level MultiIndex "
             "(cycle, side, quantity); "
             f"got {chdis_df.columns!r}"
         )
+
+    if chdis_df.empty or chdis_df.columns.empty:
+        return _empty_result()
 
     quantity_values = set(chdis_df.columns.get_level_values("quantity"))
     missing_quantities = sorted({v_name, q_name} - quantity_values)
@@ -189,9 +200,12 @@ def get_dqdv_df(
         )
 
     cols_tuples = cast("list[tuple[int, str, str]]", list(chdis_df.columns))
+    # Deterministic order: (cycle, side) with explicit side rank.
+    # ``ch`` before ``dis``, any future side lands after both (stable).
+    _side_rank: dict[str, int] = {"ch": 0, "dis": 1}
     cycle_side_pairs: list[tuple[int, str]] = sorted(
         {(int(c), str(s)) for c, s, _q in cols_tuples},
-        key=lambda t: (t[0], 0 if t[1] == "ch" else 1),
+        key=lambda t: (t[0], _side_rank.get(t[1], 2), t[1]),
     )
 
     per_segment: dict[tuple[int, str], _SegPair | None] = {}

--- a/src/toyo_battery/core/dqdv.py
+++ b/src/toyo_battery/core/dqdv.py
@@ -4,12 +4,14 @@ For each ``(cycle, side)`` segment in a ``chdis_df`` (produced by
 :func:`toyo_battery.core.chdis.get_chdis_df`), this module:
 
 1. Extracts the voltage and capacity series, drops NaN rows, sorts by V,
-   and removes duplicate V values.
+   and removes duplicate V values (``keep="last"`` to preserve CC-CV tail
+   capacity, which accumulates at ``V_max``/``V_min`` plateaus).
 2. Linearly interpolates Q onto a uniform V grid
    (``np.linspace(V.min(), V.max(), ipnum)`` with
    ``ipnum = max(int(inter_num * (V.max() - V.min())), 2)``).
-3. Applies :func:`scipy.signal.savgol_filter` with ``deriv=1`` to compute
-   ``dQ/dV`` on the resampled curve.
+3. Applies :func:`scipy.signal.savgol_filter` with ``deriv=1`` and
+   ``delta=dx`` to compute ``dQ/dV`` in physical units on the resampled
+   curve.
 
 Output shape: a wide DataFrame whose column MultiIndex mirrors ``chdis_df``
 (levels ``cycle``, ``side``, ``quantity``). The ``quantity`` level holds
@@ -18,14 +20,33 @@ Output shape: a wide DataFrame whose column MultiIndex mirrors ``chdis_df``
 ``RangeIndex`` shared across all segments; shorter segments are NaN-padded
 to the longest.
 
-Rewrite note (vs. legacy TOYO_Origin_2.01 L378 ``plot_dQdV_curve``): the
-original read the voltage bounds via ``chdis_df[cycle].at[1, "電圧"]`` and
-``chdis_df[cycle].at[len(...)-1, "電圧"]``. ``.at[1, ...]`` reads the
-*second* row, not the first, so the original implicitly skipped the first
-sample and was sensitive to whichever row landed at position 1 before
-sorting. This rewrite uses ``V.min()`` and ``V.max()`` after an explicit
-ascending sort with duplicate removal — deterministic, monotone, and works
-whether the source segment is a charge or a discharge.
+Numerical caveats:
+
+- The leading and trailing ``window_length // 2`` samples of each
+  ``dQ/dV`` column are edge-approximated (savgol ``mode="nearest"``) and
+  should be trimmed when precise slopes matter.
+- Discharge segments enter with V decreasing but Q still monotone
+  non-decreasing per the chdis invariant. After the ascending V sort, Q
+  becomes decreasing along the grid, so ``dQ/dV`` for discharge is
+  **negative** by construction. Callers plotting charge and discharge on
+  the same axis commonly take ``abs(dQ/dV)`` for a magnitude comparison;
+  the raw signed value is retained here so the direction of accumulation
+  is not lost.
+
+Rewrite notes (vs. legacy TOYO_Origin_2.01 ``plot_dQdV_curve`` L378-453):
+
+- v2.01 read the voltage bounds via ``chdis_df[cycle].at[1, "電圧"]`` and
+  ``chdis_df[cycle].at[len(...)-1, "電圧"]``. ``.at[1, ...]`` reads the
+  *second* row, not the first, so the original implicitly skipped the
+  first sample and was sensitive to whichever row landed at position 1
+  before sorting. This rewrite uses ``V.min()``/``V.max()`` after an
+  explicit ascending sort with duplicate removal — deterministic,
+  monotone, and works whether the source segment is charge or discharge.
+- v2.01's ``savgol_filter`` call (L423-429) omitted ``delta=``, so its
+  output was ``d(Q)/d(sample-index)`` rather than ``d(Q)/d(V)`` — the
+  legacy plots carried a sample-count-scaled axis labeled ``dQ/dV``.
+  This rewrite passes ``delta=dx`` so the output is in physical units
+  (mAh/g per V).
 """
 
 from __future__ import annotations
@@ -35,7 +56,6 @@ from typing import cast
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
-from scipy.interpolate import interp1d
 from scipy.signal import savgol_filter
 
 from toyo_battery.io.schema import JA_TO_EN, ColumnLang
@@ -66,6 +86,22 @@ def _empty_result() -> pd.DataFrame:
     return pd.DataFrame(columns=idx)
 
 
+def _validate_savgol_params(inter_num: int, window_length: int, polyorder: int) -> None:
+    """Validate Savitzky-Golay preconditions up-front for a helpful error.
+
+    scipy raises from deep inside ``savgol_filter`` otherwise, which is
+    harder to correlate with a caller's actual input.
+    """
+    if inter_num < 1:
+        raise ValueError(f"inter_num must be >= 1, got {inter_num}")
+    if window_length < 1:
+        raise ValueError(f"window_length must be >= 1, got {window_length}")
+    if polyorder < 0:
+        raise ValueError(f"polyorder must be >= 0, got {polyorder}")
+    if polyorder >= window_length:
+        raise ValueError(f"polyorder ({polyorder}) must be < window_length ({window_length})")
+
+
 def get_dqdv_df(
     chdis_df: pd.DataFrame,
     *,
@@ -88,12 +124,15 @@ def get_dqdv_df(
         is ``max(int(inter_num * (V.max() - V.min())), 2)`` per segment.
         Segments whose interpolated length is below ``window_length`` yield
         all-NaN columns (Savitzky-Golay requires at least ``window_length``
-        samples).
+        samples). Must be ``>= 1``.
     window_length
-        Savitzky-Golay window length (must be odd and > ``polyorder``; the
-        caller is responsible for satisfying the scipy constraints).
+        Savitzky-Golay window length. Must be a positive integer strictly
+        greater than ``polyorder``. scipy ``< 1.13`` additionally requires
+        an odd value; 1.13+ accepts even. The module does not enforce
+        odd-ness to stay compatible with modern scipy.
     polyorder
-        Savitzky-Golay polynomial order.
+        Savitzky-Golay polynomial order. Must be ``>= 0`` and strictly
+        less than ``window_length``.
     column_lang
         Language of the ``quantity`` level on both input and output. When
         ``"ja"`` the output uses ``{"電圧", "dQ/dV"}``; when ``"en"`` it
@@ -106,17 +145,40 @@ def get_dqdv_df(
         Row axis: ``RangeIndex`` sized to the longest segment; shorter
         segments are NaN-padded.
 
+    Raises
+    ------
+    ValueError
+        If ``inter_num`` / ``window_length`` / ``polyorder`` violate the
+        Savitzky-Golay preconditions above.
+    KeyError
+        If ``chdis_df.columns`` is not a 3-level ``(cycle, side, quantity)``
+        MultiIndex, or if the ``quantity`` level is missing the voltage /
+        capacity labels for the requested ``column_lang``.
+
     Notes
     -----
     Non-default ``inter_num`` / ``window_length`` / ``polyorder`` must be
     passed by calling this function directly —
     :attr:`toyo_battery.core.cell.Cell.dqdv_df` uses the defaults.
     """
+    _validate_savgol_params(inter_num, window_length, polyorder)
+
     cols = _resolve_cols(column_lang)
     v_name, q_name, dqdv_name = cols["voltage"], cols["capacity"], cols["dqdv"]
 
     if chdis_df.empty or chdis_df.columns.empty:
         return _empty_result()
+
+    # Structural check: the 3-level MultiIndex is part of the chdis contract.
+    # Anything else is a caller bug; raise with the same framing as the
+    # missing-quantity error below so both failure modes are catchable
+    # under ``except KeyError``.
+    if not isinstance(chdis_df.columns, pd.MultiIndex) or chdis_df.columns.nlevels != 3:
+        raise KeyError(
+            "chdis_df.columns must be a 3-level MultiIndex "
+            "(cycle, side, quantity); "
+            f"got {chdis_df.columns!r}"
+        )
 
     quantity_values = set(chdis_df.columns.get_level_values("quantity"))
     missing_quantities = sorted({v_name, q_name} - quantity_values)
@@ -172,12 +234,15 @@ def get_dqdv_df(
 
         x_latent: NDArray[np.float64] = np.linspace(v_min, v_max, ipnum)
         dx = float(x_latent[1] - x_latent[0])
-        ip = interp1d(v_arr, q_arr, fill_value="extrapolate")
-        q_latent: NDArray[np.float64] = np.asarray(ip(x_latent), dtype=float)
-        # ``delta=dx`` makes savgol return d(Q)/d(V) in the physical units of
-        # the input (mAh/g per V), not d(Q)/d(sample-index). v2.01 omitted
-        # this and the legacy plots showed a slope-scaled axis; the rewrite
-        # fixes it.
+        # ``np.interp`` replaces legacy ``scipy.interpolate.interp1d`` for
+        # 1-D linear interpolation (scipy flags interp1d as legacy in 1.10+).
+        # Preconditions: ``v_arr`` strictly increasing (guaranteed by the
+        # sort + drop_duplicates above) and ``x_latent`` within
+        # ``[v_min, v_max]`` (linspace over the same bounds). Under these
+        # conditions ``np.interp``'s default clamping is equivalent to
+        # ``interp1d(..., fill_value="extrapolate")`` — no extrapolation
+        # actually occurs.
+        q_latent: NDArray[np.float64] = np.interp(x_latent, v_arr, q_arr)
         dy: NDArray[np.float64] = np.asarray(
             savgol_filter(
                 q_latent,
@@ -195,36 +260,24 @@ def get_dqdv_df(
         (len(pair[0]) for pair in per_segment.values() if pair is not None),
         default=0,
     )
-    if longest == 0:
-        # All segments degenerate — still return a frame whose columns mirror
-        # the input so downstream consumers can detect the empty case without
-        # KeyErrors. Rows are empty.
-        empty_data: dict[tuple[int, str, str], NDArray[np.float64]] = {}
-        for cycle, side in cycle_side_pairs:
-            empty_data[(cycle, side, v_name)] = np.array([], dtype=float)
-            empty_data[(cycle, side, dqdv_name)] = np.array([], dtype=float)
-        out = pd.DataFrame(empty_data)
-        out.columns = pd.MultiIndex.from_tuples(
-            cast("list[tuple[int, str, str]]", list(out.columns)),
-            names=["cycle", "side", "quantity"],
-        )
-        return out
-
-    columns: dict[tuple[int, str, str], NDArray[np.float64]] = {}
-    for cycle, side in cycle_side_pairs:
-        pair = per_segment[(cycle, side)]
-        v_col: NDArray[np.float64] = np.full(longest, np.nan, dtype=float)
-        d_col: NDArray[np.float64] = np.full(longest, np.nan, dtype=float)
-        if pair is not None:
-            x_latent, dy = pair
-            v_col[: len(x_latent)] = x_latent
-            d_col[: len(dy)] = dy
-        columns[(cycle, side, v_name)] = v_col
-        columns[(cycle, side, dqdv_name)] = d_col
-
-    out = pd.DataFrame(columns)
-    out.columns = pd.MultiIndex.from_tuples(
-        cast("list[tuple[int, str, str]]", list(out.columns)),
+    # The output MultiIndex is the same shape whether rows are populated
+    # or not — build it once and hand it to the DataFrame constructor.
+    out_cols = pd.MultiIndex.from_tuples(
+        [(c, s, q) for (c, s) in cycle_side_pairs for q in (v_name, dqdv_name)],
         names=["cycle", "side", "quantity"],
     )
-    return out
+    if longest == 0:
+        # All segments degenerate — return a 0-row frame with the expected
+        # columns so downstream consumers can detect the empty case without
+        # KeyErrors.
+        return pd.DataFrame(columns=out_cols, dtype=float)
+
+    data_matrix: NDArray[np.float64] = np.full((longest, len(out_cols)), np.nan, dtype=float)
+    for col_idx, (c, s, q) in enumerate(out_cols):
+        pair = per_segment[(int(c), str(s))]
+        if pair is None:
+            continue
+        x_latent_, dy_ = pair
+        n = len(x_latent_)
+        data_matrix[:n, col_idx] = x_latent_ if q == v_name else dy_
+    return pd.DataFrame(data_matrix, columns=out_cols)

--- a/src/toyo_battery/core/dqdv.py
+++ b/src/toyo_battery/core/dqdv.py
@@ -118,6 +118,14 @@ def get_dqdv_df(
     if chdis_df.empty or chdis_df.columns.empty:
         return _empty_result()
 
+    quantity_values = set(chdis_df.columns.get_level_values("quantity"))
+    missing_quantities = sorted({v_name, q_name} - quantity_values)
+    if missing_quantities:
+        raise KeyError(
+            f"input missing required quantity level values {missing_quantities} "
+            f"for column_lang={column_lang!r}; got quantities={sorted(quantity_values)}"
+        )
+
     cols_tuples = cast("list[tuple[int, str, str]]", list(chdis_df.columns))
     cycle_side_pairs: list[tuple[int, str]] = sorted(
         {(int(c), str(s)) for c, s, _q in cols_tuples},
@@ -138,9 +146,15 @@ def get_dqdv_df(
             per_segment[(cycle, side)] = None
             continue
 
+        # ``keep="last"``: chdis guarantees Q is monotone non-decreasing within
+        # each segment. After a stable sort by V, the last row among duplicate
+        # V values preserves the highest Q — which is essential for CC-CV
+        # plateaus where V saturates at V_max (charge) or V_min (discharge)
+        # while Q continues to grow. ``keep="first"`` would silently discard
+        # the CV tail capacity.
         frame = (
             frame.sort_values("v", kind="mergesort")
-            .drop_duplicates(subset="v", keep="first")
+            .drop_duplicates(subset="v", keep="last")
             .reset_index(drop=True)
         )
         if len(frame) < 2:

--- a/src/toyo_battery/core/dqdv.py
+++ b/src/toyo_battery/core/dqdv.py
@@ -210,12 +210,14 @@ def get_dqdv_df(
 
     per_segment: dict[tuple[int, str], _SegPair | None] = {}
     for cycle, side in cycle_side_pairs:
-        try:
-            v_series = chdis_df[(cycle, side, v_name)]
-            q_series = chdis_df[(cycle, side, q_name)]
-        except KeyError:
-            per_segment[(cycle, side)] = None
-            continue
+        # Both quantities are guaranteed to exist: cycle_side_pairs is
+        # derived from chdis_df.columns, and the top-level missing_quantities
+        # check already verified v_name and q_name are present in the
+        # quantity level. A KeyError here would indicate a chdis contract
+        # violation — a per-(cycle,side) quantity asymmetry — which should
+        # propagate loudly rather than be silently masked.
+        v_series = chdis_df[(cycle, side, v_name)]
+        q_series = chdis_df[(cycle, side, q_name)]
 
         frame = pd.concat({"v": v_series, "q": q_series}, axis=1).dropna()
         if frame.empty:

--- a/tests/test_dqdv.py
+++ b/tests/test_dqdv.py
@@ -113,12 +113,94 @@ def test_wrong_column_lang_raises_with_context() -> None:
 
     Regression test for a prior bug where the per-segment ``try/except`` in
     ``get_dqdv_df`` silently swallowed the mismatch and returned an all-NaN
-    frame — turning a configuration bug into silent data loss.
+    frame — turning a configuration bug into silent data loss. The match
+    pattern targets the structural phrase ``missing required quantity``
+    rather than the f-string formatting so rewording does not break it.
     """
     raw = _linear_chdis_ch_only(lang="ja")
     chdis = get_chdis_df(raw, column_lang="ja")  # quantity level = {電圧, 電気量}
-    with pytest.raises(KeyError, match="column_lang='en'"):
+    with pytest.raises(KeyError, match="missing required quantity"):
         get_dqdv_df(chdis, column_lang="en")
+
+
+def test_non_multiindex_columns_raises_structural_keyerror() -> None:
+    """A chdis_df with flat (non-MultiIndex) columns must raise a helpful
+    ``KeyError`` naming the structural violation.
+    """
+    bogus = pd.DataFrame({"voltage": [3.0, 3.5, 4.0], "capacity": [0.0, 50.0, 100.0]})
+    with pytest.raises(KeyError, match="3-level MultiIndex"):
+        get_dqdv_df(bogus)
+
+
+def test_polyorder_not_less_than_window_length_raises() -> None:
+    """``polyorder >= window_length`` surfaces a clear ``ValueError`` before
+    the per-segment loop, not from deep inside scipy.
+    """
+    raw = _linear_chdis_ch_only()
+    chdis = get_chdis_df(raw)
+    with pytest.raises(ValueError, match="polyorder"):
+        get_dqdv_df(chdis, window_length=5, polyorder=5)
+
+
+def test_invalid_inter_num_raises() -> None:
+    """``inter_num < 1`` is a caller bug → ``ValueError`` at entry."""
+    raw = _linear_chdis_ch_only()
+    chdis = get_chdis_df(raw)
+    with pytest.raises(ValueError, match="inter_num"):
+        get_dqdv_df(chdis, inter_num=0)
+
+
+def test_discharge_segment_yields_negative_dqdv() -> None:
+    """Discharge: V decreases while Q still accumulates (chdis invariant).
+
+    After the ascending-V sort inside :func:`get_dqdv_df`, Q becomes
+    decreasing along the grid, so savgol returns negative ``dQ/dV``. This
+    test pins that sign convention so a future ``abs()`` or sign-flip is a
+    visible, deliberate change.
+    """
+    n = 200
+    v_ch = np.linspace(3.0, 4.2, n)
+    q_ch = 400.0 * (v_ch - 3.0)
+    v_dis = np.linspace(4.2, 3.0, n)
+    q_dis = 400.0 * (4.2 - v_dis)
+    rows = [(1, "充電", float(vi), float(qi)) for vi, qi in zip(v_ch, q_ch)]
+    rows += [(1, "放電", float(vi), float(qi)) for vi, qi in zip(v_dis, q_dis)]
+    raw = pd.DataFrame(rows, columns=["サイクル", "状態", "電圧", "電気量"])
+    chdis = get_chdis_df(raw)
+
+    out = get_dqdv_df(chdis)
+    dis_interior = out[(1, "dis", "dQ/dV")].dropna().iloc[5:-5]
+    assert float(np.median(dis_interior)) < 0.0, (
+        "discharge dQ/dV expected negative (sign convention); "
+        f"got median={float(np.median(dis_interior)):.2f}"
+    )
+
+
+def test_in_memory_cell_dqdv_exercises_interpolation_path() -> None:
+    """End-to-end: a Cell built from a wide-V-range in-memory frame yields
+    populated ``dqdv_df`` (not all-NaN), unlike the narrow-range
+    ``make_cell_dir("renzoku")`` fixture.
+    """
+    from toyo_battery.core.cell import Cell  # local import to scope the fixture
+
+    n = 200
+    v_ch = np.linspace(3.0, 4.2, n)
+    q_ch = 400.0 * (v_ch - 3.0)
+    v_dis = np.linspace(4.2, 3.0, n)
+    q_dis = 400.0 * (4.2 - v_dis)
+    rows = [(1, "1", "充電", float(vi), float(qi)) for vi, qi in zip(v_ch, q_ch)]
+    rows += [(1, "1", "放電", float(vi), float(qi)) for vi, qi in zip(v_dis, q_dis)]
+    raw = pd.DataFrame(rows, columns=["サイクル", "モード", "状態", "電圧", "電気量"])
+
+    cell = Cell(name="synthetic", mass_g=0.001, raw_df=raw)
+    dqdv = cell.dqdv_df
+    # Wide V range (1.2 V) → ipnum = 120, well above window_length = 11.
+    # Real populated rows on both sides.
+    assert dqdv[(1, "ch", "dQ/dV")].notna().any()
+    assert dqdv[(1, "dis", "dQ/dV")].notna().any()
+    # Linear ramp → median dQ/dV near the analytical slope.
+    ch_interior = dqdv[(1, "ch", "dQ/dV")].dropna().iloc[5:-5]
+    np.testing.assert_allclose(float(np.median(ch_interior)), 400.0, rtol=0.05)
 
 
 def test_cc_cv_plateau_preserves_tail_capacity() -> None:

--- a/tests/test_dqdv.py
+++ b/tests/test_dqdv.py
@@ -1,0 +1,125 @@
+"""Tests for :mod:`toyo_battery.core.dqdv`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+
+from toyo_battery.core.cell import Cell
+from toyo_battery.core.chdis import get_chdis_df
+from toyo_battery.core.dqdv import get_dqdv_df
+
+
+def _linear_chdis_ch_only(
+    *,
+    slope: float = 500.0,
+    v_lo: float = 3.0,
+    v_hi: float = 4.2,
+    n_points: int = 200,
+    lang: str = "ja",
+) -> pd.DataFrame:
+    """Build a ``chdis_df`` with a single cycle of linear Q = slope*(V - v_lo).
+
+    The 2-point reversal filter in chdis is a no-op here because Q is
+    monotone non-decreasing along the synthetic ramp.
+    """
+    v = np.linspace(v_lo, v_hi, n_points)
+    q = slope * (v - v_lo)
+    rows = [(1, "充電", float(vi), float(qi)) for vi, qi in zip(v, q)]
+    if lang == "ja":
+        columns = ["サイクル", "状態", "電圧", "電気量"]
+    else:
+        columns = ["cycle", "state", "voltage", "capacity"]
+        # Even with EN column frame, chdis expects JA state strings.
+    return pd.DataFrame(rows, columns=columns)
+
+
+def test_linear_ramp_yields_constant_derivative() -> None:
+    """Q = slope * (V - V_lo) → dQ/dV ≈ slope everywhere (within savgol bounds)."""
+    slope = 500.0
+    raw = _linear_chdis_ch_only(slope=slope, v_lo=3.0, v_hi=4.2, n_points=200)
+    chdis = get_chdis_df(raw)
+
+    out = get_dqdv_df(chdis)
+    dqdv_series = out[(1, "ch", "dQ/dV")].dropna()
+    # Interior samples (trim edges where savgol_filter mode="nearest"
+    # mildly distorts) should recover the analytical slope.
+    interior = dqdv_series.iloc[5:-5]
+    np.testing.assert_allclose(np.median(interior), slope, rtol=0.05)
+
+
+def test_segment_with_single_distinct_voltage_emits_nan_column() -> None:
+    """A segment with <2 distinct V values must yield NaN columns (no exception)."""
+    # Cycle 1 ch has 1 row only → <2 distinct V. Cycle 1 dis is a well-formed
+    # ramp so the function has something to produce on the other side.
+    v = np.linspace(3.0, 4.0, 200)
+    q = 400.0 * (v - 3.0)
+    rows: list[tuple[int, str, float, float]] = [(1, "充電", 3.5, 0.0)]
+    rows.extend((1, "放電", float(vi), float(qi)) for vi, qi in zip(v, q))
+    raw = pd.DataFrame(rows, columns=["サイクル", "状態", "電圧", "電気量"])
+    chdis = get_chdis_df(raw)
+
+    out = get_dqdv_df(chdis)
+    assert (1, "ch", "電圧") in out.columns
+    assert (1, "ch", "dQ/dV") in out.columns
+    # ch has a single sample → chdis keeps it (no reversal to filter), but
+    # after dedup there is only 1 distinct V → the whole column is NaN.
+    assert out[(1, "ch", "電圧")].isna().all()
+    assert out[(1, "ch", "dQ/dV")].isna().all()
+    # dis retains real values.
+    assert out[(1, "dis", "dQ/dV")].notna().any()
+
+
+def test_column_multiindex_level_names() -> None:
+    raw = _linear_chdis_ch_only()
+    chdis = get_chdis_df(raw)
+    out = get_dqdv_df(chdis)
+    assert list(out.columns.names) == ["cycle", "side", "quantity"]
+
+
+def test_inter_num_controls_row_axis_length() -> None:
+    """With ``inter_num=50`` and a 1.2 V range, ipnum ~= 60 per segment; pinning
+    the observable sanity bounds (>= 2, <= 50 when V-range < 1.0)."""
+    # V range 3.8-4.2 → 0.4 V window. inter_num * range = 50 * 0.4 = 20.
+    raw = _linear_chdis_ch_only(v_lo=3.8, v_hi=4.2, n_points=100)
+    chdis = get_chdis_df(raw)
+    out = get_dqdv_df(chdis, inter_num=50, window_length=11, polyorder=2)
+
+    # Row count is the global max across segments. For a single ch segment
+    # with V range 0.4 and inter_num=50, ipnum = 20 so row axis has exactly 20.
+    assert 2 <= len(out) <= 50
+    non_nan = out[(1, "ch", "電圧")].dropna()
+    assert 2 <= len(non_nan) <= 50
+
+
+def test_column_lang_en_uses_english_quantity_names() -> None:
+    raw = _linear_chdis_ch_only(lang="en")
+    chdis = get_chdis_df(raw, column_lang="en")
+    out = get_dqdv_df(chdis, column_lang="en")
+    qset = set(out.columns.get_level_values("quantity"))
+    assert qset == {"voltage", "dq_dv"}
+    # And the JA names are absent.
+    assert "電圧" not in qset
+    assert "dQ/dV" not in qset
+
+
+def test_cell_dqdv_df_is_cached(make_cell_dir: Callable[..., Path]) -> None:
+    """Cell.dqdv_df is cached_property — second access returns the same object."""
+    cell_dir = make_cell_dir("renzoku")
+    cell = Cell.from_dir(cell_dir)
+
+    first = cell.dqdv_df
+    second = cell.dqdv_df
+    assert first is second
+    # The synthetic renzoku fixture has a very small voltage span (0.1 V for
+    # ch, 0.2 V for dis) so ipnum=int(100*0.1)=10 < window_length=11 → both
+    # segments produce NaN columns by design. The shape + column layout must
+    # still be correct.
+    assert list(first.columns.names) == ["cycle", "side", "quantity"]
+    assert (1, "ch", "電圧") in first.columns
+    assert (1, "ch", "dQ/dV") in first.columns
+    assert (1, "dis", "電圧") in first.columns
+    assert (1, "dis", "dQ/dV") in first.columns

--- a/tests/test_dqdv.py
+++ b/tests/test_dqdv.py
@@ -82,18 +82,18 @@ def test_column_multiindex_level_names() -> None:
 
 
 def test_inter_num_controls_row_axis_length() -> None:
-    """With ``inter_num=50`` and a 1.2 V range, ipnum ~= 60 per segment; pinning
-    the observable sanity bounds (>= 2, <= 50 when V-range < 1.0)."""
+    """With ``inter_num=50`` and a 0.4 V range, ``ipnum = int(50 * 0.4) = 20``
+    per segment — pinned exactly so a regression in the ``ipnum`` formula is
+    loud rather than silent.
+    """
     # V range 3.8-4.2 → 0.4 V window. inter_num * range = 50 * 0.4 = 20.
     raw = _linear_chdis_ch_only(v_lo=3.8, v_hi=4.2, n_points=100)
     chdis = get_chdis_df(raw)
     out = get_dqdv_df(chdis, inter_num=50, window_length=11, polyorder=2)
 
-    # Row count is the global max across segments. For a single ch segment
-    # with V range 0.4 and inter_num=50, ipnum = 20 so row axis has exactly 20.
-    assert 2 <= len(out) <= 50
-    non_nan = out[(1, "ch", "電圧")].dropna()
-    assert 2 <= len(non_nan) <= 50
+    # Single ch segment: row axis length equals ipnum exactly.
+    assert len(out) == 20
+    assert out[(1, "ch", "電圧")].notna().sum() == 20
 
 
 def test_column_lang_en_uses_english_quantity_names() -> None:
@@ -105,6 +105,26 @@ def test_column_lang_en_uses_english_quantity_names() -> None:
     # And the JA names are absent.
     assert "電圧" not in qset
     assert "dQ/dV" not in qset
+
+
+def test_even_window_length_raises() -> None:
+    """Even ``window_length`` is rejected up-front (scipy < 1.13 requires odd;
+    enforcing uniformly keeps behaviour stable across the supported range).
+    """
+    raw = _linear_chdis_ch_only()
+    chdis = get_chdis_df(raw)
+    with pytest.raises(ValueError, match="window_length must be odd"):
+        get_dqdv_df(chdis, window_length=10, polyorder=2)
+
+
+def test_truly_empty_input_returns_empty_result() -> None:
+    """``pd.DataFrame()`` with no rows and no columns returns the canonical
+    empty frame (3-level MultiIndex columns, 0 rows) — the short-circuit
+    path used by :func:`chdis._empty_result`.
+    """
+    out = get_dqdv_df(pd.DataFrame())
+    assert out.empty
+    assert list(out.columns.names) == ["cycle", "side", "quantity"]
 
 
 def test_wrong_column_lang_raises_with_context() -> None:
@@ -181,8 +201,6 @@ def test_in_memory_cell_dqdv_exercises_interpolation_path() -> None:
     populated ``dqdv_df`` (not all-NaN), unlike the narrow-range
     ``make_cell_dir("renzoku")`` fixture.
     """
-    from toyo_battery.core.cell import Cell  # local import to scope the fixture
-
     n = 200
     v_ch = np.linspace(3.0, 4.2, n)
     q_ch = 400.0 * (v_ch - 3.0)

--- a/tests/test_dqdv.py
+++ b/tests/test_dqdv.py
@@ -7,6 +7,7 @@ from typing import Callable
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from toyo_battery.core.cell import Cell
 from toyo_battery.core.chdis import get_chdis_df
@@ -104,6 +105,60 @@ def test_column_lang_en_uses_english_quantity_names() -> None:
     # And the JA names are absent.
     assert "電圧" not in qset
     assert "dQ/dV" not in qset
+
+
+def test_wrong_column_lang_raises_with_context() -> None:
+    """Passing JA-labeled quantities with ``column_lang='en'`` must raise a
+    helpful ``KeyError`` (mirrors :func:`chdis.get_chdis_df` behavior).
+
+    Regression test for a prior bug where the per-segment ``try/except`` in
+    ``get_dqdv_df`` silently swallowed the mismatch and returned an all-NaN
+    frame — turning a configuration bug into silent data loss.
+    """
+    raw = _linear_chdis_ch_only(lang="ja")
+    chdis = get_chdis_df(raw, column_lang="ja")  # quantity level = {電圧, 電気量}
+    with pytest.raises(KeyError, match="column_lang='en'"):
+        get_dqdv_df(chdis, column_lang="en")
+
+
+def test_cc_cv_plateau_preserves_tail_capacity() -> None:
+    """CC-CV charging: V rises to V_max, then plateaus while Q keeps growing.
+
+    ``drop_duplicates(keep="last")`` must preserve the tail Q at V_max. With
+    ``keep="first"`` the CV tail would be silently dropped and the Q value at
+    V_max would be the start of the plateau, not the end.
+    """
+    # CC segment: V rises 3.0 → 4.2 linearly, Q rises 0 → 480.
+    # CV segment: V pinned at 4.2, Q continues 480 → 530 (tail capacity).
+    n_cc = 200
+    v_cc = np.linspace(3.0, 4.2, n_cc)
+    q_cc = 400.0 * (v_cc - 3.0)  # slope 400, ends at Q=480
+    n_cv = 50
+    v_cv = np.full(n_cv, 4.2)
+    q_cv = np.linspace(480.0, 530.0, n_cv)
+
+    rows: list[tuple[int, str, float, float]] = []
+    rows.extend((1, "充電", float(vi), float(qi)) for vi, qi in zip(v_cc, q_cc))
+    rows.extend((1, "充電", float(vi), float(qi)) for vi, qi in zip(v_cv, q_cv))
+    raw = pd.DataFrame(rows, columns=["サイクル", "状態", "電圧", "電気量"])
+    chdis = get_chdis_df(raw)
+
+    out = get_dqdv_df(chdis, inter_num=100, window_length=11, polyorder=2)
+    # The interpolator sees the real Q(V=4.2) = 530, so the dQ/dV grid
+    # evaluated at V=4.2 must correspond to a Q-level near 530, not 480.
+    # We verify this indirectly: the total integrated dQ from V_min to V_max,
+    # using trapezoidal rule on the (V, dQ/dV) grid, should approximate the
+    # full Q excursion 0 → 530 (not the CC-only 0 → 480).
+    v_grid = out[(1, "ch", "電圧")].dropna().to_numpy()
+    dqdv_grid = out[(1, "ch", "dQ/dV")].dropna().to_numpy()
+    # np.trapezoid replaces np.trapz (removed in numpy 2.0); fall back for 1.x.
+    trap = getattr(np, "trapezoid", None) or np.trapz  # type: ignore[attr-defined]
+    integrated_q = float(trap(dqdv_grid, v_grid))
+    # Without the fix this would be ≈ 480 (CC only). With the fix, the
+    # interpolator reaches the CV tail and the integral approaches ≈ 530.
+    assert integrated_q > 500.0, (
+        f"CV tail capacity was dropped: integrated Q = {integrated_q:.1f} mAh, expected >500"
+    )
 
 
 def test_cell_dqdv_df_is_cached(make_cell_dir: Callable[..., Path]) -> None:

--- a/tests/test_dqdv.py
+++ b/tests/test_dqdv.py
@@ -41,14 +41,17 @@ def _linear_chdis_ch_only(
 def test_linear_ramp_yields_constant_derivative() -> None:
     """Q = slope * (V - V_lo) → dQ/dV ≈ slope everywhere (within savgol bounds)."""
     slope = 500.0
+    window_length = 11
     raw = _linear_chdis_ch_only(slope=slope, v_lo=3.0, v_hi=4.2, n_points=200)
     chdis = get_chdis_df(raw)
 
-    out = get_dqdv_df(chdis)
+    out = get_dqdv_df(chdis, window_length=window_length)
     dqdv_series = out[(1, "ch", "dQ/dV")].dropna()
-    # Interior samples (trim edges where savgol_filter mode="nearest"
-    # mildly distorts) should recover the analytical slope.
-    interior = dqdv_series.iloc[5:-5]
+    # Trim the savgol edge-approximated samples (mode="nearest" biases the
+    # first/last half-window). Computing ``half`` from ``window_length``
+    # keeps the trim correct if the default window changes.
+    half = window_length // 2
+    interior = dqdv_series.iloc[half:-half]
     np.testing.assert_allclose(np.median(interior), slope, rtol=0.05)
 
 


### PR DESCRIPTION
## Summary

Adds `get_dqdv_df(chdis_df, *, inter_num=100, window_length=11, polyorder=2, column_lang='ja')` and the corresponding `Cell.dqdv_df` cached_property. Per `(cycle, side)` segment in the chdis MultiIndex frame, the function:

1. Extracts V/Q, drops NaN, sorts by V ascending, drops duplicate V (keep first)
2. `ipnum = max(int(inter_num * (V.max() - V.min())), 2)`, builds `x_latent = np.linspace(V.min(), V.max(), ipnum)`
3. `scipy.interpolate.interp1d(V, Q, fill_value='extrapolate')` → `Q_latent`
4. `scipy.signal.savgol_filter(Q_latent, window_length, polyorder, deriv=1, delta=dx, mode='nearest')` → `dQ/dV`
5. Emits `(cycle, side, 電圧|voltage)` and `(cycle, side, dQ/dV|dq_dv)` columns; shorter segments NaN-padded to the global longest.

Edge cases handled: <2 distinct V points, `ipnum < window_length`, empty chdis_df, `column_lang='en'`.

## Deviations from v2.01

Documented in the module docstring and commit body:

1. **V bounds** — v2.01 used `chdis_df[cycle].at[1, '電圧']` / `at[len(...)-1, '電圧']`, which reads rows *1* and *len-1* (0-based `.at` is label-based — and with a default RangeIndex this reads the second row). This rewrite uses `V.min()`/`V.max()` after explicit ascending sort + dedup: deterministic for both charge and discharge segments.
2. **savgol delta** — v2.01 omitted `delta=` on `savgol_filter`, so its output was `d(Q)/d(sample-index)` rather than `d(Q)/d(V)`. This rewrite passes `delta=(v_max - v_min)/(ipnum - 1)`, so `dQ/dV` is returned in physical units (mAh/g per V). The linear-ramp test pins this — it asserts the recovered median slope matches the analytical `Q = 500·(V - V_lo)` slope within 5% relative tolerance.

Per CLAUDE.md \"rewrite, not bug-for-bug port\".

## Test plan

- [x] `uv run pytest tests/test_dqdv.py -v` — 6 passed
  - `test_linear_ramp_yields_constant_derivative` — 500 mAh/g/V linear ramp → median dQ/dV within 5% of analytical slope
  - `test_segment_with_single_distinct_voltage_emits_nan_column` — ch has 1 row, dis has 200 rows → ch column is NaN, dis is populated, no exception
  - `test_column_multiindex_level_names` — `['cycle', 'side', 'quantity']`
  - `test_inter_num_controls_row_axis_length` — `inter_num=50`, V-range 0.4 → row axis length within `[2, 50]`
  - `test_column_lang_en_uses_english_quantity_names` — `{'voltage', 'dq_dv'}`
  - `test_cell_dqdv_df_is_cached` — `cell.dqdv_df is cell.dqdv_df`, correct MultiIndex, works on renzoku fixture
- [x] `uv run pytest tests/ -x` — 58 passed (16 chdis + 6 dqdv + 32 reader + 4 smoke)
- [x] `uv run mypy` — no issues
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)