### PR TITLE
feat(core): stats — stat_table per-cell summary table

### DIFF
--- a/src/toyo_battery/core/stats.py
+++ b/src/toyo_battery/core/stats.py
@@ -1,1 +1,362 @@
-"""Summary statistics (stat_table). P1 scope — scaffold only."""
+"""Per-cell summary statistics (``stat_table``).
+
+Aggregates a list of :class:`toyo_battery.core.cell.Cell` objects into a
+single wide summary table — one row per cell, with a deterministic set of
+capacity / efficiency / retention columns keyed off a caller-supplied
+``target_cycles``. This is the table that downstream users typically
+export as CSV or feed into a plotting pipeline.
+
+Output columns (all float64, English-fixed regardless of each cell's
+``column_lang``):
+
+* ``Q_dis_max`` — ``max(cap_df["q_dis"])`` over all cycles for that cell.
+* ``cycle_at_{pct}pct`` — first cycle at which ``q_dis`` dips below
+  ``retention_threshold * q_dis[1]``. ``NaN`` if the fade threshold is
+  never crossed, or if ``q_dis[1]`` is missing / zero. The ``{pct}``
+  suffix is derived from the threshold: ``retention_threshold=0.80``
+  yields ``cycle_at_80pct``.
+* For each ``n`` in ``target_cycles`` (in caller-given order):
+
+  - ``Q_dis@{n}`` — discharge capacity at cycle ``n`` (NaN if missing).
+  - ``CE@{n}`` — Coulombic efficiency at cycle ``n`` (NaN if missing).
+  - ``V_mean_dis@{n}`` — energy-weighted mean discharge voltage at cycle
+    ``n``: ``(∫V dQ) / q_dis[n]`` where the integral runs over the
+    discharge segment's ``(V, Q)`` curve.
+  - ``EE@{n}`` — energy efficiency in percent:
+    ``100 * ∫V dQ_dis / ∫V dQ_ch``. NaN if either integral is NaN or if
+    the charge-side integral is zero.
+  - ``retention@{n}`` — ``100 * q_dis[n] / q_dis[1]`` in percent. Exactly
+    ``100.0`` for ``n == 1`` when ``q_dis[1]`` is non-NaN. NaN when
+    ``q_dis[1]`` or ``q_dis[n]`` is missing / zero-denominator.
+  - ``CE_mean_1to{n}`` — mean of ``cap_df.loc[1:n, "ce"]`` skipping NaN.
+    NaN if cycle 1 is absent or the sub-range contains no finite values.
+
+Integration detail: each per-segment ``∫V dQ`` uses Q as the integration
+variable (the :mod:`chdis` contract guarantees Q is monotone non-decreasing
+within a segment). After sorting rows by Q ascending and dropping duplicate
+Q values (``keep="last"``, same convention as :mod:`dqdv` for CC-CV tail
+preservation), the integral is evaluated by:
+
+- :func:`scipy.integrate.simpson` when ``len >= 3``
+- :func:`scipy.integrate.trapezoid` when ``len == 2``
+- ``NaN`` otherwise
+
+The deprecated ``scipy.integrate.simps`` is intentionally not used;
+``numpy.trapz`` was removed in NumPy 2.0 and is likewise avoided in favour
+of :func:`scipy.integrate.trapezoid`.
+
+Rewrite note (vs. legacy TOYO_Origin_2.01 ``stat_table`` L579-656): v2.01
+used V as the integration variable with ``simpson(V_lat, Q_lat)`` (argument
+order swapped — accidentally computing ``∫Q dV`` and relying on positional
+quirks in older scipy), then divided by capacity to recover a mean voltage.
+It also read ``chdis_df[str(n)+"-dis"].at[1, "電圧"]`` (row 1, not 0) and
+wrapped the entire per-n computation in a bare ``except Exception``, masking
+structural bugs as silent data loss. This rewrite uses Q as the
+integration variable directly (so the value is ``∫V dQ`` without sign
+ambiguity), reads bounds after an explicit Q sort + duplicate drop, and
+propagates NaN for genuinely-missing data only — structural mismatches
+raise loudly from upstream (:mod:`chdis`, :mod:`capacity`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+from scipy.integrate import simpson, trapezoid
+
+from toyo_battery.io.schema import JA_TO_EN, ColumnLang
+
+if TYPE_CHECKING:
+    from toyo_battery.core.cell import Cell
+
+_JA_COLS: dict[str, str] = {
+    "voltage": "電圧",
+    "capacity": "電気量",
+}
+
+
+def _resolve_cols(column_lang: ColumnLang) -> dict[str, str]:
+    if column_lang == "ja":
+        return _JA_COLS
+    return {k: JA_TO_EN[v] for k, v in _JA_COLS.items()}
+
+
+def _build_column_order(target_cycles: Sequence[int], pct: int) -> list[str]:
+    """Canonical column order shared between the populated and empty paths."""
+    cols: list[str] = ["Q_dis_max", f"cycle_at_{pct}pct"]
+    for n in target_cycles:
+        cols.extend(
+            [
+                f"Q_dis@{n}",
+                f"CE@{n}",
+                f"V_mean_dis@{n}",
+                f"EE@{n}",
+                f"retention@{n}",
+                f"CE_mean_1to{n}",
+            ]
+        )
+    return cols
+
+
+def _empty_result(columns: list[str]) -> pd.DataFrame:
+    """Empty frame with the right columns / dtypes / index name."""
+    idx = pd.Index([], dtype="object", name="cell")
+    data = {c: pd.Series([], dtype="float64") for c in columns}
+    return pd.DataFrame(data, index=idx)
+
+
+def _integrate_v_dq(v_arr: NDArray[np.float64], q_arr: NDArray[np.float64]) -> float:
+    """Return ``∫V dQ`` over a single segment, using Q as the integration axis.
+
+    The :mod:`chdis` contract guarantees Q is monotone non-decreasing within
+    a segment, so a Q-ascending sort is a stable reorder. Duplicate Q values
+    (CC-CV plateaus accumulate at the same Q level? No — plateaus accumulate
+    at the same *voltage* level, so Q remains distinct; duplicates here
+    would come from tester-side point repeats) are dropped ``keep="last"``
+    to match the :mod:`dqdv` convention and keep the latest-recorded V for
+    any Q repeat.
+
+    Returns ``NaN`` for <2 finite points; trapezoidal for exactly 2;
+    Simpson's rule for 3+.
+    """
+    # Pair up, drop any NaN rows, and sort by Q ascending. A dedicated
+    # DataFrame round-trip keeps the sort + dedup logic one-liner-clean
+    # and mirrors the :mod:`dqdv` pattern.
+    frame = pd.DataFrame({"v": v_arr, "q": q_arr}).dropna()
+    if frame.empty:
+        return float("nan")
+    frame = (
+        frame.sort_values("q", kind="mergesort")
+        .drop_duplicates(subset="q", keep="last")
+        .reset_index(drop=True)
+    )
+    n = len(frame)
+    if n < 2:
+        return float("nan")
+    v: NDArray[np.float64] = frame["v"].to_numpy(dtype=float)
+    q: NDArray[np.float64] = frame["q"].to_numpy(dtype=float)
+    if n == 2:
+        return float(trapezoid(y=v, x=q))
+    # simpson() returns a numpy scalar; explicit float() cast pins the
+    # return contract for mypy under the scipy.* ignore_missing_imports
+    # override so callers see a plain float, not an ``Any``.
+    return float(simpson(y=v, x=q))
+
+
+def _segment_arrays(
+    chdis_df: pd.DataFrame,
+    cycle: int,
+    side: str,
+    v_name: str,
+    q_name: str,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
+    """Pull (V, Q) arrays for one ``(cycle, side)`` segment, or None if absent.
+
+    Returns ``None`` when the segment's columns are not present at all
+    (e.g. ``target_cycles`` references a cycle the cell never reached).
+    When the columns exist but hold only NaN, returns the raw arrays and
+    lets the integrator handle the degenerate case — keeps the "cycle
+    exists but reversal-filter wiped it" and "cycle doesn't exist" cases
+    distinguishable upstream if needed.
+    """
+    key_v = (cycle, side, v_name)
+    key_q = (cycle, side, q_name)
+    if key_v not in chdis_df.columns or key_q not in chdis_df.columns:
+        return None
+    v: NDArray[np.float64] = chdis_df[key_v].to_numpy(dtype=float)
+    q: NDArray[np.float64] = chdis_df[key_q].to_numpy(dtype=float)
+    return v, q
+
+
+def _safe_lookup(cap_df: pd.DataFrame, cycle: int, col: str) -> float:
+    """Return ``cap_df.loc[cycle, col]`` as float, or NaN if the row is absent."""
+    if cycle not in cap_df.index:
+        return float("nan")
+    val = cap_df.at[cycle, col]
+    return float("nan") if pd.isna(val) else float(val)
+
+
+def _cycle_at_threshold(
+    q_dis_series: pd.Series, q_dis_first: float, retention_threshold: float
+) -> float:
+    """First cycle where ``q_dis < retention_threshold * q_dis[1]``, else NaN.
+
+    ``q_dis_first`` is passed in (rather than re-derived) so callers that
+    already decided cycle 1 is unusable (missing / zero) can short-circuit
+    without a redundant lookup.
+    """
+    if not np.isfinite(q_dis_first) or q_dis_first == 0.0:
+        return float("nan")
+    threshold = retention_threshold * q_dis_first
+    fade_mask = q_dis_series < threshold
+    if not fade_mask.any():
+        return float("nan")
+    # idxmax on a boolean Series returns the label of the first True;
+    # safe here because we've confirmed at least one True exists.
+    return float(fade_mask.idxmax())
+
+
+def _ce_mean_1_to_n(cap_df: pd.DataFrame, n: int) -> float:
+    """``cap_df.loc[1:n, "ce"].mean(skipna=True)``, NaN-safe.
+
+    Returns NaN when cycle 1 is absent from the cap frame or when the
+    sliced sub-series contains no finite values (so downstream consumers
+    don't conflate "no data" with an artificial zero).
+    """
+    if 1 not in cap_df.index:
+        return float("nan")
+    # ``.loc[1:n]`` is label-inclusive for both bounds on a sorted int
+    # index; capacity guarantees the index is sorted int64 ascending.
+    sub = cap_df.loc[1:n, "ce"]
+    if sub.empty:
+        return float("nan")
+    mean = sub.mean(skipna=True)
+    return float("nan") if pd.isna(mean) else float(mean)
+
+
+def _per_cell_row(
+    cell: Cell,
+    target_cycles: Sequence[int],
+    retention_threshold: float,
+    pct: int,
+) -> dict[str, float]:
+    """Compute one row of the stat table for a single Cell."""
+    cap_df = cell.cap_df
+    chdis_df = cell.chdis_df
+    cols = _resolve_cols(cell.column_lang)
+    v_name, q_name = cols["voltage"], cols["capacity"]
+
+    # Q_dis_max: NaN-safe max over the column. An empty cap_df has an
+    # empty Series → .max() returns NaN (pandas convention), which is the
+    # behaviour we want for a cell whose chdis was fully wiped.
+    q_dis_max = (
+        float(cap_df["q_dis"].max())
+        if ("q_dis" in cap_df.columns and not cap_df["q_dis"].dropna().empty)
+        else float("nan")
+    )
+
+    # cycle-1 discharge capacity — the reference for retention + fade.
+    q_dis_first = _safe_lookup(cap_df, 1, "q_dis")
+
+    row: dict[str, float] = {
+        "Q_dis_max": q_dis_max,
+        f"cycle_at_{pct}pct": _cycle_at_threshold(
+            cap_df["q_dis"] if "q_dis" in cap_df.columns else pd.Series([], dtype=float),
+            q_dis_first,
+            retention_threshold,
+        ),
+    }
+
+    for n in target_cycles:
+        q_dis_n = _safe_lookup(cap_df, n, "q_dis")
+        ce_n = _safe_lookup(cap_df, n, "ce")
+
+        # V_mean_dis@n and EE@n need per-segment integrals.
+        v_mean_dis = float("nan")
+        ee = float("nan")
+        dis_pair = _segment_arrays(chdis_df, n, "dis", v_name, q_name)
+        ch_pair = _segment_arrays(chdis_df, n, "ch", v_name, q_name)
+
+        if dis_pair is not None:
+            int_v_dq_dis = _integrate_v_dq(*dis_pair)
+            if np.isfinite(int_v_dq_dis) and np.isfinite(q_dis_n) and q_dis_n != 0.0:
+                v_mean_dis = int_v_dq_dis / q_dis_n
+            if ch_pair is not None:
+                int_v_dq_ch = _integrate_v_dq(*ch_pair)
+                if np.isfinite(int_v_dq_dis) and np.isfinite(int_v_dq_ch) and int_v_dq_ch != 0.0:
+                    ee = 100.0 * int_v_dq_dis / int_v_dq_ch
+
+        # Retention@n: 100.0 exactly for n=1 iff q_dis[1] is finite; else
+        # 100 * q_dis[n] / q_dis[1] with NaN propagation through both
+        # numerator and denominator.
+        if not np.isfinite(q_dis_first) or q_dis_first == 0.0:
+            retention = float("nan")
+        elif n == 1:
+            retention = 100.0
+        elif np.isfinite(q_dis_n):
+            retention = 100.0 * q_dis_n / q_dis_first
+        else:
+            retention = float("nan")
+
+        row[f"Q_dis@{n}"] = q_dis_n
+        row[f"CE@{n}"] = ce_n
+        row[f"V_mean_dis@{n}"] = v_mean_dis
+        row[f"EE@{n}"] = ee
+        row[f"retention@{n}"] = retention
+        row[f"CE_mean_1to{n}"] = _ce_mean_1_to_n(cap_df, n)
+
+    return row
+
+
+def stat_table(
+    cells: list[Cell],
+    *,
+    target_cycles: Sequence[int] = (10, 50),
+    retention_threshold: float = 0.80,
+) -> pd.DataFrame:
+    """Summarize a list of cells into a per-cell wide statistics table.
+
+    Parameters
+    ----------
+    cells
+        List of :class:`toyo_battery.core.cell.Cell`. Each cell contributes
+        one row keyed by ``cell.name``. An empty list returns an empty
+        DataFrame with the correct column schema.
+    target_cycles
+        Cycle numbers at which to emit ``Q_dis@n`` / ``CE@n`` /
+        ``V_mean_dis@n`` / ``EE@n`` / ``retention@n`` / ``CE_mean_1to{n}``.
+        Order is preserved in the output columns so callers can pin column
+        layout by tuple order. Cycles beyond a cell's maximum produce NaN
+        for that cell, but the row itself is still emitted.
+    retention_threshold
+        Fade threshold as a fraction of ``q_dis[1]``. The derived column
+        name is ``f"cycle_at_{int(retention_threshold * 100)}pct"`` so a
+        threshold of ``0.80`` yields ``cycle_at_80pct`` (default) and
+        ``0.50`` yields ``cycle_at_50pct``. The value in that column is
+        the first cycle where ``q_dis`` dips below
+        ``retention_threshold * q_dis[1]``; NaN if the threshold is never
+        crossed or if ``q_dis[1]`` is unusable.
+
+    Returns
+    -------
+    DataFrame
+        Index ``cell`` (``cell.name`` strings). Columns in deterministic
+        order (see the module docstring). All values are float64; empty
+        positions are NaN.
+
+    Notes
+    -----
+    Integration over ``∫V dQ`` uses :func:`scipy.integrate.simpson` when
+    the segment has 3+ distinct-Q points, :func:`scipy.integrate.trapezoid`
+    for exactly 2, and yields NaN for fewer. The deprecated
+    ``scipy.integrate.simps`` is not used; ``numpy.trapz`` (removed in
+    NumPy 2.0) is avoided in favour of ``scipy.integrate.trapezoid``.
+    """
+    pct = int(retention_threshold * 100)
+    columns = _build_column_order(target_cycles, pct)
+
+    if not cells:
+        return _empty_result(columns)
+
+    # Seed the accumulator with the full column set so every row has the
+    # same key set and ``DataFrame.from_records`` doesn't need a manual
+    # reindex after the fact. The dict preserves insertion order (py 3.7+)
+    # so column order round-trips cleanly from ``_build_column_order``.
+    names: list[str] = []
+    rows: list[dict[str, float]] = []
+    for cell in cells:
+        names.append(cell.name)
+        rows.append(_per_cell_row(cell, target_cycles, retention_threshold, pct))
+
+    out = pd.DataFrame(rows, index=pd.Index(names, name="cell"))
+    # Enforce column order + float64 dtype end-to-end. ``reindex`` also
+    # guards against any runtime dict-mutation slip that silently dropped
+    # a key — an absent column would surface here as a silent all-NaN
+    # column, which is the correct degraded behaviour anyway. The explicit
+    # ``pd.DataFrame`` wrap pins the mypy return type against pandas-stubs
+    # occasionally inferring ``.astype`` as ``Any``.
+    return pd.DataFrame(out.reindex(columns=columns).astype("float64"))

--- a/src/toyo_battery/core/stats.py
+++ b/src/toyo_battery/core/stats.py
@@ -314,9 +314,12 @@ def stat_table(
         for that cell, but the row itself is still emitted.
     retention_threshold
         Fade threshold as a fraction of ``q_dis[1]``. The derived column
-        name is ``f"cycle_at_{int(retention_threshold * 100)}pct"`` so a
+        name is ``f"cycle_at_{round(retention_threshold * 100)}pct"`` so a
         threshold of ``0.80`` yields ``cycle_at_80pct`` (default) and
-        ``0.50`` yields ``cycle_at_50pct``. The value in that column is
+        ``0.50`` yields ``cycle_at_50pct``. ``round`` (not ``int``) avoids
+        the IEEE-754 truncation trap where e.g. ``0.29 * 100`` evaluates
+        to ``28.999999999999996`` and would otherwise mislabel the column
+        ``cycle_at_28pct``. The value in that column is
         the first cycle where ``q_dis`` dips below
         ``retention_threshold * q_dis[1]``; NaN if the threshold is never
         crossed or if ``q_dis[1]`` is unusable.
@@ -336,7 +339,10 @@ def stat_table(
     ``scipy.integrate.simps`` is not used; ``numpy.trapz`` (removed in
     NumPy 2.0) is avoided in favour of ``scipy.integrate.trapezoid``.
     """
-    pct = int(retention_threshold * 100)
+    # ``round`` (not ``int``) because ``0.29 * 100 == 28.999999999999996``
+    # under IEEE-754 and ``int`` would truncate to ``28``, silently
+    # mislabelling the column. See the ``retention_threshold`` docstring.
+    pct = round(retention_threshold * 100)
     columns = _build_column_order(target_cycles, pct)
 
     if not cells:

--- a/src/toyo_battery/core/stats.py
+++ b/src/toyo_battery/core/stats.py
@@ -46,22 +46,20 @@ The deprecated ``scipy.integrate.simps`` is intentionally not used;
 of :func:`scipy.integrate.trapezoid`.
 
 Rewrite note (vs. legacy TOYO_Origin_2.01 ``stat_table`` L579-656): v2.01
-used V as the integration variable with ``simpson(V_lat, Q_lat)`` (argument
-order swapped — accidentally computing ``∫Q dV`` and relying on positional
-quirks in older scipy), then divided by capacity to recover a mean voltage.
-It also read ``chdis_df[str(n)+"-dis"].at[1, "電圧"]`` (row 1, not 0) and
-wrapped the entire per-n computation in a bare ``except Exception``, masking
-structural bugs as silent data loss. This rewrite uses Q as the
-integration variable directly (so the value is ``∫V dQ`` without sign
-ambiguity), reads bounds after an explicit Q sort + duplicate drop, and
-propagates NaN for genuinely-missing data only — structural mismatches
-raise loudly from upstream (:mod:`chdis`, :mod:`capacity`).
+passed positional args to ``simpson`` and read segment bounds from
+``chdis_df[str(n)+"-dis"].at[1, "電圧"]`` (row 1, not 0), then wrapped the
+entire per-n block in a bare ``except Exception`` that silently masked
+structural bugs as missing data. This rewrite uses Q as the integration
+variable via explicit keyword args (``simpson(y=v, x=q)`` ⇒ unambiguously
+``∫V dQ``), sorts + de-duplicates Q before reading bounds, and propagates
+NaN only for genuinely-missing data — structural mismatches raise loudly
+from upstream (:mod:`chdis`, :mod:`capacity`).
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
@@ -114,11 +112,9 @@ def _integrate_v_dq(v_arr: NDArray[np.float64], q_arr: NDArray[np.float64]) -> f
 
     The :mod:`chdis` contract guarantees Q is monotone non-decreasing within
     a segment, so a Q-ascending sort is a stable reorder. Duplicate Q values
-    (CC-CV plateaus accumulate at the same Q level? No — plateaus accumulate
-    at the same *voltage* level, so Q remains distinct; duplicates here
-    would come from tester-side point repeats) are dropped ``keep="last"``
-    to match the :mod:`dqdv` convention and keep the latest-recorded V for
-    any Q repeat.
+    — rare in real data because CC-CV plateaus saturate V, not Q — are
+    dropped with ``keep="last"`` to match the :mod:`dqdv` convention,
+    preserving the latest-recorded V for any repeat.
 
     Returns ``NaN`` for <2 finite points; trapezoidal for exactly 2;
     Simpson's rule for 3+.
@@ -150,7 +146,7 @@ def _integrate_v_dq(v_arr: NDArray[np.float64], q_arr: NDArray[np.float64]) -> f
 def _segment_arrays(
     chdis_df: pd.DataFrame,
     cycle: int,
-    side: str,
+    side: Literal["ch", "dis"],
     v_name: str,
     q_name: str,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
@@ -230,25 +226,19 @@ def _per_cell_row(
     cols = _resolve_cols(cell.column_lang)
     v_name, q_name = cols["voltage"], cols["capacity"]
 
-    # Q_dis_max: NaN-safe max over the column. An empty cap_df has an
-    # empty Series → .max() returns NaN (pandas convention), which is the
-    # behaviour we want for a cell whose chdis was fully wiped.
-    q_dis_max = (
-        float(cap_df["q_dis"].max())
-        if ("q_dis" in cap_df.columns and not cap_df["q_dis"].dropna().empty)
-        else float("nan")
-    )
+    # :func:`capacity.get_cap_df` unconditionally emits ``q_ch`` / ``q_dis``
+    # / ``ce`` columns (see capacity.py's empty-path branch), so no column
+    # presence guards are needed here — the frame may be row-empty, but the
+    # schema is fixed.
+    q_dis_series = cap_df["q_dis"]
+    q_dis_max = float(q_dis_series.max()) if not q_dis_series.dropna().empty else float("nan")
 
     # cycle-1 discharge capacity — the reference for retention + fade.
     q_dis_first = _safe_lookup(cap_df, 1, "q_dis")
 
     row: dict[str, float] = {
         "Q_dis_max": q_dis_max,
-        f"cycle_at_{pct}pct": _cycle_at_threshold(
-            cap_df["q_dis"] if "q_dis" in cap_df.columns else pd.Series([], dtype=float),
-            q_dis_first,
-            retention_threshold,
-        ),
+        f"cycle_at_{pct}pct": _cycle_at_threshold(q_dis_series, q_dis_first, retention_threshold),
     }
 
     for n in target_cycles:
@@ -263,12 +253,16 @@ def _per_cell_row(
 
         if dis_pair is not None:
             int_v_dq_dis = _integrate_v_dq(*dis_pair)
-            if np.isfinite(int_v_dq_dis) and np.isfinite(q_dis_n) and q_dis_n != 0.0:
-                v_mean_dis = int_v_dq_dis / q_dis_n
-            if ch_pair is not None:
-                int_v_dq_ch = _integrate_v_dq(*ch_pair)
-                if np.isfinite(int_v_dq_dis) and np.isfinite(int_v_dq_ch) and int_v_dq_ch != 0.0:
-                    ee = 100.0 * int_v_dq_dis / int_v_dq_ch
+            if np.isfinite(int_v_dq_dis):
+                if np.isfinite(q_dis_n) and q_dis_n != 0.0:
+                    v_mean_dis = int_v_dq_dis / q_dis_n
+                # Charge-side integral is only needed when the discharge
+                # side yielded a finite value — otherwise EE is NaN
+                # regardless of the charge integral.
+                if ch_pair is not None:
+                    int_v_dq_ch = _integrate_v_dq(*ch_pair)
+                    if np.isfinite(int_v_dq_ch) and int_v_dq_ch != 0.0:
+                        ee = 100.0 * int_v_dq_dis / int_v_dq_ch
 
         # Retention@n: 100.0 exactly for n=1 iff q_dis[1] is finite; else
         # 100 * q_dis[n] / q_dis[1] with NaN propagation through both
@@ -293,7 +287,7 @@ def _per_cell_row(
 
 
 def stat_table(
-    cells: list[Cell],
+    cells: Sequence[Cell],
     *,
     target_cycles: Sequence[int] = (10, 50),
     retention_threshold: float = 0.80,
@@ -303,24 +297,29 @@ def stat_table(
     Parameters
     ----------
     cells
-        List of :class:`toyo_battery.core.cell.Cell`. Each cell contributes
-        one row keyed by ``cell.name``. An empty list returns an empty
-        DataFrame with the correct column schema.
+        Sequence of :class:`toyo_battery.core.cell.Cell`. Each cell
+        contributes one row keyed by ``cell.name``. An empty sequence
+        returns an empty DataFrame with the correct column schema.
     target_cycles
         Cycle numbers at which to emit ``Q_dis@n`` / ``CE@n`` /
         ``V_mean_dis@n`` / ``EE@n`` / ``retention@n`` / ``CE_mean_1to{n}``.
         Order is preserved in the output columns so callers can pin column
         layout by tuple order. Cycles beyond a cell's maximum produce NaN
-        for that cell, but the row itself is still emitted.
+        for that cell, but the row itself is still emitted. Duplicate
+        entries raise ``ValueError`` to avoid silently-duplicated columns.
     retention_threshold
-        Fade threshold as a fraction of ``q_dis[1]``. The derived column
-        name is ``f"cycle_at_{round(retention_threshold * 100)}pct"`` so a
+        Fade threshold as a fraction of ``q_dis[1]``, in the open interval
+        ``(0, 1)`` (values at or outside the bounds raise ``ValueError``).
+        The derived column name is
+        ``f"cycle_at_{round(retention_threshold * 100)}pct"`` so a
         threshold of ``0.80`` yields ``cycle_at_80pct`` (default) and
         ``0.50`` yields ``cycle_at_50pct``. ``round`` (not ``int``) avoids
         the IEEE-754 truncation trap where e.g. ``0.29 * 100`` evaluates
         to ``28.999999999999996`` and would otherwise mislabel the column
-        ``cycle_at_28pct``. The value in that column is
-        the first cycle where ``q_dis`` dips below
+        ``cycle_at_28pct``. Python's ``round`` uses banker's rounding (tie
+        to even) — irrelevant for realistic thresholds but worth noting
+        if a caller passes an exact-half value like ``0.125``. The value
+        in that column is the first cycle where ``q_dis`` dips below
         ``retention_threshold * q_dis[1]``; NaN if the threshold is never
         crossed or if ``q_dis[1]`` is unusable.
 
@@ -331,6 +330,12 @@ def stat_table(
         order (see the module docstring). All values are float64; empty
         positions are NaN.
 
+    Raises
+    ------
+    ValueError
+        If ``retention_threshold`` is not in the open interval ``(0, 1)``,
+        or if ``target_cycles`` contains duplicate entries.
+
     Notes
     -----
     Integration over ``∫V dQ`` uses :func:`scipy.integrate.simpson` when
@@ -339,11 +344,19 @@ def stat_table(
     ``scipy.integrate.simps`` is not used; ``numpy.trapz`` (removed in
     NumPy 2.0) is avoided in favour of ``scipy.integrate.trapezoid``.
     """
+    if not (0.0 < retention_threshold < 1.0):
+        raise ValueError(
+            f"retention_threshold must lie in the open interval (0, 1); got {retention_threshold!r}"
+        )
+    target_cycles_list = list(target_cycles)
+    if len(set(target_cycles_list)) != len(target_cycles_list):
+        raise ValueError(f"target_cycles must not contain duplicates; got {target_cycles_list!r}")
+
     # ``round`` (not ``int``) because ``0.29 * 100 == 28.999999999999996``
     # under IEEE-754 and ``int`` would truncate to ``28``, silently
     # mislabelling the column. See the ``retention_threshold`` docstring.
     pct = round(retention_threshold * 100)
-    columns = _build_column_order(target_cycles, pct)
+    columns = _build_column_order(target_cycles_list, pct)
 
     if not cells:
         return _empty_result(columns)
@@ -356,9 +369,12 @@ def stat_table(
     rows: list[dict[str, float]] = []
     for cell in cells:
         names.append(cell.name)
-        rows.append(_per_cell_row(cell, target_cycles, retention_threshold, pct))
+        rows.append(_per_cell_row(cell, target_cycles_list, retention_threshold, pct))
 
-    out = pd.DataFrame(rows, index=pd.Index(names, name="cell"))
+    # ``dtype="object"`` for the populated path too, matching ``_empty_result``
+    # so ``pd.concat`` of an empty + populated stat_table doesn't trigger
+    # dtype-coercion warnings on the index.
+    out = pd.DataFrame(rows, index=pd.Index(names, dtype="object", name="cell"))
     # Enforce column order + float64 dtype end-to-end. ``reindex`` also
     # guards against any runtime dict-mutation slip that silently dropped
     # a key — an absent column would surface here as a silent all-NaN

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -243,6 +243,38 @@ def test_retention_threshold_parametrized_column_name() -> None:
     np.testing.assert_allclose(tbl.loc["fade", "cycle_at_50pct"], 3.0, atol=1e-9)
 
 
+@pytest.mark.parametrize(
+    ("threshold", "expected_pct"),
+    [
+        # 0.29 * 100 == 28.999999999999996 under IEEE-754
+        # 0.58 * 100 == 57.99999999999999
+        # int(...) would truncate to 28 / 57 — regression guard.
+        (0.29, 29),
+        (0.58, 58),
+        (0.80, 80),
+    ],
+)
+def test_retention_threshold_column_name_rounds_not_truncates(
+    threshold: float, expected_pct: int
+) -> None:
+    """Float-imprecise thresholds round to nearest integer, not truncate.
+
+    Regression for the IEEE-754 trap in ``int(retention_threshold * 100)``:
+    callers who build thresholds programmatically (e.g. ``1.0 - fade_pct``)
+    would otherwise receive a silently-mislabelled column.
+    """
+    cell = _linear_cell(
+        "fade",
+        cycles_q_ch={1: 1000.0, 2: 1000.0},
+        cycles_q_dis={1: 1000.0, 2: 100.0},
+    )
+    tbl = stat_table([cell], target_cycles=(1,), retention_threshold=threshold)
+    expected_column = f"cycle_at_{expected_pct}pct"
+    assert expected_column in tbl.columns, (
+        f"Expected {expected_column!r} for threshold={threshold}; got columns={list(tbl.columns)}"
+    )
+
+
 def test_retention_at_cycle_1_is_100_exactly() -> None:
     """``retention@1`` must be 100.0 exactly (no floating-point drift).
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -524,13 +524,15 @@ def test_retention_threshold_out_of_range_raises(bad: float) -> None:
         stat_table([cell], target_cycles=(1,), retention_threshold=bad)
 
 
-def test_duplicate_target_cycles_raises() -> None:
-    """``target_cycles`` with duplicates raises — prevents silently-duplicated columns.
+@pytest.mark.parametrize("dup", [(1, 1, 2), (2, 1, 1), (1, 2, 1)])
+def test_duplicate_target_cycles_raises(dup: tuple[int, ...]) -> None:
+    """``target_cycles`` with duplicates raises — regardless of position.
 
     Pandas will happily emit two columns named ``Q_dis@1``; downstream
     consumers (and ``.to_csv``) then behave surprisingly. Surface the
     sloppy caller intent at the entry point rather than shipping a
-    malformed frame.
+    malformed frame. The parametrize pins position-independence: the
+    duplicate can sit at start, end, or sandwiched — all fire.
     """
     cell = _linear_cell(
         "v",
@@ -538,7 +540,7 @@ def test_duplicate_target_cycles_raises() -> None:
         cycles_q_dis={1: 990.0, 2: 880.0},
     )
     with pytest.raises(ValueError, match="target_cycles"):
-        stat_table([cell], target_cycles=(1, 1, 2))
+        stat_table([cell], target_cycles=dup)
 
 
 @pytest.mark.parametrize("layout", ["renzoku", "renzoku_py", "raw_6digit"])

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -273,6 +273,14 @@ def test_retention_threshold_column_name_rounds_not_truncates(
     assert expected_column in tbl.columns, (
         f"Expected {expected_column!r} for threshold={threshold}; got columns={list(tbl.columns)}"
     )
+    # The ``int()`` regression would produce the truncated-down label (e.g.
+    # 0.29 → ``cycle_at_28pct``). Assert it's absent — makes the intent
+    # of the test explicit even if the ``assert ... in columns`` above
+    # already covers it by omission.
+    wrong_column = f"cycle_at_{expected_pct - 1}pct"
+    assert wrong_column not in tbl.columns, (
+        f"Truncation-regression label {wrong_column!r} must not appear"
+    )
 
 
 def test_retention_at_cycle_1_is_100_exactly() -> None:
@@ -290,6 +298,41 @@ def test_retention_at_cycle_1_is_100_exactly() -> None:
     )
     tbl = stat_table([cell], target_cycles=(1,))
     assert tbl.loc["solo", "retention@1"] == 100.0
+
+
+def test_q_dis_first_zero_yields_nan_retention_and_cycle_at() -> None:
+    """Literal ``q_dis[1] == 0.0`` (non-NaN) triggers the zero-denominator guard.
+
+    Distinguishes from the NaN-denominator path: a cell where cycle 1
+    *physically* went through a discharge segment that accumulated zero
+    capacity (e.g. a mistimed test, a misconfigured mass, or a genuine
+    dud first cycle) is a legitimate-shaped input, not missing data.
+    Retention / fade must still be NaN (can't divide by zero), but the
+    rest of the row must populate normally.
+    """
+    rows: list[tuple[int, str, str, float, float]] = []
+    v_ch = np.linspace(3.0, 4.2, 50)
+    q_ch = np.linspace(0.0, 1000.0, 50)
+    # Cycle 1: charge fine, but discharge Q stays at 0 throughout.
+    rows.extend((1, "1", "充電", float(v), float(q)) for v, q in zip(v_ch, q_ch))
+    v_dis = np.linspace(4.2, 3.0, 50)
+    rows.extend((1, "1", "放電", float(v), 0.0) for v in v_dis)
+    # Cycle 2: normal charge + discharge.
+    rows.extend((2, "1", "充電", float(v), float(q)) for v, q in zip(v_ch, q_ch))
+    q_dis_2 = np.linspace(0.0, 500.0, 50)
+    rows.extend((2, "1", "放電", float(v), float(q)) for v, q in zip(v_dis, q_dis_2))
+    raw = pd.DataFrame(rows, columns=["サイクル", "モード", "状態", "電圧", "電気量"])
+    cell = Cell(name="zero_dis_1", mass_g=0.001, raw_df=raw)
+    tbl = stat_table([cell], target_cycles=(1, 2))
+
+    # Zero-denominator guard fires: fade + all retentions NaN.
+    assert pd.isna(tbl.loc["zero_dis_1", "cycle_at_80pct"])
+    assert pd.isna(tbl.loc["zero_dis_1", "retention@1"])
+    assert pd.isna(tbl.loc["zero_dis_1", "retention@2"])
+    # Q_dis@1 is literally 0.0, not NaN — the segment existed.
+    np.testing.assert_allclose(tbl.loc["zero_dis_1", "Q_dis@1"], 0.0, atol=1e-12)
+    # Cycle 2 remains functional.
+    np.testing.assert_allclose(tbl.loc["zero_dis_1", "Q_dis@2"], 500.0, atol=1e-9)
 
 
 def test_q_dis_first_missing_yields_nan_retention_and_cycle_at() -> None:
@@ -460,6 +503,42 @@ def test_end_to_end_with_cell_from_dir(make_cell_dir: Callable[..., Path]) -> No
     np.testing.assert_allclose(tbl.loc["cell_A", "V_mean_dis@1"], 3.30, atol=1e-9)
     # EE = 100 * (3.30 * 1000) / (3.55 * 1000) = 100 * 3.30 / 3.55
     np.testing.assert_allclose(tbl.loc["cell_A", "EE@1"], 100.0 * 3.30 / 3.55, atol=1e-9)
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1, 1.5, -1e-12, 1.0 + 1e-12])
+def test_retention_threshold_out_of_range_raises(bad: float) -> None:
+    """``retention_threshold`` outside the open interval (0, 1) raises ValueError.
+
+    Closed-interval endpoints (0.0 and 1.0) also raise — 0.0 is a
+    degenerate "never fade" threshold and 1.0 trivially fires on the
+    first sub-unity cycle, neither of which is a meaningful caller
+    intent. Callers expressing those extremes should pass a default
+    threshold and filter the output themselves.
+    """
+    cell = _linear_cell(
+        "v",
+        cycles_q_ch={1: 1000.0},
+        cycles_q_dis={1: 990.0},
+    )
+    with pytest.raises(ValueError, match="retention_threshold"):
+        stat_table([cell], target_cycles=(1,), retention_threshold=bad)
+
+
+def test_duplicate_target_cycles_raises() -> None:
+    """``target_cycles`` with duplicates raises — prevents silently-duplicated columns.
+
+    Pandas will happily emit two columns named ``Q_dis@1``; downstream
+    consumers (and ``.to_csv``) then behave surprisingly. Surface the
+    sloppy caller intent at the entry point rather than shipping a
+    malformed frame.
+    """
+    cell = _linear_cell(
+        "v",
+        cycles_q_ch={1: 1000.0, 2: 900.0},
+        cycles_q_dis={1: 990.0, 2: 880.0},
+    )
+    with pytest.raises(ValueError, match="target_cycles"):
+        stat_table([cell], target_cycles=(1, 1, 2))
 
 
 @pytest.mark.parametrize("layout", ["renzoku", "renzoku_py", "raw_6digit"])

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,445 @@
+"""Tests for :mod:`toyo_battery.core.stats`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from toyo_battery.core.cell import Cell
+from toyo_battery.core.stats import stat_table
+
+
+def _linear_cell(
+    name: str,
+    *,
+    cycles_q_ch: dict[int, float],
+    cycles_q_dis: dict[int, float],
+    v_ch_lo: float = 3.0,
+    v_ch_hi: float = 4.2,
+    v_dis_lo: float = 3.0,
+    v_dis_hi: float = 4.2,
+    n_points: int = 50,
+) -> Cell:
+    """Build a :class:`Cell` whose raw_df has linear V-Q ramps per cycle.
+
+    Each cycle's charge segment rises V from ``v_ch_lo`` to ``v_ch_hi`` while
+    Q rises 0 → ``cycles_q_ch[cycle]``. Discharge reverses V (``v_dis_hi`` →
+    ``v_dis_lo``) while Q rises 0 → ``cycles_q_dis[cycle]`` — mirroring
+    :mod:`chdis`'s invariant that Q is monotone non-decreasing within a
+    segment regardless of V direction.
+
+    With linear V-Q ramps the energy-weighted mean voltage equals the
+    arithmetic mean ``(V_lo + V_hi) / 2`` (for either direction), which
+    lets tests pin ``V_mean_dis`` / ``EE`` values at arbitrarily tight
+    tolerances.
+    """
+    rows: list[tuple[int, str, str, float, float]] = []
+    for cycle, q_max_ch in cycles_q_ch.items():
+        v_ch = np.linspace(v_ch_lo, v_ch_hi, n_points)
+        q_ch = np.linspace(0.0, q_max_ch, n_points)
+        rows.extend((cycle, "1", "充電", float(v), float(q)) for v, q in zip(v_ch, q_ch))
+        if cycle in cycles_q_dis:
+            q_max_dis = cycles_q_dis[cycle]
+            v_dis = np.linspace(v_dis_hi, v_dis_lo, n_points)
+            q_dis = np.linspace(0.0, q_max_dis, n_points)
+            rows.extend((cycle, "1", "放電", float(v), float(q)) for v, q in zip(v_dis, q_dis))
+    raw = pd.DataFrame(rows, columns=["サイクル", "モード", "状態", "電圧", "電気量"])
+    return Cell(name=name, mass_g=0.001, raw_df=raw)
+
+
+def test_two_cell_hand_computed_fixture_pinned() -> None:
+    """Two synthetic cells, every output column pinned to hand-computed values.
+
+    Fixture design: both cells have linear V-Q ramps (3.0→4.2 V on charge,
+    4.2→3.0 V on discharge with Q still rising per chdis invariant). Cell A
+    has q_ch=[1000, 900] and q_dis=[990, 880]; Cell B has q_ch=[800, 600]
+    and q_dis=[760, 500]. With these numbers every column is either
+    analytical (capacity/CE/retention ratios) or derivable from the mean-V
+    identity for linear ramps (mean = 3.6 V on both sides).
+    """
+    cell_a = _linear_cell(
+        "A",
+        cycles_q_ch={1: 1000.0, 2: 900.0},
+        cycles_q_dis={1: 990.0, 2: 880.0},
+    )
+    cell_b = _linear_cell(
+        "B",
+        cycles_q_ch={1: 800.0, 2: 600.0},
+        cycles_q_dis={1: 760.0, 2: 500.0},
+    )
+    tbl = stat_table([cell_a, cell_b], target_cycles=(1, 2))
+
+    # Index + shape
+    assert tbl.index.name == "cell"
+    assert tbl.index.tolist() == ["A", "B"]
+    assert (tbl.dtypes == np.float64).all()
+
+    # ------- Cell A -------
+    # Q_dis_max = max(990, 880) = 990
+    np.testing.assert_allclose(tbl.loc["A", "Q_dis_max"], 990.0, atol=1e-9)
+    # q_dis doesn't dip below 0.8 * q_dis[1] = 792 (cycle 2 = 880 > 792).
+    assert pd.isna(tbl.loc["A", "cycle_at_80pct"])
+    # Cycle 1
+    np.testing.assert_allclose(tbl.loc["A", "Q_dis@1"], 990.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["A", "CE@1"], 99.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["A", "V_mean_dis@1"], 3.6, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["A", "EE@1"], 99.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["A", "retention@1"], 100.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["A", "CE_mean_1to1"], 99.0, atol=1e-9)
+    # Cycle 2
+    np.testing.assert_allclose(tbl.loc["A", "Q_dis@2"], 880.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["A", "CE@2"], 100.0 * 880.0 / 900.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["A", "V_mean_dis@2"], 3.6, atol=1e-9)
+    # EE@2 = 100 * (3.6 * 880) / (3.6 * 900) = 100 * 880 / 900
+    np.testing.assert_allclose(tbl.loc["A", "EE@2"], 100.0 * 880.0 / 900.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["A", "retention@2"], 100.0 * 880.0 / 990.0, atol=1e-9)
+    # CE_mean_1to2 = mean(CE@1, CE@2) = (99 + 100*880/900) / 2
+    np.testing.assert_allclose(
+        tbl.loc["A", "CE_mean_1to2"],
+        (99.0 + 100.0 * 880.0 / 900.0) / 2.0,
+        atol=1e-9,
+    )
+
+    # ------- Cell B -------
+    # Q_dis_max = 760. 0.8 * q_dis[1] = 608. Cycle 2 = 500 < 608 → cycle_at_80pct = 2.
+    np.testing.assert_allclose(tbl.loc["B", "Q_dis_max"], 760.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "cycle_at_80pct"], 2.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "Q_dis@1"], 760.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "CE@1"], 95.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "V_mean_dis@1"], 3.6, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "EE@1"], 95.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "retention@1"], 100.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "CE_mean_1to1"], 95.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "Q_dis@2"], 500.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "CE@2"], 100.0 * 500.0 / 600.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "V_mean_dis@2"], 3.6, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "EE@2"], 100.0 * 500.0 / 600.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["B", "retention@2"], 100.0 * 500.0 / 760.0, atol=1e-9)
+    np.testing.assert_allclose(
+        tbl.loc["B", "CE_mean_1to2"],
+        (95.0 + 100.0 * 500.0 / 600.0) / 2.0,
+        atol=1e-9,
+    )
+
+
+def test_never_faded_yields_nan_cycle_at_threshold() -> None:
+    """A cell whose q_dis never dips below the threshold → cycle_at_80pct is NaN.
+
+    Also exercises the "Q_dis increases slightly cycle-over-cycle" shape,
+    which older ``while``-style fade trackers could misreport as "never
+    faded" for the wrong reason.
+    """
+    cell = _linear_cell(
+        "flat",
+        # Nearly-flat discharge capacity: 1000, 1010, 995. Never < 800.
+        cycles_q_ch={1: 1050.0, 2: 1050.0, 3: 1050.0},
+        cycles_q_dis={1: 1000.0, 2: 1010.0, 3: 995.0},
+    )
+    tbl = stat_table([cell], target_cycles=(1, 2, 3))
+    assert pd.isna(tbl.loc["flat", "cycle_at_80pct"])
+    # Sanity: other columns remain alive.
+    np.testing.assert_allclose(tbl.loc["flat", "Q_dis_max"], 1010.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["flat", "retention@3"], 99.5, atol=1e-9)
+
+
+def test_target_cycles_beyond_max_cycle_yield_nan_in_row() -> None:
+    """Asking for cycle 50 on a 2-cycle cell → NaN in that column, row preserved."""
+    cell = _linear_cell(
+        "short",
+        cycles_q_ch={1: 1000.0, 2: 950.0},
+        cycles_q_dis={1: 990.0, 2: 940.0},
+    )
+    tbl = stat_table([cell], target_cycles=(1, 50))
+
+    # Row is still present
+    assert "short" in tbl.index
+    # Cycle-1 columns are populated
+    np.testing.assert_allclose(tbl.loc["short", "Q_dis@1"], 990.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["short", "CE@1"], 99.0, atol=1e-9)
+    # Cycle-50 direct look-ups are NaN (no such row in cap_df / chdis_df)
+    for col in ("Q_dis@50", "CE@50", "V_mean_dis@50", "EE@50", "retention@50"):
+        assert pd.isna(tbl.loc["short", col]), f"{col} should be NaN on a short cell"
+    # CE_mean_1to50 is *not* NaN — pandas ``.loc[1:50]`` on a 2-row cap_df
+    # returns cycles 1 & 2, and the mean of those two CEs is a finite value.
+    # This pins the "take whatever cycles exist up to n" semantics; a caller
+    # who wanted a NaN-on-short contract would need a separate helper.
+    np.testing.assert_allclose(
+        tbl.loc["short", "CE_mean_1to50"],
+        (99.0 + 100.0 * 940.0 / 950.0) / 2.0,
+        atol=1e-9,
+    )
+    # Whole-cell columns still populated
+    np.testing.assert_allclose(tbl.loc["short", "Q_dis_max"], 990.0, atol=1e-9)
+
+
+def test_empty_cells_list_returns_empty_frame_with_schema() -> None:
+    """``stat_table([])`` → empty frame with the right columns / dtype / index name."""
+    tbl = stat_table([])
+    assert tbl.empty
+    assert tbl.index.name == "cell"
+    assert list(tbl.columns) == [
+        "Q_dis_max",
+        "cycle_at_80pct",
+        "Q_dis@10",
+        "CE@10",
+        "V_mean_dis@10",
+        "EE@10",
+        "retention@10",
+        "CE_mean_1to10",
+        "Q_dis@50",
+        "CE@50",
+        "V_mean_dis@50",
+        "EE@50",
+        "retention@50",
+        "CE_mean_1to50",
+    ]
+    for col in tbl.columns:
+        assert tbl[col].dtype == np.float64
+
+
+def test_column_order_is_deterministic_and_follows_target_cycles() -> None:
+    """Column order: [Q_dis_max, cycle_at_Xpct, then each n's 6-column block]."""
+    cell = _linear_cell(
+        "one",
+        cycles_q_ch={1: 1000.0, 5: 900.0, 3: 950.0},
+        cycles_q_dis={1: 990.0, 5: 880.0, 3: 930.0},
+    )
+    # target_cycles=(5, 3) (intentionally not sorted) to pin that insertion
+    # order is preserved rather than sorted.
+    tbl = stat_table([cell], target_cycles=(5, 3))
+    assert list(tbl.columns) == [
+        "Q_dis_max",
+        "cycle_at_80pct",
+        "Q_dis@5",
+        "CE@5",
+        "V_mean_dis@5",
+        "EE@5",
+        "retention@5",
+        "CE_mean_1to5",
+        "Q_dis@3",
+        "CE@3",
+        "V_mean_dis@3",
+        "EE@3",
+        "retention@3",
+        "CE_mean_1to3",
+    ]
+
+
+def test_retention_threshold_parametrized_column_name() -> None:
+    """``retention_threshold=0.5`` yields a ``cycle_at_50pct`` column."""
+    cell = _linear_cell(
+        "fade",
+        cycles_q_ch={1: 1000.0, 2: 1000.0, 3: 1000.0},
+        cycles_q_dis={1: 1000.0, 2: 700.0, 3: 400.0},
+    )
+    tbl = stat_table([cell], target_cycles=(1,), retention_threshold=0.5)
+    assert "cycle_at_50pct" in tbl.columns
+    assert "cycle_at_80pct" not in tbl.columns
+    # 0.5 * 1000 = 500. q_dis drops below 500 first at cycle 3 (= 400).
+    np.testing.assert_allclose(tbl.loc["fade", "cycle_at_50pct"], 3.0, atol=1e-9)
+
+
+def test_retention_at_cycle_1_is_100_exactly() -> None:
+    """``retention@1`` must be 100.0 exactly (no floating-point drift).
+
+    Guards against a regression that would compute ``q_dis[1]/q_dis[1]`` via
+    the general formula and hit a sub-ULP error — harmless numerically, but
+    visible in CSV exports and annoying to downstream consumers comparing
+    equality.
+    """
+    cell = _linear_cell(
+        "solo",
+        cycles_q_ch={1: 1000.0},
+        cycles_q_dis={1: 990.0},
+    )
+    tbl = stat_table([cell], target_cycles=(1,))
+    assert tbl.loc["solo", "retention@1"] == 100.0
+
+
+def test_q_dis_first_missing_yields_nan_retention_and_cycle_at() -> None:
+    """When cycle 1 has no discharge (q_dis[1] NaN), retention + fade are NaN."""
+    # Build a cell where cycle 1 has only charge (no discharge).
+    rows: list[tuple[int, str, str, float, float]] = []
+    v_ch = np.linspace(3.0, 4.2, 50)
+    q_ch = np.linspace(0.0, 1000.0, 50)
+    rows.extend((1, "1", "充電", float(v), float(q)) for v, q in zip(v_ch, q_ch))
+    # Cycle 2: full charge + discharge
+    rows.extend((2, "1", "充電", float(v), float(q)) for v, q in zip(v_ch, q_ch))
+    v_dis = np.linspace(4.2, 3.0, 50)
+    q_dis = np.linspace(0.0, 900.0, 50)
+    rows.extend((2, "1", "放電", float(v), float(q)) for v, q in zip(v_dis, q_dis))
+    raw = pd.DataFrame(rows, columns=["サイクル", "モード", "状態", "電圧", "電気量"])
+    cell = Cell(name="no_dis_1", mass_g=0.001, raw_df=raw)
+    tbl = stat_table([cell], target_cycles=(1, 2))
+
+    # q_dis[1] is NaN → fade + all retentions are NaN
+    assert pd.isna(tbl.loc["no_dis_1", "cycle_at_80pct"])
+    assert pd.isna(tbl.loc["no_dis_1", "retention@1"])
+    assert pd.isna(tbl.loc["no_dis_1", "retention@2"])
+    # Cycle-2 direct look-ups still work
+    np.testing.assert_allclose(tbl.loc["no_dis_1", "Q_dis@2"], 900.0, atol=1e-9)
+
+
+def test_multi_cell_rows_independent() -> None:
+    """Two cells in one call must yield two rows with independent values."""
+    a = _linear_cell(
+        "a",
+        cycles_q_ch={1: 1000.0, 2: 1000.0},
+        cycles_q_dis={1: 990.0, 2: 990.0},
+    )
+    b = _linear_cell(
+        "b",
+        cycles_q_ch={1: 500.0, 2: 500.0},
+        cycles_q_dis={1: 450.0, 2: 300.0},
+    )
+    tbl = stat_table([a, b], target_cycles=(1, 2))
+    assert tbl.index.tolist() == ["a", "b"]
+    # Cell b's cycle 2 retention = 100 * 300/450 ≈ 66.67%
+    np.testing.assert_allclose(tbl.loc["b", "retention@2"], 100.0 * 300.0 / 450.0, atol=1e-9)
+    # Cell a's cycle 2 retention = 100% (same q_dis)
+    np.testing.assert_allclose(tbl.loc["a", "retention@2"], 100.0, atol=1e-9)
+
+
+def test_two_point_segment_uses_trapezoidal_fallback() -> None:
+    """2-point segment → trapezoid integral (not NaN, not Simpson error).
+
+    Hand-constructed raw_df with exactly 2 points in the cycle-1 discharge
+    segment. The trapezoidal integral of V with the x-axis being Q is
+    ``(V1 + V2)/2 * (Q2 - Q1)`` → mean V is exactly the arithmetic mean.
+    """
+    rows = [
+        # Cycle 1 charge: full well-formed ramp (3+ points so simpson works).
+        (1, "1", "充電", 3.0, 0.0),
+        (1, "1", "充電", 3.6, 500.0),
+        (1, "1", "充電", 4.2, 1000.0),
+        # Cycle 1 discharge: exactly 2 distinct points → trapezoid fallback.
+        (1, "1", "放電", 4.2, 0.0),
+        (1, "1", "放電", 3.0, 990.0),
+    ]
+    raw = pd.DataFrame(rows, columns=["サイクル", "モード", "状態", "電圧", "電気量"])
+    cell = Cell(name="tiny", mass_g=0.001, raw_df=raw)
+    tbl = stat_table([cell], target_cycles=(1,))
+
+    # Arithmetic-mean V on the 2-point trapezoid: (4.2 + 3.0) / 2 = 3.6
+    np.testing.assert_allclose(tbl.loc["tiny", "V_mean_dis@1"], 3.6, atol=1e-9)
+    # EE = 100 * ∫V dQ_dis / ∫V dQ_ch
+    # ∫V dQ_ch via simpson on (V=3.0/3.6/4.2, Q=0/500/1000) — with uniform Q
+    # spacing, simpson reduces to (Q_step/3) * (V[0] + 4 V[1] + V[2])
+    # = (500/3) * (3.0 + 14.4 + 4.2) = (500/3) * 21.6 = 3600.
+    # ∫V dQ_dis via trapezoid = 0.5 * (4.2 + 3.0) * 990 = 3.6 * 990 = 3564.
+    # EE = 100 * 3564 / 3600 = 99.0.
+    np.testing.assert_allclose(tbl.loc["tiny", "EE@1"], 99.0, atol=1e-9)
+
+
+def test_single_point_segment_yields_nan_integrals() -> None:
+    """Segment with only 1 distinct Q → V_mean_dis and EE are NaN."""
+    rows = [
+        # Cycle 1 charge: well-formed.
+        (1, "1", "充電", 3.0, 0.0),
+        (1, "1", "充電", 3.6, 500.0),
+        (1, "1", "充電", 4.2, 1000.0),
+        # Cycle 1 discharge: 1 row. Q_dis from cap_df is 500 (the single max).
+        (1, "1", "放電", 3.7, 500.0),
+    ]
+    raw = pd.DataFrame(rows, columns=["サイクル", "モード", "状態", "電圧", "電気量"])
+    cell = Cell(name="degen", mass_g=0.001, raw_df=raw)
+    tbl = stat_table([cell], target_cycles=(1,))
+
+    assert pd.isna(tbl.loc["degen", "V_mean_dis@1"])
+    assert pd.isna(tbl.loc["degen", "EE@1"])
+    # Direct look-ups survive.
+    np.testing.assert_allclose(tbl.loc["degen", "Q_dis@1"], 500.0, atol=1e-9)
+
+
+def test_column_lang_en_input_produces_english_output() -> None:
+    """EN-column cell yields the same EN-fixed output columns.
+
+    ``column_lang`` selects which raw-frame labels to read. The output
+    schema is EN-fixed regardless, so the column list is identical to the
+    JA-input case.
+    """
+    rows = [
+        (1, "1", "充電", 3.0, 0.0),
+        (1, "1", "充電", 4.2, 1000.0),
+        (1, "1", "放電", 4.2, 0.0),
+        (1, "1", "放電", 3.0, 990.0),
+    ]
+    raw = pd.DataFrame(rows, columns=["cycle", "mode", "state", "voltage", "capacity"])
+    cell = Cell(name="en_cell", mass_g=0.001, raw_df=raw, column_lang="en")
+    tbl = stat_table([cell], target_cycles=(1,))
+
+    assert list(tbl.columns) == [
+        "Q_dis_max",
+        "cycle_at_80pct",
+        "Q_dis@1",
+        "CE@1",
+        "V_mean_dis@1",
+        "EE@1",
+        "retention@1",
+        "CE_mean_1to1",
+    ]
+    np.testing.assert_allclose(tbl.loc["en_cell", "Q_dis@1"], 990.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["en_cell", "V_mean_dis@1"], 3.6, atol=1e-9)
+
+
+def test_all_nan_cap_df_yields_all_nan_row() -> None:
+    """A cell whose chdis is structurally empty produces a row of NaN.
+
+    Build a raw frame with only rest rows → chdis filters everything out →
+    cap_df is empty → every stat column is NaN, but the cell still shows up
+    as a row so downstream consumers aren't silently missing it.
+    """
+    rows = [
+        (1, "1", "休止", 3.0, 0.0),
+        (1, "1", "休止", 3.0, 0.0),
+    ]
+    raw = pd.DataFrame(rows, columns=["サイクル", "モード", "状態", "電圧", "電気量"])
+    cell = Cell(name="empty", mass_g=0.001, raw_df=raw)
+    tbl = stat_table([cell], target_cycles=(1, 2))
+
+    assert "empty" in tbl.index
+    # Every column is NaN (including Q_dis_max — empty .max() → NaN).
+    assert tbl.loc["empty"].isna().all()
+
+
+def test_end_to_end_with_cell_from_dir(make_cell_dir: Callable[..., Path]) -> None:
+    """Smoke test via ``Cell.from_dir`` — exercises the on-disk read path.
+
+    The shared fixture has a single cycle with q_ch = q_dis = 1000 mAh/g
+    and V ranging 3.50→3.60 V on charge, 3.40→3.20 V on discharge. With
+    ``target_cycles=(1,)`` we can pin the whole row analytically.
+    """
+    cell_dir = make_cell_dir("renzoku")
+    cell = Cell.from_dir(cell_dir)
+    tbl = stat_table([cell], target_cycles=(1,))
+
+    # One row keyed by directory name.
+    assert tbl.index.tolist() == ["cell_A"]
+    np.testing.assert_allclose(tbl.loc["cell_A", "Q_dis_max"], 1000.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["cell_A", "Q_dis@1"], 1000.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["cell_A", "CE@1"], 100.0, atol=1e-9)
+    np.testing.assert_allclose(tbl.loc["cell_A", "retention@1"], 100.0, atol=1e-9)
+    # Mean V on linear ramp: (3.50 + 3.60)/2 = 3.55 for charge,
+    # (3.40 + 3.20)/2 = 3.30 for discharge.
+    np.testing.assert_allclose(tbl.loc["cell_A", "V_mean_dis@1"], 3.30, atol=1e-9)
+    # EE = 100 * (3.30 * 1000) / (3.55 * 1000) = 100 * 3.30 / 3.55
+    np.testing.assert_allclose(tbl.loc["cell_A", "EE@1"], 100.0 * 3.30 / 3.55, atol=1e-9)
+
+
+@pytest.mark.parametrize("layout", ["renzoku", "renzoku_py", "raw_6digit"])
+def test_layouts_produce_equivalent_stats(make_cell_dir: Callable[..., Path], layout: str) -> None:
+    """All three on-disk layouts must yield the same stat_table values.
+
+    This is a consistency test across reader paths — not an algorithmic
+    test. ``raw_6digit`` derives capacity from elapsed * current / mass,
+    introducing float rounding, so the tolerance is relaxed.
+    """
+    cell = Cell.from_dir(make_cell_dir(layout))
+    tbl = stat_table([cell], target_cycles=(1,))
+    np.testing.assert_allclose(tbl.loc["cell_A", "Q_dis@1"], 1000.0, rtol=1e-6)
+    np.testing.assert_allclose(tbl.loc["cell_A", "V_mean_dis@1"], 3.30, rtol=1e-6)
+    np.testing.assert_allclose(tbl.loc["cell_A", "EE@1"], 100.0 * 3.30 / 3.55, rtol=1e-6)


### PR DESCRIPTION
## Summary

Ships `stat_table(cells, *, target_cycles=(10, 50), retention_threshold=0.80)` in `src/toyo_battery/core/stats.py` — a multi-cell summary aggregator that produces a wide per-cell DataFrame with deterministic EN-fixed columns.

### Output schema

- Index: `cell.name` (`Index.name == "cell"`)
- Whole-cell columns: `Q_dis_max`, `cycle_at_{pct}pct` (threshold-parametrized — `0.80` → `cycle_at_80pct`; uses `round()` not `int()` to avoid IEEE-754 truncation on values like `0.29 * 100 = 28.999…`)
- Per `n ∈ target_cycles` (caller-ordered): `Q_dis@n`, `CE@n`, `V_mean_dis@n`, `EE@n`, `retention@n`, `CE_mean_1to{n}`
- All values float64

### Integration detail

Per-segment `∫V dQ` uses Q as the integration axis (chdis guarantees monotone non-decreasing Q within a segment). Scipy API:

- `simpson` for 3+ distinct-Q points
- `trapezoid` for exactly 2
- NaN otherwise

Deprecated `scipy.integrate.simps` is not used; NumPy-2.0-removed `np.trapz` is likewise avoided in favour of `scipy.integrate.trapezoid`.

### Validation at entry point

- `retention_threshold` must lie in the open interval `(0, 1)` — `ValueError` otherwise.
- `target_cycles` must not contain duplicates — `ValueError` otherwise (prevents silently-duplicated columns).

### Edge cases covered

- Empty `cells` sequence → empty frame with correct columns, dtypes (float64), and `Index.name == "cell"`
- `target_cycles` beyond max cycle → NaN for that n's direct look-ups; `CE_mean_1to{n}` still takes whatever cycles exist
- `q_dis[1]` NaN or 0.0 → `cycle_at_{pct}pct` and all `retention@n` NaN (zero-denominator guard distinguished from NaN-denominator path in tests)
- `int_v_dq_ch == 0` → `EE@n` NaN (not inf)
- `retention@1` is exactly `100.0` (no FP drift) when `q_dis[1]` is finite
- Segments with 1 distinct Q → `V_mean_dis` / `EE` NaN (no scipy crash)
- All-NaN `cap_df` (e.g. cell with only rest rows) → row of NaN, cell still appears in output
- `column_lang="en"` cell → same EN-fixed output columns

### Cell integration

Per the plan, **no Cell changes** — `stat_table` is multi-cell by nature and callers invoke it directly.

### Rewrite notes vs. TOYO_Origin_2.01

- v2.01 passed positional args to `simpson` and read segment bounds from `chdis_df[...].at[1, "電圧"]` (row 1, not 0), then wrapped the per-n block in a bare `except Exception` that silently masked structural bugs as missing data. This rewrite uses Q as the integration variable via explicit keyword args (`simpson(y=v, x=q)` ⇒ unambiguously `∫V dQ`), sorts + dedups Q before reading bounds, and propagates NaN only for genuinely-missing data — structural mismatches raise loudly from upstream (`chdis`, `capacity`).

## Review cycle polish

This PR went through three review rounds. Post-review changes:

- **`d215e52`** — round-1 HIGH fix: `int(retention_threshold * 100)` → `round(...)` (IEEE-754 truncation trap). Regression test added for `0.29` / `0.58` / `0.80`.
- **`a84227a`** — round-2 polish addressing MEDIUM/LOW: validation for `retention_threshold` bounds and `target_cycles` duplicates, dead-code removal (unreachable `q_dis in cap_df.columns` guards), docstring rewrites (no Q&A prose, unambiguous scipy-arg note), typing tightenings (`cells: Sequence[Cell]`, `side: Literal["ch", "dis"]`), populated-path index dtype alignment, charge-side micro-opt (skip when discharge integral is NaN). New tests for `q_dis[1] == 0.0` literal, out-of-range threshold, duplicate target_cycles.
- **`29a991d`** — round-3 micro-polish: parametrize duplicate-target_cycles test over start/mid/end positions.

## Test plan

- [x] `uv run pytest` — 112 passed (30 in `tests/test_stats.py`, 97%+ coverage on `stats.py`)
- [x] `uv run mypy` — 20 source files, 0 errors
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — 28 files already formatted
- [x] `uv build` — wheel + sdist build cleanly

### Test coverage (tests/test_stats.py — 30 parametrized cases)

1. **Hand-computed 2-cell fixture** — every output column pinned at 1e-9 tolerance
2. **Never-faded cell** → `cycle_at_80pct` NaN
3. **target_cycles beyond max** → NaN direct look-ups, row preserved
4. **Empty cells list** → empty frame with schema
5. **Column order deterministic** including unsorted `target_cycles=(5, 3)`
6. **`retention_threshold=0.5`** → `cycle_at_50pct` column
7. **Threshold column naming** — parametrized over `0.29` / `0.58` / `0.80` (IEEE-754 regression guard) with negative assertion that the truncated label is absent
8. **`retention@1 == 100.0`** exactly
9. **q_dis[1] missing (NaN)** → NaN retention + fade
10. **q_dis[1] == 0.0 literal** → NaN retention + fade, but `Q_dis@1` stays 0.0 (distinguishes zero-denom from NaN-denom path)
11. **Multi-cell independence**
12. **2-point segment** → trapezoid fallback
13. **1-point segment** → NaN integrals
14. **column_lang="en"** input
15. **All-NaN cap_df** → NaN row, preserved
16. **`retention_threshold` out of range** — parametrized over `0.0` / `1.0` / `-0.1` / `1.5` / `-1e-12` / `1.0+1e-12` → `ValueError`
17. **Duplicate target_cycles** — parametrized over `(1,1,2)` / `(2,1,1)` / `(1,2,1)` (position-independent) → `ValueError`
18. **End-to-end `Cell.from_dir`** smoke
19. **All 3 on-disk layouts** (renzoku / renzoku_py / raw_6digit) produce equivalent stats

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)