### PR TITLE
fix(gui+plot): SG window via plot_dqdv kwargs; close Tk figures on window destroy

### DIFF
--- a/src/toyo_battery/gui/_controller.py
+++ b/src/toyo_battery/gui/_controller.py
@@ -17,12 +17,12 @@ Design notes:
   capacity range never accidentally lands on the efficiency axis.
 - The Savitzky-Golay ``window_length`` is not reachable through the cached
   :attr:`toyo_battery.core.cell.Cell.dqdv_df` property, which hard-codes
-  the defaults. When the caller requests a non-default window, we compute
-  a fresh ``dqdv_df`` via :func:`toyo_battery.core.dqdv.get_dqdv_df` and
-  set it on the cell's ``__dict__`` to shadow the ``cached_property``
-  lookup before handing the cell to the plotting backend. The override
-  is local to freshly constructed cells and does not mutate any shared
-  state outside this call.
+  the defaults. The controller forwards ``request.sg_window`` straight to
+  :func:`toyo_battery.plotting.matplotlib_backend.plot_dqdv` as the
+  ``sg_window_length`` kwarg; the backend reuses the cached
+  :attr:`Cell.dqdv_df` at defaults and recomputes via
+  :func:`toyo_battery.core.dqdv.get_dqdv_df` on overrides. ``Cell``
+  instances are never mutated.
 """
 
 from __future__ import annotations
@@ -33,7 +33,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from toyo_battery.core.cell import Cell
-from toyo_battery.core.dqdv import get_dqdv_df
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
@@ -97,26 +96,14 @@ def _validate(request: GuiRequest) -> None:
         raise ValueError(f"sg_window must be odd, got {request.sg_window}")
 
 
-def _load_cells(dirs: Sequence[Path], sg_window: int) -> list[Cell]:
+def _load_cells(dirs: Sequence[Path]) -> list[Cell]:
     """Load one :class:`Cell` per directory.
 
-    When ``sg_window`` differs from :func:`get_dqdv_df`'s default (11),
-    we precompute ``dqdv_df`` with the requested window and install it on
-    the cell's instance ``__dict__`` so the ``cached_property`` lookup on
-    :attr:`Cell.dqdv_df` returns the overridden frame. This shadows the
-    default without mutating the ``Cell`` class or any shared cache.
+    ``Cell`` instances are returned untouched; per-call Savitzky-Golay
+    overrides are forwarded directly to the plotting backend rather than
+    threaded through the cell's cached properties.
     """
-    cells: list[Cell] = []
-    for d in dirs:
-        cell = Cell.from_dir(d)
-        if sg_window != 11:
-            cell.__dict__["dqdv_df"] = get_dqdv_df(
-                cell.chdis_df,
-                window_length=sg_window,
-                column_lang=cell.column_lang,
-            )
-        cells.append(cell)
-    return cells
+    return [Cell.from_dir(d) for d in dirs]
 
 
 def _apply_ylim(fig: Figure, ylabel: str, ylim: tuple[float, float]) -> None:
@@ -168,7 +155,7 @@ def run(request: GuiRequest) -> list[Figure]:
 
     _validate(request)
 
-    cells = _load_cells(request.dirs, request.sg_window)
+    cells = _load_cells(request.dirs)
     # ``None`` / empty cycles → let the backend default to all available.
     cycles_arg: Sequence[int] | None = list(request.cycles) if request.cycles else None
 
@@ -184,7 +171,7 @@ def run(request: GuiRequest) -> list[Figure]:
             _apply_ylim(fig, _YLABEL_CAPACITY, request.capacity_range)
         figures.append(fig)
     if "dqdv" in request.kinds:
-        fig = plot_dqdv(cells, cycles=cycles_arg)
+        fig = plot_dqdv(cells, cycles=cycles_arg, sg_window_length=request.sg_window)
         if request.dqdv_range is not None:
             _apply_ylim(fig, _YLABEL_DQDV, request.dqdv_range)
         figures.append(fig)

--- a/src/toyo_battery/gui/tk_app.py
+++ b/src/toyo_battery/gui/tk_app.py
@@ -276,7 +276,15 @@ class _App:
         self._status.set(f"Ran {len(figures)} figure(s).")
 
     def _show_figure(self, fig: Figure) -> None:
-        """Embed ``fig`` in a new ``Toplevel`` with a matplotlib toolbar."""
+        """Embed ``fig`` in a new ``Toplevel`` with a matplotlib toolbar.
+
+        Closing the Toplevel also closes the matplotlib figure via
+        ``plt.close`` so a long-running session doesn't accumulate figures
+        in pyplot's global registry (which would eventually trip the
+        max_open_warning).
+        """
+        import matplotlib.pyplot as plt  # local: pyplot only at show-time
+
         top = tk.Toplevel(self.root)
         top.title("toyo-battery plot")
         canvas = FigureCanvasTkAgg(fig, master=top)  # type: ignore[no-untyped-call]
@@ -286,6 +294,14 @@ class _App:
         canvas.get_tk_widget().pack(  # type: ignore[no-untyped-call]
             side=tk.TOP, fill=tk.BOTH, expand=True
         )
+
+        # Default args bind ``fig`` and ``top`` by value — avoids late-binding
+        # bugs if ``_show_figure`` is called multiple times in quick succession.
+        def _on_close(fig: Figure = fig, top: tk.Toplevel = top) -> None:
+            plt.close(fig)
+            top.destroy()
+
+        top.protocol("WM_DELETE_WINDOW", _on_close)
 
     def _fail(self, message: str) -> None:
         """Surface ``message`` via a modal error and the status bar."""

--- a/src/toyo_battery/plotting/matplotlib_backend.py
+++ b/src/toyo_battery/plotting/matplotlib_backend.py
@@ -40,6 +40,7 @@ from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 
 from toyo_battery.core.cell import Cell
+from toyo_battery.core.dqdv import get_dqdv_df
 from toyo_battery.io.schema import ColumnLang
 
 _CYCLE_COLOR_FIRST = "red"
@@ -267,6 +268,9 @@ def plot_cycle(cells: Sequence[Cell]) -> Figure:
 def plot_dqdv(
     cells: Sequence[Cell],
     cycles: Sequence[int] | None = None,
+    *,
+    sg_window_length: int = 11,
+    sg_polyorder: int = 2,
 ) -> Figure:
     """dQ/dV vs voltage, cycle 1 red / other cycles black.
 
@@ -284,6 +288,18 @@ def plot_dqdv(
         cycles whose ``dqdv_df`` columns collapsed to all-NaN (e.g.
         ``ipnum < window_length`` for a narrow-voltage segment) are
         skipped silently for that cell.
+    sg_window_length
+        Savitzky-Golay ``window_length`` forwarded to
+        :func:`toyo_battery.core.dqdv.get_dqdv_df`. When this and
+        ``sg_polyorder`` are both at their defaults (``11`` / ``2``), the
+        cached :attr:`Cell.dqdv_df` is reused; otherwise a fresh
+        ``dqdv_df`` is computed per cell with the requested parameters.
+        Must be a positive odd integer strictly greater than
+        ``sg_polyorder``.
+    sg_polyorder
+        Savitzky-Golay polynomial order forwarded to
+        :func:`toyo_battery.core.dqdv.get_dqdv_df`. See ``sg_window_length``
+        for the cache-or-recompute behavior.
 
     Returns
     -------
@@ -293,15 +309,29 @@ def plot_dqdv(
     Raises
     ------
     ValueError
-        If ``cells`` is empty.
+        If ``cells`` is empty, or if Savitzky-Golay parameters violate
+        :func:`toyo_battery.core.dqdv.get_dqdv_df`'s preconditions.
     """
     _check_nonempty(cells)
     fig, axes = _build_grid(len(cells))
 
+    # Reuse the cached property only at the defaults; any override forces a
+    # recompute via ``get_dqdv_df`` so the requested SG parameters actually
+    # land in the output.
+    use_default = sg_window_length == 11 and sg_polyorder == 2
+
     for ax, cell in zip(axes, cells):
         v_name = _quantity(cell.column_lang, "voltage")
         dqdv_name = _quantity(cell.column_lang, "dqdv")
-        dqdv = cell.dqdv_df
+        if use_default:
+            df = cell.dqdv_df
+        else:
+            df = get_dqdv_df(
+                cell.chdis_df,
+                window_length=sg_window_length,
+                polyorder=sg_polyorder,
+                column_lang=cell.column_lang,
+            )
 
         plotted: list[int] = []
         for cycle in _resolve_cycles(cell, cycles):
@@ -310,10 +340,10 @@ def plot_dqdv(
             for side in ("ch", "dis"):
                 v_key = (cycle, side, v_name)
                 y_key = (cycle, side, dqdv_name)
-                if v_key not in dqdv.columns or y_key not in dqdv.columns:
+                if v_key not in df.columns or y_key not in df.columns:
                     continue
                 # Joint dropna — see plot_chdis for the rationale.
-                pair = dqdv[[v_key, y_key]].dropna()
+                pair = df[[v_key, y_key]].dropna()
                 if pair.empty:
                     continue
                 ax.plot(pair[v_key], pair[y_key], color=color, linewidth=0.9)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -163,6 +163,54 @@ def test_sg_window_override_changes_dqdv_values(wide_cell_dir: Path) -> None:
     assert not np.allclose(y_default, y_wide)
 
 
+def test_controller_passes_sg_window_to_plot_dqdv(
+    monkeypatch: pytest.MonkeyPatch, wide_cell_dir: Path
+) -> None:
+    """The controller must forward ``request.sg_window`` as ``plot_dqdv``'s
+    ``sg_window_length`` kwarg.
+
+    Implementation note: the controller imports ``plot_dqdv`` lazily inside
+    :func:`run`, so monkeypatching the controller-module attribute would be
+    a no-op for the first call. We patch the symbol on the source module
+    (``toyo_battery.plotting.matplotlib_backend``) which is what the lazy
+    import resolves to.
+    """
+    import toyo_battery.plotting.matplotlib_backend as backend
+
+    calls: list[dict[str, object]] = []
+
+    def fake_plot_dqdv(
+        cells: object,
+        cycles: object = None,
+        *,
+        sg_window_length: int = 11,
+        sg_polyorder: int = 2,
+    ) -> object:
+        calls.append(
+            {
+                "sg_window_length": sg_window_length,
+                "sg_polyorder": sg_polyorder,
+                "cycles": cycles,
+            }
+        )
+        return plt.figure()
+
+    monkeypatch.setattr(backend, "plot_dqdv", fake_plot_dqdv)
+
+    figures = run(
+        GuiRequest(
+            dirs=[wide_cell_dir],
+            kinds=frozenset({"dqdv"}),
+            cycles=[1],
+            sg_window=21,
+        )
+    )
+
+    assert len(figures) == 1
+    assert len(calls) == 1
+    assert calls[0]["sg_window_length"] == 21
+
+
 # ---- axis ranges -----------------------------------------------------------
 
 

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -245,6 +245,27 @@ def test_plot_chdis_cycles_filter_spans_cells_with_different_cycle_counts() -> N
     assert len(axes_by_title["large"].lines) == 6
 
 
+def test_plot_dqdv_sg_override_changes_curve() -> None:
+    """``plot_dqdv`` with a non-default ``sg_window_length`` must produce
+    different y-values than the default.
+
+    Guards the new SG-override plumbing on the matplotlib backend — at the
+    defaults the cached :attr:`Cell.dqdv_df` is reused, but any override
+    must force a recompute via :func:`get_dqdv_df`.
+    """
+    cell = _linear_cell(n_cycles=1)
+
+    fig_default = plot_dqdv([cell])
+    fig_wide = plot_dqdv([cell], sg_window_length=21)
+
+    y_default = np.asarray(_first_visible(fig_default).lines[0].get_ydata(), dtype=float)
+    y_wide = np.asarray(_first_visible(fig_wide).lines[0].get_ydata(), dtype=float)
+    # Same sample count (interpolation grid is independent of the SG window)
+    # but the smoothed derivatives should disagree.
+    assert y_default.shape == y_wide.shape
+    assert not np.allclose(y_default, y_wide, equal_nan=True)
+
+
 def test_column_lang_en_cell_plots_successfully() -> None:
     """A Cell built with ``column_lang='en'`` still plots (regression guard
     for the internal ``_quantity`` lookup).


### PR DESCRIPTION
Closes #38.

## Summary
- Add `sg_window_length` and `sg_polyorder` kwargs to `plot_dqdv` (matplotlib backend). Defaults preserve cached `cell.dqdv_df` reads; non-defaults recompute via `get_dqdv_df`.
- Drop the `cell.__dict__["dqdv_df"]` shadow hack from `gui/_controller.py`. The controller now forwards `request.sg_window` straight to `plot_dqdv`. `Cell` stays untouched (and is now safe under a future `slots=True`).
- Bind `WM_DELETE_WINDOW` on each Tk Toplevel to `plt.close(fig)` + `top.destroy()` so figures do not leak into pyplots global registry across Run-clicks.

## Tests
- `tests/test_matplotlib_backend.py::test_plot_dqdv_sg_override_changes_curve` — default vs sg_window_length=21 produce different y-values.
- `tests/test_gui.py::test_controller_passes_sg_window_to_plot_dqdv` — controller forwards `sg_window_length` kwarg.
- Existing `tests/test_gui.py::test_sg_window_override_changes_dqdv_values` remains green (proof of behavior preservation).

## Out of scope (follow-up)
- Plotly backend `plot_dqdv` mirror to maintain API parity. Will be filed as a separate issue.

## Verification
- ruff + mypy + pytest green on default Python.
- pytest tests/test_gui.py tests/test_matplotlib_backend.py green on Python 3.9.
- Pure-Python wheel preserved.

Generated with [Claude Code](https://claude.com/claude-code)