### PR TITLE
fix(api): re-export Cell from top-level package

### DIFF
--- a/src/toyo_battery/__init__.py
+++ b/src/toyo_battery/__init__.py
@@ -1,5 +1,6 @@
 """toyo-battery: OSS Python toolkit for TOYO battery cycler data."""
 
 from toyo_battery._version import __version__
+from toyo_battery.core.cell import Cell
 
-__all__ = ["__version__"]
+__all__ = ["Cell", "__version__"]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -9,6 +9,14 @@ def test_import_package() -> None:
     assert toyo_battery.__version__
 
 
+def test_cell_reexported_at_top_level() -> None:
+    """README Quick Start uses ``from toyo_battery import Cell`` — keep it working."""
+    from toyo_battery import Cell
+    from toyo_battery.core.cell import Cell as CoreCell
+
+    assert Cell is CoreCell
+
+
 def test_import_submodules() -> None:
     from toyo_battery import config  # noqa: F401
     from toyo_battery.core import cell  # noqa: F401


### PR DESCRIPTION
## Summary

- Re-export `Cell` from the top-level `toyo_battery` package so the README Quick Start (`from toyo_battery import Cell`) actually works — required before the v0.0.1 PyPI publish, otherwise the first snippet a visitor copies raises `ImportError`.
- Add a smoke test that imports `Cell` at the top level and asserts it is the same class as `toyo_battery.core.cell.Cell`.
- Plotting helpers (`plot_chdis`, `plot_dqdv`, `plot_cycle`) are intentionally NOT re-exported — matplotlib is an optional extra and core-only installs must not break.

Closes #42

## Test plan

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 36 files already formatted
- [x] `uv run pytest tests/test_smoke.py -x` — 5 passed (including new `test_cell_reexported_at_top_level`)
- [x] `uv run mypy` — same 6 pre-existing errors in `src/toyo_battery/cli.py` (typer/rich stubs missing); verified also present on `main`, unrelated to this change

Generated with Claude Code