### PR TITLE
feat(gui): standalone Tk application

### DIFF
--- a/src/toyo_battery/gui/__init__.py
+++ b/src/toyo_battery/gui/__init__.py
@@ -1,1 +1,5 @@
 """Standalone Tk GUI. Requires the [gui] extra."""
+
+from toyo_battery.gui.tk_app import main
+
+__all__ = ["main"]

--- a/src/toyo_battery/gui/__main__.py
+++ b/src/toyo_battery/gui/__main__.py
@@ -1,0 +1,6 @@
+"""Enable ``python -m toyo_battery.gui`` as a shortcut for the Tk entry point."""
+
+from toyo_battery.gui.tk_app import main
+
+if __name__ == "__main__":
+    main()

--- a/src/toyo_battery/gui/_controller.py
+++ b/src/toyo_battery/gui/_controller.py
@@ -1,0 +1,191 @@
+"""Headless-testable adapter between the Tk view and the core pipeline.
+
+The controller owns every piece of logic that needs to be verified in CI:
+validation, cell loading, plot dispatch, axis-limit application. It
+imports no ``tkinter`` symbols so it can run on a headless runner and be
+unit-tested directly — the Tk view (``tk_app.py``) is a thin translator
+from widget state into a :class:`GuiRequest`.
+
+Design notes:
+
+- The view builds a :class:`GuiRequest` and hands it to :func:`run`. The
+  dataclass is ``frozen`` to make it cheap to log, compare, and round-trip
+  through tests.
+- Axis ranges are optional; when present they are applied by iterating
+  ``fig.axes`` after the matplotlib backend has drawn. For :func:`plot_cycle`
+  the dual-Y twin is matched by y-label rather than position so the
+  capacity range never accidentally lands on the efficiency axis.
+- The Savitzky-Golay ``window_length`` is not reachable through the cached
+  :attr:`toyo_battery.core.cell.Cell.dqdv_df` property, which hard-codes
+  the defaults. When the caller requests a non-default window, we compute
+  a fresh ``dqdv_df`` via :func:`toyo_battery.core.dqdv.get_dqdv_df` and
+  set it on the cell's ``__dict__`` to shadow the ``cached_property``
+  lookup before handing the cell to the plotting backend. The override
+  is local to freshly constructed cells and does not mutate any shared
+  state outside this call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from toyo_battery.core.cell import Cell
+from toyo_battery.core.dqdv import get_dqdv_df
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
+
+_VALID_KINDS: frozenset[str] = frozenset({"chdis", "cycle", "dqdv"})
+
+# Labels set by the matplotlib backend; we key off these strings rather
+# than axis ordering so twin-Y axes aren't confused with primary ones.
+_YLABEL_VOLTAGE = "Voltage [V]"
+_YLABEL_CAPACITY = "Discharge capacity [mAh/g]"
+_YLABEL_DQDV = "dQ/dV [mAh/g/V]"
+
+
+@dataclass(frozen=True)
+class GuiRequest:
+    """Inputs to :func:`run`, produced by the Tk view after parsing widgets.
+
+    Attributes
+    ----------
+    dirs
+        Cell directories to load. Each must be a directory acceptable to
+        :meth:`Cell.from_dir`. Empty ``dirs`` raises ``ValueError``.
+    kinds
+        Subset of ``{"chdis", "cycle", "dqdv"}``. Unknown values raise
+        ``ValueError`` in :func:`run`.
+    cycles
+        Cycles to highlight on charge/discharge and dQ/dV plots. Ignored
+        by the cycle-vs-capacity plot. Empty sequence = plot every cycle.
+    sg_window
+        Savitzky-Golay ``window_length`` passed to
+        :func:`toyo_battery.core.dqdv.get_dqdv_df`. Must be an odd integer
+        ``>= 1``; even or non-positive values raise ``ValueError``.
+    voltage_range, capacity_range, dqdv_range
+        Optional ``(lo, hi)`` tuples applied to the corresponding plot's
+        y-axis via :meth:`Axes.set_ylim`. ``None`` leaves the backend's
+        auto-scaled limits in place.
+    """
+
+    dirs: Sequence[Path]
+    kinds: frozenset[str]
+    cycles: Sequence[int] = field(default_factory=tuple)
+    sg_window: int = 11
+    voltage_range: tuple[float, float] | None = None
+    capacity_range: tuple[float, float] | None = None
+    dqdv_range: tuple[float, float] | None = None
+
+
+def _validate(request: GuiRequest) -> None:
+    if not request.dirs:
+        raise ValueError("dirs must contain at least one directory")
+    unknown = set(request.kinds) - _VALID_KINDS
+    if unknown:
+        raise ValueError(
+            f"unknown plot kinds {sorted(unknown)}; valid kinds are {sorted(_VALID_KINDS)}"
+        )
+    if not request.kinds:
+        raise ValueError("kinds must contain at least one of chdis/cycle/dqdv")
+    if request.sg_window < 1:
+        raise ValueError(f"sg_window must be >= 1, got {request.sg_window}")
+    if request.sg_window % 2 == 0:
+        raise ValueError(f"sg_window must be odd, got {request.sg_window}")
+
+
+def _load_cells(dirs: Sequence[Path], sg_window: int) -> list[Cell]:
+    """Load one :class:`Cell` per directory.
+
+    When ``sg_window`` differs from :func:`get_dqdv_df`'s default (11),
+    we precompute ``dqdv_df`` with the requested window and install it on
+    the cell's instance ``__dict__`` so the ``cached_property`` lookup on
+    :attr:`Cell.dqdv_df` returns the overridden frame. This shadows the
+    default without mutating the ``Cell`` class or any shared cache.
+    """
+    cells: list[Cell] = []
+    for d in dirs:
+        cell = Cell.from_dir(d)
+        if sg_window != 11:
+            cell.__dict__["dqdv_df"] = get_dqdv_df(
+                cell.chdis_df,
+                window_length=sg_window,
+                column_lang=cell.column_lang,
+            )
+        cells.append(cell)
+    return cells
+
+
+def _apply_ylim(fig: Figure, ylabel: str, ylim: tuple[float, float]) -> None:
+    """Set ``set_ylim(*ylim)`` on every Axes of ``fig`` whose y-label matches.
+
+    Iterating all axes (rather than the first one) is deliberate: the
+    grid layout emits one Axes per cell, and all of them share the same
+    y-label, so the caller-supplied range applies to every subplot.
+    """
+    for ax in fig.axes:
+        if ax.get_ylabel() == ylabel:
+            ax.set_ylim(*ylim)
+
+
+def run(request: GuiRequest) -> list[Figure]:
+    """Load cells, dispatch to the matplotlib backend, return figures.
+
+    Figures are returned in a stable order (``chdis``, ``cycle``,
+    ``dqdv``) — independent of the iteration order of the input frozenset
+    — so the view can present them predictably.
+
+    Parameters
+    ----------
+    request
+        The form state translated into a :class:`GuiRequest` by the Tk
+        view. See that class for per-field constraints.
+
+    Returns
+    -------
+    list of Figure
+        One figure per requested plot kind. The caller owns the figures;
+        they are not closed on return.
+
+    Raises
+    ------
+    ValueError
+        If ``request`` fails validation (empty dirs, unknown kinds, even
+        or non-positive ``sg_window``).
+    """
+    # Import the backend lazily so a missing ``matplotlib`` extra surfaces
+    # only when ``run`` is actually called — importing the controller by
+    # itself (for unit tests, or during Tk view construction before the
+    # Run button is clicked) stays cheap.
+    from toyo_battery.plotting.matplotlib_backend import (
+        plot_chdis,
+        plot_cycle,
+        plot_dqdv,
+    )
+
+    _validate(request)
+
+    cells = _load_cells(request.dirs, request.sg_window)
+    # ``None`` / empty cycles → let the backend default to all available.
+    cycles_arg: Sequence[int] | None = list(request.cycles) if request.cycles else None
+
+    figures: list[Figure] = []
+    if "chdis" in request.kinds:
+        fig = plot_chdis(cells, cycles=cycles_arg)
+        if request.voltage_range is not None:
+            _apply_ylim(fig, _YLABEL_VOLTAGE, request.voltage_range)
+        figures.append(fig)
+    if "cycle" in request.kinds:
+        fig = plot_cycle(cells)
+        if request.capacity_range is not None:
+            _apply_ylim(fig, _YLABEL_CAPACITY, request.capacity_range)
+        figures.append(fig)
+    if "dqdv" in request.kinds:
+        fig = plot_dqdv(cells, cycles=cycles_arg)
+        if request.dqdv_range is not None:
+            _apply_ylim(fig, _YLABEL_DQDV, request.dqdv_range)
+        figures.append(fig)
+    return figures

--- a/src/toyo_battery/gui/tk_app.py
+++ b/src/toyo_battery/gui/tk_app.py
@@ -1,7 +1,311 @@
-"""Tk application. Requires the [gui] extra."""
+"""Tk application. Requires the [gui] extra.
+
+Launch with ``python -m toyo_battery.gui.tk_app`` (or
+``python -m toyo_battery.gui`` via the module's ``__main__``).
+
+This module is the view only: it parses widget state, hands a
+:class:`toyo_battery.gui._controller.GuiRequest` to
+:func:`toyo_battery.gui._controller.run`, and displays the resulting
+:class:`matplotlib.figure.Figure` objects in one ``Toplevel`` per plot.
+All non-UI logic — directory loading, plot dispatch, axis-range
+application, Savitzky-Golay window propagation — lives in the
+controller so it can be tested without a display.
+
+Matplotlib and tkinter are imported at module scope so an
+``ImportError`` raised when the ``[gui]`` extra is missing propagates
+immediately (the expected UX for an optional feature).
+
+The matplotlib / tkinter stubs are permissive and emit ``no-untyped-call``
+or ``arg-type`` errors for a handful of standard invocations
+(``FigureCanvasTkAgg``, ``NavigationToolbar2Tk``, ``Listbox.curselection``).
+We silence those locally with ``# type: ignore`` rather than relaxing
+mypy project-wide or adding a pyproject override — this file is the only
+place those calls live.
+"""
 
 from __future__ import annotations
 
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+from typing import TYPE_CHECKING
+
+import matplotlib
+
+# Force a Tk-compatible backend before pyplot is imported anywhere else.
+# Without this, on some headless setups matplotlib picks a non-Tk backend
+# and ``FigureCanvasTkAgg`` fails at draw time.
+matplotlib.use("TkAgg")
+
+from matplotlib.backends.backend_tkagg import (  # type: ignore[attr-defined]
+    FigureCanvasTkAgg,
+    NavigationToolbar2Tk,
+)
+
+from toyo_battery.gui._controller import GuiRequest, run
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
+
+_DEFAULT_CYCLES_TEXT = "1 10 50"
+_DEFAULT_SG_WINDOW_TEXT = "11"
+_PADX = 6
+_PADY = 4
+
+
+def _parse_cycles(text: str) -> list[int]:
+    """Parse a space-separated cycle list.
+
+    Empty/whitespace-only input → empty list (plot every available cycle
+    per the controller's convention). Non-integer tokens raise
+    ``ValueError``.
+    """
+    tokens = text.split()
+    if not tokens:
+        return []
+    out: list[int] = []
+    for tok in tokens:
+        try:
+            out.append(int(tok))
+        except ValueError as exc:
+            raise ValueError(f"cycles entry must be space-separated integers; got {tok!r}") from exc
+    return out
+
+
+def _parse_range(text: str, field_name: str) -> tuple[float, float] | None:
+    """Parse an optional ``"lo hi"`` axis range.
+
+    Empty/whitespace-only text → ``None`` (use matplotlib's auto-scale).
+    Anything else must be exactly two whitespace-separated floats with
+    ``lo < hi``; violations raise ``ValueError``.
+    """
+    tokens = text.split()
+    if not tokens:
+        return None
+    if len(tokens) != 2:
+        raise ValueError(f"{field_name} must be two space-separated numbers 'lo hi' or blank")
+    try:
+        lo = float(tokens[0])
+        hi = float(tokens[1])
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be numeric; got {text!r}") from exc
+    if not lo < hi:
+        raise ValueError(f"{field_name} must satisfy lo < hi; got {lo} {hi}")
+    return (lo, hi)
+
+
+def _parse_sg_window(text: str) -> int:
+    """Parse the SG window_length entry.
+
+    Must be a positive odd integer. Even or non-positive values raise
+    ``ValueError`` with a message the caller surfaces via ``messagebox``.
+    """
+    try:
+        n = int(text.strip())
+    except ValueError as exc:
+        raise ValueError(f"SG window_length must be a positive odd integer; got {text!r}") from exc
+    if n < 1:
+        raise ValueError(f"SG window_length must be >= 1, got {n}")
+    if n % 2 == 0:
+        raise ValueError(f"SG window_length must be odd, got {n}")
+    return n
+
+
+class _App:
+    """The single Tk window that owns all widgets and event handlers.
+
+    Kept as a class (rather than a pile of module-level closures) so
+    ``main`` can construct one instance per ``mainloop`` call and all
+    inter-widget state lives on ``self``.
+    """
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        root.title("toyo-battery GUI")
+
+        # State owned by the instance (not the widgets) so it round-trips
+        # through the directory list reliably — Listbox stores only the
+        # display strings.
+        self._dirs: list[Path] = []
+
+        self._build_widgets()
+
+    # ----- layout ---------------------------------------------------
+
+    def _build_widgets(self) -> None:
+        # Directories section
+        dirs_frame = ttk.LabelFrame(self.root, text="Cell directories")
+        dirs_frame.grid(row=0, column=0, columnspan=2, sticky="nsew", padx=_PADX, pady=_PADY)
+
+        self._dirs_list = tk.Listbox(dirs_frame, height=6, width=60)
+        self._dirs_list.grid(row=0, column=0, rowspan=3, sticky="nsew", padx=_PADX, pady=_PADY)
+        ttk.Button(dirs_frame, text="Add...", command=self._on_add).grid(
+            row=0, column=1, sticky="ew", padx=_PADX, pady=_PADY
+        )
+        ttk.Button(dirs_frame, text="Remove selected", command=self._on_remove).grid(
+            row=1, column=1, sticky="ew", padx=_PADX, pady=_PADY
+        )
+        ttk.Button(dirs_frame, text="Clear", command=self._on_clear).grid(
+            row=2, column=1, sticky="ew", padx=_PADX, pady=_PADY
+        )
+
+        # Plot kinds
+        kinds_frame = ttk.LabelFrame(self.root, text="Plot kinds")
+        kinds_frame.grid(row=1, column=0, sticky="nsew", padx=_PADX, pady=_PADY)
+        self._var_chdis = tk.BooleanVar(value=True)
+        self._var_cycle = tk.BooleanVar(value=True)
+        self._var_dqdv = tk.BooleanVar(value=False)
+        ttk.Checkbutton(kinds_frame, text="chdis", variable=self._var_chdis).grid(
+            row=0, column=0, sticky="w", padx=_PADX, pady=_PADY
+        )
+        ttk.Checkbutton(kinds_frame, text="cycle", variable=self._var_cycle).grid(
+            row=1, column=0, sticky="w", padx=_PADX, pady=_PADY
+        )
+        ttk.Checkbutton(kinds_frame, text="dQ/dV", variable=self._var_dqdv).grid(
+            row=2, column=0, sticky="w", padx=_PADX, pady=_PADY
+        )
+
+        # Parameters
+        params_frame = ttk.LabelFrame(self.root, text="Parameters")
+        params_frame.grid(row=1, column=1, sticky="nsew", padx=_PADX, pady=_PADY)
+
+        ttk.Label(params_frame, text="Cycles (space-separated):").grid(
+            row=0, column=0, sticky="w", padx=_PADX, pady=_PADY
+        )
+        self._entry_cycles = ttk.Entry(params_frame, width=24)
+        self._entry_cycles.insert(0, _DEFAULT_CYCLES_TEXT)
+        self._entry_cycles.grid(row=0, column=1, sticky="ew", padx=_PADX, pady=_PADY)
+
+        ttk.Label(params_frame, text="SG window_length:").grid(
+            row=1, column=0, sticky="w", padx=_PADX, pady=_PADY
+        )
+        self._entry_sg = ttk.Entry(params_frame, width=24)
+        self._entry_sg.insert(0, _DEFAULT_SG_WINDOW_TEXT)
+        self._entry_sg.grid(row=1, column=1, sticky="ew", padx=_PADX, pady=_PADY)
+
+        ttk.Label(params_frame, text="Voltage range (lo hi):").grid(
+            row=2, column=0, sticky="w", padx=_PADX, pady=_PADY
+        )
+        self._entry_vrange = ttk.Entry(params_frame, width=24)
+        self._entry_vrange.grid(row=2, column=1, sticky="ew", padx=_PADX, pady=_PADY)
+
+        ttk.Label(params_frame, text="Capacity range (lo hi):").grid(
+            row=3, column=0, sticky="w", padx=_PADX, pady=_PADY
+        )
+        self._entry_qrange = ttk.Entry(params_frame, width=24)
+        self._entry_qrange.grid(row=3, column=1, sticky="ew", padx=_PADX, pady=_PADY)
+
+        ttk.Label(params_frame, text="dQ/dV range (lo hi):").grid(
+            row=4, column=0, sticky="w", padx=_PADX, pady=_PADY
+        )
+        self._entry_drange = ttk.Entry(params_frame, width=24)
+        self._entry_drange.grid(row=4, column=1, sticky="ew", padx=_PADX, pady=_PADY)
+
+        # Run + status
+        ttk.Button(self.root, text="Run", command=self._on_run).grid(
+            row=2, column=0, columnspan=2, sticky="ew", padx=_PADX, pady=_PADY
+        )
+        self._status = tk.StringVar(value="Ready.")
+        ttk.Label(self.root, textvariable=self._status, relief=tk.SUNKEN, anchor="w").grid(
+            row=3, column=0, columnspan=2, sticky="ew", padx=_PADX, pady=_PADY
+        )
+
+    # ----- directory list handlers ----------------------------------
+
+    def _on_add(self) -> None:
+        """Open ``askdirectory`` in a loop so the user can add multiple dirs.
+
+        An empty return from ``askdirectory`` (the user cancelled) breaks
+        the loop; otherwise each selection is appended to both the state
+        list and the display listbox.
+        """
+        while True:
+            selected = filedialog.askdirectory(
+                parent=self.root, title="Select a cell directory (cancel to stop)"
+            )
+            if not selected:
+                break
+            path = Path(selected)
+            self._dirs.append(path)
+            self._dirs_list.insert(tk.END, str(path))
+
+    def _on_remove(self) -> None:
+        # Walk selected indices in reverse so the remaining indices stay
+        # valid as we pop from the lists.
+        selection = self._dirs_list.curselection()  # type: ignore[no-untyped-call]
+        for idx in reversed(selection):
+            self._dirs_list.delete(idx)
+            del self._dirs[int(idx)]
+
+    def _on_clear(self) -> None:
+        self._dirs_list.delete(0, tk.END)
+        self._dirs.clear()
+
+    # ----- run --------------------------------------------------------
+
+    def _collect_kinds(self) -> frozenset[str]:
+        kinds: set[str] = set()
+        if self._var_chdis.get():
+            kinds.add("chdis")
+        if self._var_cycle.get():
+            kinds.add("cycle")
+        if self._var_dqdv.get():
+            kinds.add("dqdv")
+        return frozenset(kinds)
+
+    def _on_run(self) -> None:
+        try:
+            request = GuiRequest(
+                dirs=tuple(self._dirs),
+                kinds=self._collect_kinds(),
+                cycles=tuple(_parse_cycles(self._entry_cycles.get())),
+                sg_window=_parse_sg_window(self._entry_sg.get()),
+                voltage_range=_parse_range(self._entry_vrange.get(), "Voltage range"),
+                capacity_range=_parse_range(self._entry_qrange.get(), "Capacity range"),
+                dqdv_range=_parse_range(self._entry_drange.get(), "dQ/dV range"),
+            )
+        except ValueError as exc:
+            self._fail(f"Invalid input: {exc}")
+            return
+
+        # Controller-level validation (empty dirs / no kinds) raises too.
+        try:
+            figures = run(request)
+        except ValueError as exc:
+            self._fail(f"Invalid request: {exc}")
+            return
+        except Exception as exc:
+            self._fail(f"Error running pipeline: {exc}")
+            return
+
+        for fig in figures:
+            self._show_figure(fig)
+        self._status.set(f"Ran {len(figures)} figure(s).")
+
+    def _show_figure(self, fig: Figure) -> None:
+        """Embed ``fig`` in a new ``Toplevel`` with a matplotlib toolbar."""
+        top = tk.Toplevel(self.root)
+        top.title("toyo-battery plot")
+        canvas = FigureCanvasTkAgg(fig, master=top)  # type: ignore[no-untyped-call]
+        canvas.draw()  # type: ignore[no-untyped-call]
+        toolbar = NavigationToolbar2Tk(canvas, top)  # type: ignore[no-untyped-call]
+        toolbar.update()
+        canvas.get_tk_widget().pack(  # type: ignore[no-untyped-call]
+            side=tk.TOP, fill=tk.BOTH, expand=True
+        )
+
+    def _fail(self, message: str) -> None:
+        """Surface ``message`` via a modal error and the status bar."""
+        messagebox.showerror("toyo-battery", message, parent=self.root)
+        self._status.set(message)
+
 
 def main() -> None:
-    raise NotImplementedError("Tk GUI will be implemented in P3")
+    """Entry point for ``python -m toyo_battery.gui.tk_app``."""
+    root = tk.Tk()
+    _App(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,276 @@
+"""Tests for :mod:`toyo_battery.gui`.
+
+Only the controller is exercised — the Tk view is touched with
+import-only smoke to avoid spinning up a display in CI. Matplotlib is
+imported via :func:`pytest.importorskip` so this module is silently
+skipped when the ``[plot]`` / ``[gui]`` extras aren't installed.
+
+``_write_wide_renzoku`` below builds a cell directory with a 1.2 V-wide
+linear charge/discharge over two cycles — wide enough that the dQ/dV
+interpolation density comfortably exceeds the default Savitzky-Golay
+window (``ipnum = 100 * 1.2 = 120 >> 11``) and populates dQ/dV columns.
+The conftest ``make_cell_dir`` fixture uses 0.2 V, which collapses dQ/dV
+to all-NaN and defeats the SG-window assertion below.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("matplotlib")
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+
+from toyo_battery.gui._controller import GuiRequest, run
+
+
+@pytest.fixture(autouse=True)
+def _close_figures() -> Generator[None, None, None]:
+    """Close figures after each test so matplotlib's warning threshold
+    isn't tripped as the suite grows.
+    """
+    yield
+    plt.close("all")
+
+
+def _write_wide_renzoku(
+    cell_dir: Path,
+    *,
+    mass_mg: float = 1.0,
+    n_cycles: int = 2,
+    n_points: int = 200,
+    v_lo: float = 3.0,
+    v_hi: float = 4.2,
+) -> None:
+    """Write a ``連続データ.csv`` with a wide-voltage linear ramp per cycle.
+
+    Mirrors the layout expected by :func:`toyo_battery.io.reader.read_cell_dir`
+    for the renzoku path (mass row, JP header, channel row, separator,
+    units, then data).
+    """
+    v_ch = np.linspace(v_lo, v_hi, n_points)
+    q_ch = 400.0 * (v_ch - v_lo)
+    v_dis = np.linspace(v_hi, v_lo, n_points)
+    q_dis = 400.0 * (v_hi - v_dis)
+
+    lines = [
+        ",試験名,C:¥synthetic¥test¥path,,,,開始日時,2026-01-01 00:00:00",
+        ",測定備考,",
+        f",重量[mg],{mass_mg:.3f}",
+        "サイクル,モード,状態,電圧,電気量",
+        "1ch,1ch,1ch,1ch,1ch",
+        "-,-,-,-,-",
+        "[],[],[],[V],[mAh/g]",
+    ]
+    for cycle in range(1, n_cycles + 1):
+        for v, q in zip(v_ch, q_ch):
+            lines.append(f"{cycle},1,充電,{v:.4f},{q:.6f}")
+        # Mid-cycle rest so chdis still sees a clean boundary.
+        lines.append(f"{cycle},1,充電休止,{v_hi:.4f},{q_ch[-1]:.6f}")
+        for v, q in zip(v_dis, q_dis):
+            lines.append(f"{cycle},1,放電,{v:.4f},{q:.6f}")
+    (cell_dir / "連続データ.csv").write_text("\n".join(lines) + "\n", encoding="shift_jis")
+
+
+@pytest.fixture
+def wide_cell_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "wide_cell"
+    d.mkdir()
+    _write_wide_renzoku(d)
+    return d
+
+
+# ---- controller returns ----------------------------------------------------
+
+
+def test_run_chdis_returns_single_figure_with_axis_labels(
+    wide_cell_dir: Path,
+) -> None:
+    figures = run(
+        GuiRequest(
+            dirs=[wide_cell_dir],
+            kinds=frozenset({"chdis"}),
+            cycles=[1, 2],
+        )
+    )
+    assert len(figures) == 1
+    ax = figures[0].axes[0]
+    assert ax.get_xlabel() == "Capacity [mAh/g]"
+    assert ax.get_ylabel() == "Voltage [V]"
+
+
+def test_run_all_kinds_returns_three_figures(wide_cell_dir: Path) -> None:
+    figures = run(
+        GuiRequest(
+            dirs=[wide_cell_dir],
+            kinds=frozenset({"chdis", "cycle", "dqdv"}),
+            cycles=[1, 2],
+        )
+    )
+    assert len(figures) == 3
+    ylabels = {fig.axes[0].get_ylabel() for fig in figures}
+    # One of the figures is the cycle dual-Y plot whose primary axis is
+    # "Discharge capacity [mAh/g]"; the chdis and dQ/dV figures contribute
+    # the other two labels.
+    assert ylabels == {
+        "Voltage [V]",
+        "Discharge capacity [mAh/g]",
+        "dQ/dV [mAh/g/V]",
+    }
+
+
+# ---- sg_window propagation -------------------------------------------------
+
+
+def test_sg_window_override_changes_dqdv_values(wide_cell_dir: Path) -> None:
+    """A non-default ``sg_window`` must actually flow into the dQ/dV
+    computation, not silently fall back to the cached-property default.
+
+    Compares the y-data of the first dQ/dV line between a default-window
+    run (11) and an override (21); the smoother window produces numerically
+    distinct values across the curve.
+    """
+    fig_default = run(
+        GuiRequest(
+            dirs=[wide_cell_dir],
+            kinds=frozenset({"dqdv"}),
+            cycles=[1],
+            sg_window=11,
+        )
+    )[0]
+    fig_wide = run(
+        GuiRequest(
+            dirs=[wide_cell_dir],
+            kinds=frozenset({"dqdv"}),
+            cycles=[1],
+            sg_window=21,
+        )
+    )[0]
+    y_default = np.asarray(fig_default.axes[0].lines[0].get_ydata(), dtype=float)
+    y_wide = np.asarray(fig_wide.axes[0].lines[0].get_ydata(), dtype=float)
+    # Same sample count (interpolation grid is independent of the SG window)
+    # but the smoothed derivatives should disagree on a non-trivial fraction
+    # of samples.
+    assert y_default.shape == y_wide.shape
+    assert not np.allclose(y_default, y_wide)
+
+
+# ---- axis ranges -----------------------------------------------------------
+
+
+def test_voltage_range_applied_to_chdis(wide_cell_dir: Path) -> None:
+    figures = run(
+        GuiRequest(
+            dirs=[wide_cell_dir],
+            kinds=frozenset({"chdis"}),
+            cycles=[1],
+            voltage_range=(3.0, 4.2),
+        )
+    )
+    fig = figures[0]
+    # All visible axes in the chdis figure are "Voltage [V]" primaries.
+    lo, hi = fig.axes[0].get_ylim()
+    assert lo == pytest.approx(3.0)
+    assert hi == pytest.approx(4.2)
+
+
+def test_capacity_range_applied_only_to_primary_not_twin(
+    wide_cell_dir: Path,
+) -> None:
+    """The ``cycle`` plot has a twin-Y (Coulombic efficiency). The
+    capacity range must land on the primary axis only — a naive
+    ``fig.axes[0].set_ylim`` on all axes would clobber the efficiency
+    scale too. This test guards that labeled-axis dispatch.
+    """
+    figures = run(
+        GuiRequest(
+            dirs=[wide_cell_dir],
+            kinds=frozenset({"cycle"}),
+            capacity_range=(0.0, 9999.0),
+        )
+    )
+    fig = figures[0]
+    primaries = [ax for ax in fig.axes if ax.get_ylabel() == "Discharge capacity [mAh/g]"]
+    twins = [ax for ax in fig.axes if ax.get_ylabel() == "Coulombic efficiency [%]"]
+    assert primaries and twins
+    for ax in primaries:
+        assert ax.get_ylim() == pytest.approx((0.0, 9999.0))
+    # Twin y-axis limits are whatever matplotlib auto-picked — crucially
+    # NOT (0, 9999), which would indicate cross-contamination.
+    for ax in twins:
+        assert ax.get_ylim() != pytest.approx((0.0, 9999.0))
+
+
+# ---- validation ------------------------------------------------------------
+
+
+def test_invalid_sg_window_even_raises(wide_cell_dir: Path) -> None:
+    with pytest.raises(ValueError, match="sg_window must be odd"):
+        run(
+            GuiRequest(
+                dirs=[wide_cell_dir],
+                kinds=frozenset({"dqdv"}),
+                sg_window=10,
+            )
+        )
+
+
+def test_invalid_sg_window_nonpositive_raises(wide_cell_dir: Path) -> None:
+    with pytest.raises(ValueError, match="sg_window must be >= 1"):
+        run(
+            GuiRequest(
+                dirs=[wide_cell_dir],
+                kinds=frozenset({"dqdv"}),
+                sg_window=0,
+            )
+        )
+
+
+def test_unknown_kind_raises(wide_cell_dir: Path) -> None:
+    with pytest.raises(ValueError, match="unknown plot kinds"):
+        run(
+            GuiRequest(
+                dirs=[wide_cell_dir],
+                kinds=frozenset({"chdis", "stats"}),  # "stats" isn't a GUI plot
+            )
+        )
+
+
+def test_empty_dirs_raises() -> None:
+    with pytest.raises(ValueError, match="dirs must contain"):
+        run(GuiRequest(dirs=[], kinds=frozenset({"chdis"})))
+
+
+def test_empty_kinds_raises(wide_cell_dir: Path) -> None:
+    with pytest.raises(ValueError, match="kinds must contain"):
+        run(GuiRequest(dirs=[wide_cell_dir], kinds=frozenset()))
+
+
+# ---- smoke -----------------------------------------------------------------
+
+
+def test_tk_app_module_importable_without_display() -> None:
+    """Importing the view must not require a live display.
+
+    If the import itself spun up a Tk root or called ``mainloop``, CI
+    (no X server, no Windows session) would hang or raise. We accept a
+    ``TclError`` from any deeper setup — but the import line itself must
+    succeed.
+    """
+    import toyo_battery.gui.tk_app as tk_app
+
+    assert callable(tk_app.main)
+
+
+def test_gui_package_reexports_main() -> None:
+    import toyo_battery.gui as gui
+
+    assert callable(gui.main)


### PR DESCRIPTION
Closes #10.

## Summary
- `python -m toyo_battery.gui.tk_app` (or `python -m toyo_battery.gui`) launches a Tk app.
- Multi-directory selection, per-kind checkboxes (chdis / cycle / dqdv), space-separated cycles entry, SG window_length entry, optional per-plot axis ranges.
- View/controller split: `_controller.py` is headless-testable (no tkinter import); `tk_app.py` holds the UI.
- Uses the matplotlib backend; no Origin adapter wiring.
- `GuiRequest` is a frozen dataclass; `run(request)` returns a stable-ordered `list[Figure]` with axis limits applied by y-label dispatch (twin-Y efficiency axis stays untouched).
- Non-default SG window propagates by shadowing `Cell.dqdv_df` via `cell.__dict__` with a freshly computed `get_dqdv_df(..., window_length=sg_window)`.

## Tests
- `tests/test_gui.py` (12 tests) covers controller returns, axis-range application on primary vs twin, SG-window propagation numerics, validation errors, and import smoke.

## Verification
- `ruff check` + `ruff format --check` + `mypy --strict` + `pytest` (169 tests) all green locally.
- `import toyo_battery.gui.tk_app` succeeds without a display.
- `uv build` produces `py3-none-any.whl` — pure-Python wheel preserved.
- `pyproject.toml`, `src/toyo_battery/__init__.py`, and all other source trees untouched per the one-feature-one-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)