### PR TITLE
feat(plotting): matplotlib backend (chdis / cycle dual-Y / dQ/dV)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
     "mypy>=1.11",
     "pandas-stubs",
     "types-setuptools",
+    "matplotlib>=3.7",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/toyo_battery/plotting/matplotlib_backend.py
+++ b/src/toyo_battery/plotting/matplotlib_backend.py
@@ -1,7 +1,317 @@
-"""Matplotlib plotting backend. Requires the [plot] extra."""
+"""Matplotlib plotting backend. Requires the ``[plot]`` extra.
+
+Three user-facing functions operate on one or more :class:`toyo_battery.core.cell.Cell`
+instances and return a :class:`matplotlib.figure.Figure` (the caller handles
+``savefig``):
+
+- :func:`plot_chdis` — charge/discharge V-vs-Q curves; cycle 1 is drawn in
+  red, all other cycles in black (TOYO legacy convention).
+- :func:`plot_cycle` — per-cycle dual-Y plot: discharge capacity on the
+  left Y axis, Coulombic efficiency on the right Y axis.
+- :func:`plot_dqdv` — dQ/dV-vs-V curves, same cycle-1-red / others-black
+  coloring as :func:`plot_chdis`. Discharge dQ/dV is **negative** by
+  construction (see :mod:`toyo_battery.core.dqdv` for the sign
+  convention); raw signed values are plotted so charge and discharge
+  branches live in different half-planes.
+
+Layout: when multiple cells are passed, the returned figure contains one
+Axes per cell arranged in a near-square grid (1xN for ``N<=3``, otherwise
+``ncols = ceil(sqrt(N))``, ``nrows = ceil(N/ncols)``). Unused grid cells
+are hidden.
+
+Labels and legend text are **always English**, independent of each cell's
+``column_lang``; this avoids matplotlib JP-font configuration issues.
+Cell data access (``cell.chdis_df`` / ``cell.cap_df`` / ``cell.dqdv_df``)
+uses the correct quantity-level label for the cell's own ``column_lang``.
+
+Matplotlib is imported unconditionally at module level: this module is
+only imported when plotting is actually needed, and a missing extra
+surfaces as a standard ``ImportError`` from the import line.
+"""
 
 from __future__ import annotations
 
+import math
+from collections.abc import Sequence
 
-def plot_chdis(*args: object, **kwargs: object) -> object:
-    raise NotImplementedError("plot_chdis will be implemented in P2")
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
+
+from toyo_battery.core.cell import Cell
+from toyo_battery.io.schema import ColumnLang
+
+_CYCLE_COLOR_FIRST = "red"
+_CYCLE_COLOR_OTHER = "black"
+
+_QUANTITY_KEYS_JA: dict[str, str] = {
+    "voltage": "電圧",
+    "capacity": "電気量",
+    "dqdv": "dQ/dV",
+}
+_QUANTITY_KEYS_EN: dict[str, str] = {
+    "voltage": "voltage",
+    "capacity": "capacity",
+    "dqdv": "dq_dv",
+}
+
+
+def _quantity(column_lang: ColumnLang, key: str) -> str:
+    """Map a logical key (``"voltage"`` / ``"capacity"`` / ``"dqdv"``) to the
+    ``quantity``-level MultiIndex label used by a cell with the given
+    ``column_lang``.
+    """
+    table = _QUANTITY_KEYS_JA if column_lang == "ja" else _QUANTITY_KEYS_EN
+    return table[key]
+
+
+def _subplot_grid(n: int) -> tuple[int, int]:
+    """Return ``(nrows, ncols)`` for ``n`` subplots.
+
+    ``n <= 3`` → a single row. Larger counts fall back to a near-square
+    grid: ``ncols = ceil(sqrt(n))``, ``nrows = ceil(n / ncols)``.
+    """
+    if n <= 3:
+        return (1, max(n, 1))
+    ncols = math.ceil(math.sqrt(n))
+    nrows = math.ceil(n / ncols)
+    return (nrows, ncols)
+
+
+def _resolve_cycles(cell: Cell, cycles: Sequence[int] | None) -> list[int]:
+    """Return the cycles to plot for ``cell``.
+
+    ``cycles=None`` yields every cycle present in ``cell.cap_df.index``.
+    An explicit sequence is intersected with the available cycles while
+    preserving caller order; cycles missing from the cell are dropped
+    silently so a shared ``cycles=[1, 5, 10]`` call can span cells with
+    different cycle counts without raising.
+    """
+    available = {int(c) for c in cell.cap_df.index}
+    if cycles is None:
+        return sorted(available)
+    return [int(c) for c in cycles if int(c) in available]
+
+
+def _check_nonempty(cells: Sequence[Cell]) -> None:
+    """Raise ``ValueError`` if ``cells`` is empty.
+
+    Fails loudly rather than returning a blank figure — a zero-cell call
+    is almost always a caller bug.
+    """
+    if len(cells) == 0:
+        raise ValueError("cells must be a non-empty sequence of Cell instances")
+
+
+def _build_grid(n: int) -> tuple[Figure, list[Axes]]:
+    """Create a figure with one Axes per cell, hiding unused grid cells.
+
+    Returns the figure and a flat list of ``n`` visible Axes (in cell
+    order). Any extra Axes created by the grid layout are hidden in
+    place.
+    """
+    nrows, ncols = _subplot_grid(n)
+    fig, axes_array = plt.subplots(
+        nrows,
+        ncols,
+        figsize=(5 * ncols, 4 * nrows),
+        squeeze=False,
+    )
+    flat: list[Axes] = [ax for row in axes_array for ax in row]
+    for ax in flat[n:]:
+        ax.set_visible(False)
+    return fig, flat[:n]
+
+
+def _cycle_color(cycle: int) -> str:
+    return _CYCLE_COLOR_FIRST if cycle == 1 else _CYCLE_COLOR_OTHER
+
+
+def _add_cycle_legend(ax: Axes, cycles_plotted: list[int]) -> None:
+    """Attach a 2-entry cycle-color legend when more than one cycle was drawn."""
+    if len(cycles_plotted) <= 1:
+        return
+    handles = [
+        Line2D([], [], color=_CYCLE_COLOR_FIRST, label="cycle 1"),
+        Line2D([], [], color=_CYCLE_COLOR_OTHER, label="other cycles"),
+    ]
+    ax.legend(handles=handles, loc="best")
+
+
+def plot_chdis(
+    cells: Sequence[Cell],
+    cycles: Sequence[int] | None = None,
+) -> Figure:
+    """Charge/discharge curves (capacity on X, voltage on Y).
+
+    Parameters
+    ----------
+    cells
+        One or more :class:`Cell` instances. One subplot is drawn per
+        cell.
+    cycles
+        Cycles to include. ``None`` (default) plots every cycle present
+        in each cell's ``cap_df``. When a sequence is given, cycles not
+        present in a given cell are skipped silently for that cell only.
+
+    Returns
+    -------
+    Figure
+        A new matplotlib figure. The caller is responsible for
+        ``savefig`` and ``close``.
+
+    Raises
+    ------
+    ValueError
+        If ``cells`` is empty.
+    """
+    _check_nonempty(cells)
+    fig, axes = _build_grid(len(cells))
+
+    for ax, cell in zip(axes, cells):
+        v_name = _quantity(cell.column_lang, "voltage")
+        q_name = _quantity(cell.column_lang, "capacity")
+        chdis = cell.chdis_df
+
+        plotted: list[int] = []
+        for cycle in _resolve_cycles(cell, cycles):
+            color = _cycle_color(cycle)
+            drew_any = False
+            for side in ("ch", "dis"):
+                v_key = (cycle, side, v_name)
+                q_key = (cycle, side, q_name)
+                if v_key not in chdis.columns or q_key not in chdis.columns:
+                    continue
+                v = chdis[v_key].dropna()
+                q = chdis[q_key].dropna()
+                if v.empty or q.empty:
+                    continue
+                ax.plot(q, v, color=color, linewidth=0.9)
+                drew_any = True
+            if drew_any:
+                plotted.append(cycle)
+
+        ax.set_xlabel("Capacity [mAh/g]")
+        ax.set_ylabel("Voltage [V]")
+        ax.set_title(cell.name)
+        _add_cycle_legend(ax, plotted)
+
+    fig.tight_layout()
+    return fig
+
+
+def plot_cycle(cells: Sequence[Cell]) -> Figure:
+    """Per-cycle discharge capacity (left Y) and Coulombic efficiency (right Y).
+
+    Parameters
+    ----------
+    cells
+        One or more :class:`Cell` instances. One subplot is drawn per
+        cell, each with a twin-Y (``ax.twinx()``) for efficiency.
+
+    Returns
+    -------
+    Figure
+        A new matplotlib figure.
+
+    Raises
+    ------
+    ValueError
+        If ``cells`` is empty.
+    """
+    _check_nonempty(cells)
+    fig, axes = _build_grid(len(cells))
+
+    for ax, cell in zip(axes, cells):
+        cap = cell.cap_df
+        (line_q,) = ax.plot(
+            cap.index,
+            cap["q_dis"],
+            "o-",
+            color="C0",
+            label="Discharge capacity",
+        )
+        ax.set_xlabel("Cycle")
+        ax.set_ylabel("Discharge capacity [mAh/g]")
+
+        ax2 = ax.twinx()
+        (line_ce,) = ax2.plot(
+            cap.index,
+            cap["ce"],
+            "s--",
+            color="C3",
+            label="Coulombic efficiency",
+        )
+        ax2.set_ylabel("Coulombic efficiency [%]")
+
+        ax.set_title(cell.name)
+        ax.legend(handles=[line_q, line_ce], loc="lower right")
+
+    fig.tight_layout()
+    return fig
+
+
+def plot_dqdv(
+    cells: Sequence[Cell],
+    cycles: Sequence[int] | None = None,
+) -> Figure:
+    """dQ/dV vs voltage, cycle 1 red / other cycles black.
+
+    Discharge dQ/dV is negative by construction (see
+    :mod:`toyo_battery.core.dqdv`); the raw signed values are plotted so
+    charge and discharge branches live in different half-planes.
+
+    Parameters
+    ----------
+    cells
+        One or more :class:`Cell` instances. One subplot per cell.
+    cycles
+        Cycles to include. ``None`` plots every cycle present in each
+        cell's ``cap_df``. Cycles missing from a given cell's
+        ``dqdv_df`` (e.g. degenerate segments that collapse to an
+        all-NaN column) are skipped silently for that cell.
+
+    Returns
+    -------
+    Figure
+        A new matplotlib figure.
+
+    Raises
+    ------
+    ValueError
+        If ``cells`` is empty.
+    """
+    _check_nonempty(cells)
+    fig, axes = _build_grid(len(cells))
+
+    for ax, cell in zip(axes, cells):
+        v_name = _quantity(cell.column_lang, "voltage")
+        dqdv_name = _quantity(cell.column_lang, "dqdv")
+        dqdv = cell.dqdv_df
+
+        plotted: list[int] = []
+        for cycle in _resolve_cycles(cell, cycles):
+            color = _cycle_color(cycle)
+            drew_any = False
+            for side in ("ch", "dis"):
+                v_key = (cycle, side, v_name)
+                y_key = (cycle, side, dqdv_name)
+                if v_key not in dqdv.columns or y_key not in dqdv.columns:
+                    continue
+                v = dqdv[v_key].dropna()
+                y = dqdv[y_key].dropna()
+                if v.empty or y.empty:
+                    continue
+                ax.plot(v, y, color=color, linewidth=0.9)
+                drew_any = True
+            if drew_any:
+                plotted.append(cycle)
+
+        ax.set_xlabel("Voltage [V]")
+        ax.set_ylabel("dQ/dV [mAh/g/V]")
+        ax.set_title(cell.name)
+        _add_cycle_legend(ax, plotted)
+
+    fig.tight_layout()
+    return fig

--- a/src/toyo_battery/plotting/matplotlib_backend.py
+++ b/src/toyo_battery/plotting/matplotlib_backend.py
@@ -188,11 +188,13 @@ def plot_chdis(
                 q_key = (cycle, side, q_name)
                 if v_key not in chdis.columns or q_key not in chdis.columns:
                     continue
-                v = chdis[v_key].dropna()
-                q = chdis[q_key].dropna()
-                if v.empty or q.empty:
+                # Drop NaNs jointly so x/y stay positionally aligned; per-column
+                # dropna would silently misplot if the two columns ever have
+                # asymmetric NaN patterns.
+                pair = chdis[[q_key, v_key]].dropna()
+                if pair.empty:
                     continue
-                ax.plot(q, v, color=color, linewidth=0.9)
+                ax.plot(pair[q_key], pair[v_key], color=color, linewidth=0.9)
                 drew_any = True
             if drew_any:
                 plotted.append(cycle)
@@ -208,6 +210,11 @@ def plot_chdis(
 
 def plot_cycle(cells: Sequence[Cell]) -> Figure:
     """Per-cycle discharge capacity (left Y) and Coulombic efficiency (right Y).
+
+    Unlike :func:`plot_chdis` / :func:`plot_dqdv`, this function has no
+    ``cycles=`` parameter: the whole point of a cycle plot is the
+    capacity-vs-cycle trajectory, and slicing out cycles would break the
+    trend lines rather than filter them.
 
     Parameters
     ----------
@@ -305,11 +312,11 @@ def plot_dqdv(
                 y_key = (cycle, side, dqdv_name)
                 if v_key not in dqdv.columns or y_key not in dqdv.columns:
                     continue
-                v = dqdv[v_key].dropna()
-                y = dqdv[y_key].dropna()
-                if v.empty or y.empty:
+                # Joint dropna — see plot_chdis for the rationale.
+                pair = dqdv[[v_key, y_key]].dropna()
+                if pair.empty:
                     continue
-                ax.plot(v, y, color=color, linewidth=0.9)
+                ax.plot(pair[v_key], pair[y_key], color=color, linewidth=0.9)
                 drew_any = True
             if drew_any:
                 plotted.append(cycle)

--- a/src/toyo_battery/plotting/matplotlib_backend.py
+++ b/src/toyo_battery/plotting/matplotlib_backend.py
@@ -45,6 +45,11 @@ from toyo_battery.io.schema import ColumnLang
 _CYCLE_COLOR_FIRST = "red"
 _CYCLE_COLOR_OTHER = "black"
 
+# Per-subplot size (inches) used when building the grid. Pinned here so a
+# tweak to the default layout touches one line rather than three.
+_SUBPLOT_W_IN = 5.0
+_SUBPLOT_H_IN = 4.0
+
 _QUANTITY_KEYS_JA: dict[str, str] = {
     "voltage": "電圧",
     "capacity": "電気量",
@@ -115,7 +120,7 @@ def _build_grid(n: int) -> tuple[Figure, list[Axes]]:
     fig, axes_array = plt.subplots(
         nrows,
         ncols,
-        figsize=(5 * ncols, 4 * nrows),
+        figsize=(_SUBPLOT_W_IN * ncols, _SUBPLOT_H_IN * nrows),
         squeeze=False,
     )
     flat: list[Axes] = [ax for row in axes_array for ax in row]
@@ -268,9 +273,10 @@ def plot_dqdv(
         One or more :class:`Cell` instances. One subplot per cell.
     cycles
         Cycles to include. ``None`` plots every cycle present in each
-        cell's ``cap_df``. Cycles missing from a given cell's
-        ``dqdv_df`` (e.g. degenerate segments that collapse to an
-        all-NaN column) are skipped silently for that cell.
+        cell's ``cap_df.index`` (the authoritative cycle inventory);
+        cycles whose ``dqdv_df`` columns collapsed to all-NaN (e.g.
+        ``ipnum < window_length`` for a narrow-voltage segment) are
+        skipped silently for that cell.
 
     Returns
     -------

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -19,14 +19,20 @@ import matplotlib
 matplotlib.use("Agg")
 
 from matplotlib.axes import Axes
+from matplotlib.colors import to_rgba
 from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
 
 from toyo_battery.core.cell import Cell
+from toyo_battery.io.schema import ColumnLang
 from toyo_battery.plotting.matplotlib_backend import (
     plot_chdis,
     plot_cycle,
     plot_dqdv,
 )
+
+_RED = to_rgba("red")
+_BLACK = to_rgba("black")
 
 
 def _visible(fig: Figure) -> list[Axes]:
@@ -38,11 +44,18 @@ def _first_visible(fig: Figure) -> Axes:
     return _visible(fig)[0]
 
 
+def _line_rgba(line: Line2D) -> tuple[float, float, float, float]:
+    """Normalize a Line2D color to an RGBA tuple so comparisons don't depend
+    on whether the backend stored it as a name, hex string, or tuple.
+    """
+    return to_rgba(line.get_color())
+
+
 def _linear_cell(
     *,
     name: str = "synthetic",
     n_cycles: int = 2,
-    column_lang: str = "ja",
+    column_lang: ColumnLang = "ja",
     n_points: int = 200,
     v_lo: float = 3.0,
     v_hi: float = 4.2,
@@ -66,7 +79,7 @@ def _linear_cell(
     else:
         columns = ["cycle", "mode", "state", "voltage", "capacity"]
     raw = pd.DataFrame(rows, columns=columns)
-    return Cell(name=name, mass_g=0.001, raw_df=raw, column_lang=column_lang)  # type: ignore[arg-type]
+    return Cell(name=name, mass_g=0.001, raw_df=raw, column_lang=column_lang)
 
 
 def test_plot_chdis_returns_figure_with_one_axes_per_cell() -> None:
@@ -95,9 +108,9 @@ def test_plot_chdis_cycle_1_red_others_black() -> None:
     ax = _first_visible(fig)
     # 2 cycles * 2 sides (ch + dis) = 4 lines
     assert len(ax.lines) == 4
-    colors = [line.get_color() for line in ax.lines]
-    assert colors.count("red") == 2
-    assert colors.count("black") == 2
+    colors = [_line_rgba(line) for line in ax.lines]
+    assert colors.count(_RED) == 2
+    assert colors.count(_BLACK) == 2
 
 
 def test_plot_chdis_respects_cycles_filter() -> None:
@@ -108,7 +121,7 @@ def test_plot_chdis_respects_cycles_filter() -> None:
     ax = _first_visible(fig)
     # Only cycle 2 -> 1 cycle * 2 sides = 2 lines, all black.
     assert len(ax.lines) == 2
-    assert all(line.get_color() == "black" for line in ax.lines)
+    assert all(_line_rgba(line) == _BLACK for line in ax.lines)
 
 
 def test_plot_chdis_default_cycles_covers_all_available() -> None:
@@ -119,9 +132,9 @@ def test_plot_chdis_default_cycles_covers_all_available() -> None:
     ax = _first_visible(fig)
     # 3 cycles * 2 sides = 6 lines; cycle 1 red (2), others black (4).
     assert len(ax.lines) == 6
-    colors = [line.get_color() for line in ax.lines]
-    assert colors.count("red") == 2
-    assert colors.count("black") == 4
+    colors = [_line_rgba(line) for line in ax.lines]
+    assert colors.count(_RED) == 2
+    assert colors.count(_BLACK) == 4
 
 
 def test_plot_cycle_dual_y_has_two_y_axes() -> None:
@@ -130,14 +143,33 @@ def test_plot_cycle_dual_y_has_two_y_axes() -> None:
 
     fig = plot_cycle([cell_a, cell_b])
 
-    # Two cells, each gets a primary + twin Axes -> 4 total.
-    assert len(fig.axes) == 4
+    # Assertions pin axis *identity* via their ylabels rather than
+    # counting total axes, which is more robust if matplotlib changes
+    # how twins are enumerated.
     primaries = [a for a in fig.axes if a.get_ylabel() == "Discharge capacity [mAh/g]"]
     twins = [a for a in fig.axes if a.get_ylabel() == "Coulombic efficiency [%]"]
     assert len(primaries) == 2
     assert len(twins) == 2
     for ax in primaries:
         assert ax.get_xlabel() == "Cycle"
+
+
+def test_plot_cycle_wires_q_dis_to_primary_and_ce_to_twin() -> None:
+    """Data-to-axis regression guard: ``q_dis`` must be on the primary
+    axis and ``ce`` on the twin. A silent swap would be visually
+    plausible but numerically catastrophic.
+    """
+    cell = _linear_cell(name="cell_A", n_cycles=3)
+
+    fig = plot_cycle([cell])
+
+    primary = next(a for a in fig.axes if a.get_ylabel() == "Discharge capacity [mAh/g]")
+    twin = next(a for a in fig.axes if a.get_ylabel() == "Coulombic efficiency [%]")
+    # Single line per axis (q_dis or ce against cycle).
+    np.testing.assert_allclose(
+        primary.lines[0].get_ydata(), cell.cap_df["q_dis"].to_numpy()
+    )
+    np.testing.assert_allclose(twin.lines[0].get_ydata(), cell.cap_df["ce"].to_numpy())
 
 
 def test_plot_dqdv_axis_labels_english_even_for_ja_cell() -> None:
@@ -182,7 +214,23 @@ def test_plot_chdis_missing_cycle_in_filter_is_skipped_silently() -> None:
 
     ax = _first_visible(fig)
     assert len(ax.lines) == 0
-    assert ax.get_title() == "synthetic"
+
+
+def test_plot_chdis_cycles_filter_spans_cells_with_different_cycle_counts() -> None:
+    """A shared ``cycles=[1, 2, 5]`` call on cells with different cycle
+    inventories: each cell keeps only the cycles it actually has, so per-cell
+    line counts reflect per-cell availability (2 sides per cycle).
+    """
+    small = _linear_cell(name="small", n_cycles=2)  # has cycles {1, 2}
+    large = _linear_cell(name="large", n_cycles=6)  # has cycles {1..6}
+
+    fig = plot_chdis([small, large], cycles=[1, 2, 5])
+
+    axes_by_title = {ax.get_title(): ax for ax in _visible(fig)}
+    # small only has {1, 2} of the requested {1, 2, 5} -> 2 cycles * 2 sides = 4.
+    assert len(axes_by_title["small"].lines) == 4
+    # large has {1, 2, 5} -> 3 cycles * 2 sides = 6.
+    assert len(axes_by_title["large"].lines) == 6
 
 
 def test_column_lang_en_cell_plots_successfully() -> None:

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -166,9 +166,7 @@ def test_plot_cycle_wires_q_dis_to_primary_and_ce_to_twin() -> None:
     primary = next(a for a in fig.axes if a.get_ylabel() == "Discharge capacity [mAh/g]")
     twin = next(a for a in fig.axes if a.get_ylabel() == "Coulombic efficiency [%]")
     # Single line per axis (q_dis or ce against cycle).
-    np.testing.assert_allclose(
-        primary.lines[0].get_ydata(), cell.cap_df["q_dis"].to_numpy()
-    )
+    np.testing.assert_allclose(primary.lines[0].get_ydata(), cell.cap_df["q_dis"].to_numpy())
     np.testing.assert_allclose(twin.lines[0].get_ydata(), cell.cap_df["ce"].to_numpy())
 
 

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -1,0 +1,201 @@
+"""Tests for :mod:`toyo_battery.plotting.matplotlib_backend`.
+
+The backend is exercised with small in-memory :class:`Cell` instances
+(mirroring :mod:`test_dqdv`) so the tests run without reading real TOYO
+data. Matplotlib is imported via :func:`pytest.importorskip` so the
+suite is silently skipped when the ``[plot]`` extra is not installed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("matplotlib")
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+from toyo_battery.core.cell import Cell
+from toyo_battery.plotting.matplotlib_backend import (
+    plot_chdis,
+    plot_cycle,
+    plot_dqdv,
+)
+
+
+def _visible(fig: Figure) -> list[Axes]:
+    """Return the visible Axes on ``fig`` (hides the grid fillers)."""
+    return [ax for ax in fig.axes if ax.get_visible()]
+
+
+def _first_visible(fig: Figure) -> Axes:
+    return _visible(fig)[0]
+
+
+def _linear_cell(
+    *,
+    name: str = "synthetic",
+    n_cycles: int = 2,
+    column_lang: str = "ja",
+    n_points: int = 200,
+    v_lo: float = 3.0,
+    v_hi: float = 4.2,
+) -> Cell:
+    """Build a :class:`Cell` with ``n_cycles`` linear charge+discharge ramps.
+
+    Wide voltage span (1.2 V default) so dQ/dV interpolation
+    (``ipnum = int(100 * 1.2) = 120``) comfortably exceeds the default
+    Savitzky-Golay window length (11) and produces populated columns.
+    """
+    rows: list[tuple[int, str, str, float, float]] = []
+    v_ch = np.linspace(v_lo, v_hi, n_points)
+    q_ch = 400.0 * (v_ch - v_lo)
+    v_dis = np.linspace(v_hi, v_lo, n_points)
+    q_dis = 400.0 * (v_hi - v_dis)
+    for cycle in range(1, n_cycles + 1):
+        rows += [(cycle, "1", "充電", float(vi), float(qi)) for vi, qi in zip(v_ch, q_ch)]
+        rows += [(cycle, "1", "放電", float(vi), float(qi)) for vi, qi in zip(v_dis, q_dis)]
+    if column_lang == "ja":
+        columns = ["サイクル", "モード", "状態", "電圧", "電気量"]
+    else:
+        columns = ["cycle", "mode", "state", "voltage", "capacity"]
+    raw = pd.DataFrame(rows, columns=columns)
+    return Cell(name=name, mass_g=0.001, raw_df=raw, column_lang=column_lang)  # type: ignore[arg-type]
+
+
+def test_plot_chdis_returns_figure_with_one_axes_per_cell() -> None:
+    cell_a = _linear_cell(name="cell_A", n_cycles=2)
+    cell_b = _linear_cell(name="cell_B", n_cycles=2)
+
+    fig = plot_chdis([cell_a, cell_b])
+
+    visible_axes = _visible(fig)
+    assert len(visible_axes) == 2
+    titles = {ax.get_title() for ax in visible_axes}
+    assert titles == {"cell_A", "cell_B"}
+    for ax in visible_axes:
+        assert ax.get_xlabel() == "Capacity [mAh/g]"
+        assert ax.get_ylabel() == "Voltage [V]"
+
+
+def test_plot_chdis_cycle_1_red_others_black() -> None:
+    """Cycle 1 lines are red; cycle 2+ lines are black. Pins the legacy
+    TOYO coloring convention called out in issue #8.
+    """
+    cell = _linear_cell(n_cycles=2)
+
+    fig = plot_chdis([cell])
+
+    ax = _first_visible(fig)
+    # 2 cycles * 2 sides (ch + dis) = 4 lines
+    assert len(ax.lines) == 4
+    colors = [line.get_color() for line in ax.lines]
+    assert colors.count("red") == 2
+    assert colors.count("black") == 2
+
+
+def test_plot_chdis_respects_cycles_filter() -> None:
+    cell = _linear_cell(n_cycles=3)
+
+    fig = plot_chdis([cell], cycles=[2])
+
+    ax = _first_visible(fig)
+    # Only cycle 2 -> 1 cycle * 2 sides = 2 lines, all black.
+    assert len(ax.lines) == 2
+    assert all(line.get_color() == "black" for line in ax.lines)
+
+
+def test_plot_chdis_default_cycles_covers_all_available() -> None:
+    cell = _linear_cell(n_cycles=3)
+
+    fig = plot_chdis([cell])
+
+    ax = _first_visible(fig)
+    # 3 cycles * 2 sides = 6 lines; cycle 1 red (2), others black (4).
+    assert len(ax.lines) == 6
+    colors = [line.get_color() for line in ax.lines]
+    assert colors.count("red") == 2
+    assert colors.count("black") == 4
+
+
+def test_plot_cycle_dual_y_has_two_y_axes() -> None:
+    cell_a = _linear_cell(name="cell_A", n_cycles=3)
+    cell_b = _linear_cell(name="cell_B", n_cycles=3)
+
+    fig = plot_cycle([cell_a, cell_b])
+
+    # Two cells, each gets a primary + twin Axes -> 4 total.
+    assert len(fig.axes) == 4
+    primaries = [a for a in fig.axes if a.get_ylabel() == "Discharge capacity [mAh/g]"]
+    twins = [a for a in fig.axes if a.get_ylabel() == "Coulombic efficiency [%]"]
+    assert len(primaries) == 2
+    assert len(twins) == 2
+    for ax in primaries:
+        assert ax.get_xlabel() == "Cycle"
+
+
+def test_plot_dqdv_axis_labels_english_even_for_ja_cell() -> None:
+    """Labels are fixed English regardless of ``cell.column_lang``."""
+    cell = _linear_cell(column_lang="ja")
+
+    fig = plot_dqdv([cell])
+
+    ax = _first_visible(fig)
+    assert ax.get_xlabel() == "Voltage [V]"
+    assert ax.get_ylabel() == "dQ/dV [mAh/g/V]"
+
+
+def test_plot_dqdv_plots_both_ch_and_dis_sides() -> None:
+    """Both charge (positive dQ/dV) and discharge (negative) branches render."""
+    cell = _linear_cell(n_cycles=1)
+
+    fig = plot_dqdv([cell])
+
+    ax = _first_visible(fig)
+    # 1 cycle * 2 sides = 2 lines (both colored red because cycle 1).
+    assert len(ax.lines) == 2
+    y_medians = [float(np.median(line.get_ydata())) for line in ax.lines]
+    assert any(m > 0 for m in y_medians), "expected a positive-median charge branch"
+    assert any(m < 0 for m in y_medians), "expected a negative-median discharge branch"
+
+
+def test_empty_cells_raises_valueerror() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        plot_chdis([])
+    with pytest.raises(ValueError, match="non-empty"):
+        plot_cycle([])
+    with pytest.raises(ValueError, match="non-empty"):
+        plot_dqdv([])
+
+
+def test_plot_chdis_missing_cycle_in_filter_is_skipped_silently() -> None:
+    """Requesting a cycle not present in a cell yields no lines — no raise."""
+    cell = _linear_cell(n_cycles=1)
+
+    fig = plot_chdis([cell], cycles=[99])
+
+    ax = _first_visible(fig)
+    assert len(ax.lines) == 0
+    assert ax.get_title() == "synthetic"
+
+
+def test_column_lang_en_cell_plots_successfully() -> None:
+    """A Cell built with ``column_lang='en'`` still plots (regression guard
+    for the internal ``_quantity`` lookup).
+    """
+    cell = _linear_cell(column_lang="en", n_cycles=2)
+
+    fig_chdis = plot_chdis([cell])
+    fig_dqdv = plot_dqdv([cell])
+
+    ax_chdis = _first_visible(fig_chdis)
+    ax_dqdv = _first_visible(fig_dqdv)
+    # 2 cycles * 2 sides = 4 lines per figure.
+    assert len(ax_chdis.lines) == 4
+    assert len(ax_dqdv.lines) == 4

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -8,6 +8,8 @@ suite is silently skipped when the ``[plot]`` extra is not installed.
 
 from __future__ import annotations
 
+from collections.abc import Generator
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -18,6 +20,7 @@ import matplotlib
 
 matplotlib.use("Agg")
 
+import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.colors import to_rgba
 from matplotlib.figure import Figure
@@ -33,6 +36,17 @@ from toyo_battery.plotting.matplotlib_backend import (
 
 _RED = to_rgba("red")
 _BLACK = to_rgba("black")
+
+
+@pytest.fixture(autouse=True)
+def _close_figures() -> Generator[None, None, None]:
+    """Close all matplotlib figures after each test.
+
+    Without this, the ~dozen tests in this module each leak a Figure and
+    the suite eventually trips matplotlib's ``max_open_warning``.
+    """
+    yield
+    plt.close("all")
 
 
 def _visible(fig: Figure) -> list[Axes]:

--- a/uv.lock
+++ b/uv.lock
@@ -2849,6 +2849,8 @@ smb = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib", version = "3.10.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mypy", version = "1.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "mypy", version = "1.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pandas-stubs", version = "2.2.2.240807", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -2885,6 +2887,7 @@ provides-extras = ["plot", "plotly", "gui", "smb", "cli", "origin", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "matplotlib", specifier = ">=3.7" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "pandas-stubs" },
     { name = "pytest", specifier = ">=8" },


### PR DESCRIPTION
## Summary

Implements `toyo_battery.plotting.matplotlib_backend`, replacing the P2 stub that raised `NotImplementedError`. Closes #8.

Three public functions, each returning a `matplotlib.figure.Figure` (caller handles `savefig`):

- **`plot_chdis(cells, cycles=None)`** — charge/discharge V-vs-Q curves; cycle 1 red, other cycles black (legacy TOYO convention).
- **`plot_cycle(cells)`** — dual-Y per-cycle: discharge capacity (left, `cap_df["q_dis"]`) + Coulombic efficiency (right, `cap_df["ce"]`).
- **`plot_dqdv(cells, cycles=None)`** — dQ/dV-vs-V curves with the same cycle-1-red / others-black coloring; discharge dQ/dV stays negative by construction (sign convention preserved, verified by existing `test_discharge_segment_yields_negative_dqdv`).

### Design decisions (user-confirmed during planning)

- **Multi-cell layout**: one Axes per `Cell` in a near-square grid (1×N for N≤3, otherwise `ncols = ceil(sqrt(N))`). Unused grid cells are hidden via `set_visible(False)`.
- **Default `cycles=None`**: plots every cycle present in each cell's `cap_df.index`.
- **Labels / legend**: fixed English regardless of `cell.column_lang`, to sidestep matplotlib JP-font configuration issues. MultiIndex lookups still go through an internal `_quantity` helper so both JA- and EN-language cells plot correctly.
- **Empty-cells guard**: raises `ValueError` loudly rather than returning a blank figure.
- **Missing cycles in filter**: skipped silently per cell (enables a shared `cycles=[1, 5, 10]` call across cells with different cycle counts).

### Supporting changes

- Added `matplotlib>=3.7` to the `dev` dependency-group in `pyproject.toml` so CI can exercise the new backend. Tests also self-skip via `pytest.importorskip("matplotlib")` when the extra is absent.

## Test plan

- [x] `pytest tests/test_matplotlib_backend.py` — 10 new tests pass (Figure shape, cycle-1-red behavior, `cycles` filter, dual-Y axis labels, JA/EN cells, empty-input guard, missing-cycle tolerance, positive-charge / negative-discharge dQ/dV).
- [x] Full suite `pytest` — 122/122 pass (no regressions in chdis / capacity / dqdv / reader / stats / smoke).
- [x] `ruff check src tests` — clean.
- [x] `mypy src/toyo_battery/plotting` — clean (strict mode).
- [ ] Manual smoke: build a Cell from real TOYO data, call all three functions, inspect saved PNGs for sanity (charge branch positive dQ/dV, discharge branch negative dQ/dV, etc.).

https://claude.ai/code/session_01EpRdtTYsqdHf9hghFeja5Q