### PR TITLE
ci: add PyPI trusted-publishing workflow on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,18 @@ jobs:
           enable-cache: true
       - name: Set up Python 3.12
         run: uv python install 3.12
+      - name: Verify tag matches pyproject version
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          set -e
+          tag="${GITHUB_REF_NAME#v}"
+          pyver=$(uv run --with tomli --python 3.12 python -c "import tomli, pathlib; print(tomli.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          if [ "$tag" != "$pyver" ]; then
+            echo "FAIL: tag $GITHUB_REF_NAME does not match pyproject version $pyver"
+            exit 1
+          fi
+          echo "OK: tag $GITHUB_REF_NAME matches pyproject version $pyver"
       - name: Build
         run: uv build
       - name: Assert pure-Python wheel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build sdist+wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+      - name: Build
+        run: uv build
+      - name: Assert pure-Python wheel
+        shell: bash
+        run: |
+          set -e
+          wheels=$(ls dist/*.whl)
+          for w in $wheels; do
+            echo "Checking $w"
+            case "$w" in
+              *-py3-none-any.whl) echo "OK: $w is pure-Python";;
+              *) echo "FAIL: $w is not py3-none-any"; exit 1;;
+            esac
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/toyo-battery
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` that triggers on `v*` tag push (plus `workflow_dispatch` for manual recovery runs).
- Builds sdist + wheel with `uv build`, asserts the wheel is pure-Python (`py3-none-any`), uploads as an artifact, and publishes to **PyPI production** via `pypa/gh-action-pypi-publish@release/v1`.
- Uses **trusted publishing (OIDC)** — no API tokens, no repo secrets. `id-token: write` permission is scoped to the publish job only.
- Uses `environment: pypi` so the user can later attach GitHub Environment protection rules (required reviewers, tag restrictions, etc.).

Closes #43

## One-time setup required before first tag

Before pushing `v0.0.1`, the user must register a **Pending Publisher** on PyPI:

1. Go to https://pypi.org/manage/account/publishing/
2. Add a new pending publisher with:
   - PyPI Project Name: `toyo-battery`
   - Owner: `tomooki`
   - Repository name: `toyo-battery`
   - Workflow name: `publish.yml`
   - Environment name: `pypi`
3. (Optional but recommended) Create the `pypi` GitHub Environment under repo Settings -> Environments and add any protection rules.

Without this registration, the first publish attempt will fail with an OIDC authentication error.

## Test plan

- [ ] Register the PyPI Pending Publisher per the instructions above.
- [ ] (Optional) Create the `pypi` GitHub Environment with protection rules.
- [ ] Merge this PR to `main`.
- [ ] Tag and push: `git tag v0.0.1 && git push origin v0.0.1`.
- [ ] Verify the `Publish` workflow runs: `build` job succeeds (pure-Python wheel assertion passes), `publish` job authenticates via OIDC and uploads to PyPI.
- [ ] Confirm `toyo-battery 0.0.1` appears on https://pypi.org/project/toyo-battery/.
- [ ] Sanity check: `pip install toyo-battery==0.0.1` in a clean venv.

Robot Generated with [Claude Code](https://claude.com/claude-code)