### PR TITLE
feat(plotting): Plotly backend (mirrors matplotlib API)

### DIFF
--- a/src/toyo_battery/plotting/plotly_backend.py
+++ b/src/toyo_battery/plotting/plotly_backend.py
@@ -1,7 +1,379 @@
-"""Plotly plotting backend. Requires the [plotly] extra."""
+"""Plotly plotting backend. Requires the ``[plotly]`` extra.
+
+Mirrors the :mod:`toyo_battery.plotting.matplotlib_backend` API — three
+user-facing functions that accept one or more :class:`toyo_battery.core.cell.Cell`
+instances and return a :class:`plotly.graph_objects.Figure` (the caller
+handles ``fig.write_image(...)`` / ``fig.write_html(...)``):
+
+- :func:`plot_chdis` — charge/discharge V-vs-Q curves; cycle 1 drawn in
+  red, all others in black (TOYO legacy convention).
+- :func:`plot_cycle` — per-cycle dual-Y plot: discharge capacity on the
+  left Y axis, Coulombic efficiency on the right Y axis.
+- :func:`plot_dqdv` — dQ/dV-vs-V curves, same cycle-1-red / others-black
+  coloring as :func:`plot_chdis`. Discharge dQ/dV is **negative** by
+  construction; raw signed values are plotted.
+
+Grid layout matches the matplotlib backend verbatim: 1xN for ``N<=3``;
+otherwise ``ncols = ceil(sqrt(N))``, ``nrows = ceil(N/ncols)``. Labels
+and legend text are always English, independent of each cell's
+``column_lang``.
+
+Plotly is imported unconditionally at module level: this module is only
+imported when plotly plotting is actually needed, and a missing extra
+surfaces as a standard ``ImportError`` from the import line.
+"""
 
 from __future__ import annotations
 
+import math
+from collections.abc import Sequence
 
-def plot_chdis(*args: object, **kwargs: object) -> object:
-    raise NotImplementedError("plotly plot_chdis will be implemented in P4")
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+from toyo_battery.core.cell import Cell
+from toyo_battery.io.schema import ColumnLang
+
+_CYCLE_COLOR_FIRST = "red"
+_CYCLE_COLOR_OTHER = "black"
+
+# Per-subplot size (pixels) used when sizing the figure. Pinned here so a
+# tweak to the default layout touches one line rather than three.
+_SUBPLOT_W_PX = 500
+_SUBPLOT_H_PX = 400
+
+# Colors mirroring the matplotlib ``C0`` / ``C3`` default-cycle entries
+# used in ``plot_cycle``. Pinning explicit hex values keeps the Plotly
+# output visually close to the matplotlib output even though the two
+# backends have different default color palettes.
+_C0_BLUE = "#1f77b4"
+_C3_RED = "#d62728"
+
+_QUANTITY_KEYS_JA: dict[str, str] = {
+    "voltage": "電圧",
+    "capacity": "電気量",
+    "dqdv": "dQ/dV",
+}
+_QUANTITY_KEYS_EN: dict[str, str] = {
+    "voltage": "voltage",
+    "capacity": "capacity",
+    "dqdv": "dq_dv",
+}
+
+
+def _quantity(column_lang: ColumnLang, key: str) -> str:
+    """Map a logical key (``"voltage"`` / ``"capacity"`` / ``"dqdv"``) to the
+    ``quantity``-level MultiIndex label used by a cell with the given
+    ``column_lang``.
+    """
+    table = _QUANTITY_KEYS_JA if column_lang == "ja" else _QUANTITY_KEYS_EN
+    return table[key]
+
+
+def _subplot_grid(n: int) -> tuple[int, int]:
+    """Return ``(nrows, ncols)`` for ``n`` subplots.
+
+    ``n <= 3`` → a single row. Larger counts fall back to a near-square
+    grid: ``ncols = ceil(sqrt(n))``, ``nrows = ceil(n / ncols)``.
+    """
+    if n <= 3:
+        return (1, max(n, 1))
+    ncols = math.ceil(math.sqrt(n))
+    nrows = math.ceil(n / ncols)
+    return (nrows, ncols)
+
+
+def _resolve_cycles(cell: Cell, cycles: Sequence[int] | None) -> list[int]:
+    """Return the cycles to plot for ``cell``.
+
+    ``cycles=None`` yields every cycle present in ``cell.cap_df.index``.
+    An explicit sequence is intersected with the available cycles while
+    preserving caller order; cycles missing from the cell are dropped
+    silently so a shared ``cycles=[1, 5, 10]`` call can span cells with
+    different cycle counts without raising.
+    """
+    available = {int(c) for c in cell.cap_df.index}
+    if cycles is None:
+        return sorted(available)
+    return [int(c) for c in cycles if int(c) in available]
+
+
+def _check_nonempty(cells: Sequence[Cell]) -> None:
+    """Raise ``ValueError`` if ``cells`` is empty.
+
+    Fails loudly rather than returning a blank figure — a zero-cell call
+    is almost always a caller bug.
+    """
+    if len(cells) == 0:
+        raise ValueError("cells must be a non-empty sequence of Cell instances")
+
+
+def _cycle_color(cycle: int) -> str:
+    return _CYCLE_COLOR_FIRST if cycle == 1 else _CYCLE_COLOR_OTHER
+
+
+def _cell_rowcol(idx: int, ncols: int) -> tuple[int, int]:
+    """Return ``(row, col)`` (1-indexed) for the ``idx``-th cell in a grid
+    with ``ncols`` columns.
+    """
+    return (idx // ncols + 1, idx % ncols + 1)
+
+
+def _build_figure(n: int, *, secondary_y: bool = False) -> tuple[go.Figure, int, int]:
+    """Create a subplot figure sized for ``n`` cells.
+
+    Returns the figure and the ``(nrows, ncols)`` of the grid so callers
+    can map cell index → (row, col).
+    """
+    nrows, ncols = _subplot_grid(n)
+    specs: list[list[dict[str, bool]]] | None
+    if secondary_y:
+        specs = [[{"secondary_y": True} for _ in range(ncols)] for _ in range(nrows)]
+    else:
+        specs = None
+    fig = make_subplots(rows=nrows, cols=ncols, specs=specs)
+    fig.update_layout(
+        width=_SUBPLOT_W_PX * ncols,
+        height=_SUBPLOT_H_PX * nrows,
+        showlegend=False,
+    )
+    return fig, nrows, ncols
+
+
+def plot_chdis(
+    cells: Sequence[Cell],
+    cycles: Sequence[int] | None = None,
+) -> go.Figure:
+    """Charge/discharge curves (capacity on X, voltage on Y).
+
+    Parameters
+    ----------
+    cells
+        One or more :class:`Cell` instances. One subplot is drawn per
+        cell.
+    cycles
+        Cycles to include. ``None`` (default) plots every cycle present
+        in each cell's ``cap_df``. When a sequence is given, cycles not
+        present in a given cell are skipped silently for that cell only.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        A new Plotly figure. The caller is responsible for
+        ``write_image`` / ``write_html``.
+
+    Raises
+    ------
+    ValueError
+        If ``cells`` is empty.
+    """
+    _check_nonempty(cells)
+    fig, _nrows, ncols = _build_figure(len(cells))
+
+    for idx, cell in enumerate(cells):
+        row, col = _cell_rowcol(idx, ncols)
+        v_name = _quantity(cell.column_lang, "voltage")
+        q_name = _quantity(cell.column_lang, "capacity")
+        chdis = cell.chdis_df
+
+        for cycle in _resolve_cycles(cell, cycles):
+            color = _cycle_color(cycle)
+            for side in ("ch", "dis"):
+                v_key = (cycle, side, v_name)
+                q_key = (cycle, side, q_name)
+                if v_key not in chdis.columns or q_key not in chdis.columns:
+                    continue
+                # Drop NaNs jointly so x/y stay positionally aligned; per-column
+                # dropna would silently misplot if the two columns ever have
+                # asymmetric NaN patterns.
+                pair = chdis[[q_key, v_key]].dropna()
+                if pair.empty:
+                    continue
+                fig.add_trace(
+                    go.Scatter(
+                        x=pair[q_key],
+                        y=pair[v_key],
+                        mode="lines",
+                        line={"color": color, "width": 1.2},
+                        name=f"cycle {cycle}",
+                        showlegend=False,
+                    ),
+                    row=row,
+                    col=col,
+                )
+
+        fig.update_xaxes(title_text="Capacity [mAh/g]", row=row, col=col)
+        fig.update_yaxes(title_text="Voltage [V]", row=row, col=col)
+        _annotate_title(fig, cell.name, row, col, ncols)
+
+    return fig
+
+
+def plot_cycle(cells: Sequence[Cell]) -> go.Figure:
+    """Per-cycle discharge capacity (left Y) and Coulombic efficiency (right Y).
+
+    Unlike :func:`plot_chdis` / :func:`plot_dqdv`, this function has no
+    ``cycles=`` parameter: the whole point of a cycle plot is the
+    capacity-vs-cycle trajectory, and slicing out cycles would break the
+    trend lines rather than filter them.
+
+    Parameters
+    ----------
+    cells
+        One or more :class:`Cell` instances. One subplot is drawn per
+        cell, each with a secondary Y axis for efficiency.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        A new Plotly figure.
+
+    Raises
+    ------
+    ValueError
+        If ``cells`` is empty.
+    """
+    _check_nonempty(cells)
+    fig, _nrows, ncols = _build_figure(len(cells), secondary_y=True)
+
+    for idx, cell in enumerate(cells):
+        row, col = _cell_rowcol(idx, ncols)
+        cap = cell.cap_df
+
+        fig.add_trace(
+            go.Scatter(
+                x=cap.index,
+                y=cap["q_dis"],
+                mode="lines+markers",
+                marker={"symbol": "circle", "color": _C0_BLUE},
+                line={"color": _C0_BLUE},
+                name="Discharge capacity",
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+            secondary_y=False,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=cap.index,
+                y=cap["ce"],
+                mode="lines+markers",
+                marker={"symbol": "square", "color": _C3_RED},
+                line={"color": _C3_RED, "dash": "dash"},
+                name="Coulombic efficiency",
+                showlegend=False,
+            ),
+            row=row,
+            col=col,
+            secondary_y=True,
+        )
+
+        fig.update_xaxes(title_text="Cycle", row=row, col=col)
+        fig.update_yaxes(
+            title_text="Discharge capacity [mAh/g]", row=row, col=col, secondary_y=False
+        )
+        fig.update_yaxes(title_text="Coulombic efficiency [%]", row=row, col=col, secondary_y=True)
+        _annotate_title(fig, cell.name, row, col, ncols)
+
+    return fig
+
+
+def plot_dqdv(
+    cells: Sequence[Cell],
+    cycles: Sequence[int] | None = None,
+) -> go.Figure:
+    """dQ/dV vs voltage, cycle 1 red / other cycles black.
+
+    Discharge dQ/dV is negative by construction (see
+    :mod:`toyo_battery.core.dqdv`); the raw signed values are plotted so
+    charge and discharge branches live in different half-planes.
+
+    Parameters
+    ----------
+    cells
+        One or more :class:`Cell` instances. One subplot per cell.
+    cycles
+        Cycles to include. ``None`` plots every cycle present in each
+        cell's ``cap_df.index`` (the authoritative cycle inventory);
+        cycles whose ``dqdv_df`` columns collapsed to all-NaN (e.g.
+        ``ipnum < window_length`` for a narrow-voltage segment) are
+        skipped silently for that cell.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        A new Plotly figure.
+
+    Raises
+    ------
+    ValueError
+        If ``cells`` is empty.
+    """
+    _check_nonempty(cells)
+    fig, _nrows, ncols = _build_figure(len(cells))
+
+    for idx, cell in enumerate(cells):
+        row, col = _cell_rowcol(idx, ncols)
+        v_name = _quantity(cell.column_lang, "voltage")
+        dqdv_name = _quantity(cell.column_lang, "dqdv")
+        dqdv = cell.dqdv_df
+
+        for cycle in _resolve_cycles(cell, cycles):
+            color = _cycle_color(cycle)
+            for side in ("ch", "dis"):
+                v_key = (cycle, side, v_name)
+                y_key = (cycle, side, dqdv_name)
+                if v_key not in dqdv.columns or y_key not in dqdv.columns:
+                    continue
+                # Joint dropna — see plot_chdis for the rationale.
+                pair = dqdv[[v_key, y_key]].dropna()
+                if pair.empty:
+                    continue
+                fig.add_trace(
+                    go.Scatter(
+                        x=pair[v_key],
+                        y=pair[y_key],
+                        mode="lines",
+                        line={"color": color, "width": 1.2},
+                        name=f"cycle {cycle} {side}",
+                        showlegend=False,
+                    ),
+                    row=row,
+                    col=col,
+                )
+
+        fig.update_xaxes(title_text="Voltage [V]", row=row, col=col)
+        fig.update_yaxes(title_text="dQ/dV [mAh/g/V]", row=row, col=col)
+        _annotate_title(fig, cell.name, row, col, ncols)
+
+    return fig
+
+
+def _annotate_title(fig: go.Figure, title: str, row: int, col: int, ncols: int) -> None:
+    """Attach a per-subplot title by updating the Plotly-generated annotation.
+
+    ``make_subplots(subplot_titles=...)`` is the standard path, but the
+    title list must be set at figure construction; since we build the
+    figure generically in :func:`_build_figure` we set the per-cell title
+    after the fact by targeting the subplot-title annotation that Plotly
+    creates for each ``(row, col)``. If no annotation exists yet (the
+    default when ``subplot_titles`` is unset), we append one positioned
+    above the appropriate subplot.
+    """
+    # Compute the subplot index in row-major order (1-indexed) — this is
+    # how Plotly names axes (``xaxis``, ``xaxis2``, ...).
+    subplot_idx = (row - 1) * ncols + col
+    xref = "x domain" if subplot_idx == 1 else f"x{subplot_idx} domain"
+    yref = "y domain" if subplot_idx == 1 else f"y{subplot_idx} domain"
+    fig.add_annotation(
+        x=0.5,
+        y=1.05,
+        xref=xref,
+        yref=yref,
+        text=title,
+        showarrow=False,
+        font={"size": 14},
+        xanchor="center",
+        yanchor="bottom",
+    )

--- a/tests/test_plotly_backend.py
+++ b/tests/test_plotly_backend.py
@@ -1,0 +1,251 @@
+"""Tests for :mod:`toyo_battery.plotting.plotly_backend`.
+
+Mirror of :mod:`test_matplotlib_backend` using in-memory :class:`Cell`
+instances. Plotly is imported via :func:`pytest.importorskip` so the
+suite is silently skipped when the ``[plotly]`` extra is not installed.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("plotly")
+
+import plotly.graph_objects as go
+
+from toyo_battery.core.cell import Cell
+from toyo_battery.io.schema import ColumnLang
+from toyo_battery.plotting.plotly_backend import (
+    plot_chdis,
+    plot_cycle,
+    plot_dqdv,
+)
+
+_RED = "red"
+_BLACK = "black"
+
+
+def _linear_cell(
+    *,
+    name: str = "synthetic",
+    n_cycles: int = 2,
+    column_lang: ColumnLang = "ja",
+    n_points: int = 200,
+    v_lo: float = 3.0,
+    v_hi: float = 4.2,
+) -> Cell:
+    """Build a :class:`Cell` with ``n_cycles`` linear charge+discharge ramps.
+
+    Wide voltage span (1.2 V default) so dQ/dV interpolation
+    (``ipnum = int(100 * 1.2) = 120``) comfortably exceeds the default
+    Savitzky-Golay window length (11) and produces populated columns.
+    """
+    rows: list[tuple[int, str, str, float, float]] = []
+    v_ch = np.linspace(v_lo, v_hi, n_points)
+    q_ch = 400.0 * (v_ch - v_lo)
+    v_dis = np.linspace(v_hi, v_lo, n_points)
+    q_dis = 400.0 * (v_hi - v_dis)
+    for cycle in range(1, n_cycles + 1):
+        rows += [(cycle, "1", "充電", float(vi), float(qi)) for vi, qi in zip(v_ch, q_ch)]
+        rows += [(cycle, "1", "放電", float(vi), float(qi)) for vi, qi in zip(v_dis, q_dis)]
+    if column_lang == "ja":
+        columns = ["サイクル", "モード", "状態", "電圧", "電気量"]
+    else:
+        columns = ["cycle", "mode", "state", "voltage", "capacity"]
+    raw = pd.DataFrame(rows, columns=columns)
+    return Cell(name=name, mass_g=0.001, raw_df=raw, column_lang=column_lang)
+
+
+def _expected_grid(n: int) -> tuple[int, int]:
+    """Mirror of the backend's grid formula (kept separate as a test guard)."""
+    if n <= 3:
+        return (1, max(n, 1))
+    ncols = math.ceil(math.sqrt(n))
+    nrows = math.ceil(n / ncols)
+    return (nrows, ncols)
+
+
+def _subplot_shape(fig: go.Figure) -> tuple[int, int]:
+    """Return ``(nrows, ncols)`` from the figure's grid_ref."""
+    grid_ref = fig._grid_ref  # plotly internal; stable across 5.x
+    nrows = len(grid_ref)
+    ncols = len(grid_ref[0])
+    return nrows, ncols
+
+
+def test_plot_chdis_returns_plotly_figure() -> None:
+    cell = _linear_cell(n_cycles=2)
+    fig = plot_chdis([cell])
+    assert isinstance(fig, go.Figure)
+
+
+def test_plot_cycle_returns_plotly_figure() -> None:
+    cell = _linear_cell(n_cycles=3)
+    fig = plot_cycle([cell])
+    assert isinstance(fig, go.Figure)
+
+
+def test_plot_dqdv_returns_plotly_figure() -> None:
+    cell = _linear_cell(n_cycles=2)
+    fig = plot_dqdv([cell])
+    assert isinstance(fig, go.Figure)
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4, 5])
+def test_grid_shape_matches_formula(n: int) -> None:
+    """Grid layout mirrors matplotlib: 1xN for N<=3, else near-square."""
+    cells = [_linear_cell(name=f"cell_{i}", n_cycles=2) for i in range(n)]
+    fig = plot_chdis(cells)
+    assert _subplot_shape(fig) == _expected_grid(n)
+
+
+def test_plot_chdis_cycle_1_red_others_black() -> None:
+    """Cycle 1 traces are red; cycle 2+ are black. Pins the TOYO convention."""
+    cell = _linear_cell(n_cycles=2)
+    fig = plot_chdis([cell])
+
+    # 2 cycles * 2 sides (ch + dis) = 4 traces
+    assert len(fig.data) == 4
+    colors = [trace.line.color for trace in fig.data]
+    assert colors.count(_RED) == 2
+    assert colors.count(_BLACK) == 2
+
+
+def test_plot_chdis_respects_cycles_filter() -> None:
+    """Requesting ``cycles=[1, 10]`` on a 3-cycle cell only plots cycle 1."""
+    cell = _linear_cell(n_cycles=3)
+
+    fig = plot_chdis([cell], cycles=[1, 10])
+
+    # Only cycle 1 is present (cycle 10 doesn't exist) -> 1 * 2 sides = 2 traces.
+    assert len(fig.data) == 2
+    assert all(trace.line.color == _RED for trace in fig.data)
+
+
+def test_plot_chdis_cycles_filter_exact_subset() -> None:
+    """cycles=[1, 3] on a 5-cycle cell plots exactly those two."""
+    cell = _linear_cell(n_cycles=5)
+
+    fig = plot_chdis([cell], cycles=[1, 3])
+
+    # 2 cycles * 2 sides = 4 traces; cycle 1 red (2), cycle 3 black (2).
+    assert len(fig.data) == 4
+    colors = [trace.line.color for trace in fig.data]
+    assert colors.count(_RED) == 2
+    assert colors.count(_BLACK) == 2
+
+
+def test_plot_cycle_has_two_y_axes_per_subplot() -> None:
+    """``plot_cycle`` uses make_subplots(secondary_y=True); verify both axes
+    exist for each cell subplot.
+    """
+    cell_a = _linear_cell(name="cell_A", n_cycles=3)
+    cell_b = _linear_cell(name="cell_B", n_cycles=3)
+    fig = plot_cycle([cell_a, cell_b])
+
+    # Each cell should have a primary and secondary y axis. Plotly names
+    # secondary axes with ``overlaying`` set to the primary. Count axes
+    # whose title matches each side.
+    primaries = [
+        ax
+        for ax in fig.layout
+        if ax.startswith("yaxis")
+        and getattr(fig.layout[ax], "title", None) is not None
+        and fig.layout[ax].title.text == "Discharge capacity [mAh/g]"
+    ]
+    secondaries = [
+        ax
+        for ax in fig.layout
+        if ax.startswith("yaxis")
+        and getattr(fig.layout[ax], "title", None) is not None
+        and fig.layout[ax].title.text == "Coulombic efficiency [%]"
+    ]
+    assert len(primaries) == 2
+    assert len(secondaries) == 2
+
+
+def test_plot_cycle_wires_q_dis_primary_and_ce_secondary() -> None:
+    """Regression guard: q_dis on primary Y, ce on secondary Y."""
+    cell = _linear_cell(name="cell_A", n_cycles=3)
+    fig = plot_cycle([cell])
+
+    # Primary-y trace: q_dis. Secondary-y trace: ce.
+    # Plotly encodes secondary-y as a trace on the secondary axis
+    # (``yaxis='y2'`` for the first subplot).
+    primary_traces = [t for t in fig.data if t.yaxis in (None, "y")]
+    secondary_traces = [t for t in fig.data if t.yaxis == "y2"]
+    assert len(primary_traces) == 1
+    assert len(secondary_traces) == 1
+    np.testing.assert_allclose(primary_traces[0].y, cell.cap_df["q_dis"].to_numpy())
+    np.testing.assert_allclose(secondary_traces[0].y, cell.cap_df["ce"].to_numpy())
+
+
+def test_plot_dqdv_discharge_traces_have_negative_values() -> None:
+    """Discharge dQ/dV is negative by construction; verify the sign
+    convention round-trips through the Plotly backend (raw signed
+    values, no flipping).
+    """
+    cell = _linear_cell(n_cycles=1)
+    fig = plot_dqdv([cell])
+
+    # 1 cycle * 2 sides = 2 traces.
+    assert len(fig.data) == 2
+    medians = [float(np.median(trace.y)) for trace in fig.data]
+    assert any(m > 0 for m in medians), "expected a positive-median charge branch"
+    assert any(m < 0 for m in medians), "expected a negative-median discharge branch"
+
+
+def test_plot_dqdv_english_labels_for_ja_cell() -> None:
+    """Labels are fixed English regardless of ``cell.column_lang``."""
+    cell = _linear_cell(column_lang="ja")
+    fig = plot_dqdv([cell])
+
+    # For a single-cell figure the axes are ``xaxis`` / ``yaxis``.
+    assert fig.layout.xaxis.title.text == "Voltage [V]"
+    assert fig.layout.yaxis.title.text == "dQ/dV [mAh/g/V]"
+
+
+def test_plot_chdis_axis_labels() -> None:
+    """chdis labels: x=Capacity, y=Voltage."""
+    cell = _linear_cell(n_cycles=2)
+    fig = plot_chdis([cell])
+
+    assert fig.layout.xaxis.title.text == "Capacity [mAh/g]"
+    assert fig.layout.yaxis.title.text == "Voltage [V]"
+
+
+def test_empty_cells_raises_valueerror() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        plot_chdis([])
+    with pytest.raises(ValueError, match="non-empty"):
+        plot_cycle([])
+    with pytest.raises(ValueError, match="non-empty"):
+        plot_dqdv([])
+
+
+def test_column_lang_en_cell_plots_successfully() -> None:
+    """A Cell built with ``column_lang='en'`` still plots."""
+    cell = _linear_cell(column_lang="en", n_cycles=2)
+
+    fig_chdis = plot_chdis([cell])
+    fig_dqdv = plot_dqdv([cell])
+
+    # 2 cycles * 2 sides = 4 traces per figure.
+    assert len(fig_chdis.data) == 4
+    assert len(fig_dqdv.data) == 4
+
+
+def test_write_image_smoke(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """End-to-end: fig.write_image succeeds via kaleido."""
+    pytest.importorskip("kaleido")
+    cell = _linear_cell(n_cycles=2)
+    fig = plot_chdis([cell])
+
+    out = tmp_path / "out.png"
+    fig.write_image(str(out))
+    assert out.exists()
+    assert out.stat().st_size > 0


### PR DESCRIPTION
Closes #12.

## Summary
- Implements `plot_chdis`, `plot_cycle`, `plot_dqdv` in `plotly_backend.py` mirroring the matplotlib backend signatures.
- Same grid layout (1xN for N<=3, else `ncols=ceil(sqrt(N))`, `nrows=ceil(N/ncols)`), cycle-1-red convention, English labels, and dQ/dV sign convention.
- `plot_cycle` uses `secondary_y=True` via `make_subplots` for Coulombic efficiency.

## Tests
- New `tests/test_plotly_backend.py` covering grid shape (N=1..5), cycle-1-red coloring, dual-Y wiring (q_dis primary / ce secondary), cycle filtering, dQ/dV sign, English labels for JA cells, empty-cells ValueError, and PNG export smoke via kaleido.

## Verification
- `ruff check` + `ruff format --check` + `mypy` green locally.
- Full test suite: 143 passed (19 new).
- `uv build` produces pure-Python `toyo_battery-0.0.1-py3-none-any.whl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)