### PR TITLE
docs(readme): replace deprecated pip.main() recipe in Origin install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ Open Origin, go to **Connectivity → Python Packages**, then in the Origin
 Python console:
 
 ```python
-import pip
-pip.main(["install", "toyo-battery"])
+import subprocess
+import sys
+
+subprocess.check_call([sys.executable, "-m", "pip", "install", "toyo-battery"])
 ```
 
 The `toyo_battery.origin` submodule uses `originpro` (shipped with Origin)

--- a/docs/ORIGIN_SETUP.md
+++ b/docs/ORIGIN_SETUP.md
@@ -10,8 +10,12 @@ OriginLab's embedded Python the same way as numpy/pandas/scipy.
 3. Install:
 
    ```python
-   import pip
-   pip.main(["install", "--upgrade", "toyo-battery"])
+   import subprocess
+   import sys
+
+   subprocess.check_call(
+       [sys.executable, "-m", "pip", "install", "--upgrade", "toyo-battery"]
+   )
    ```
 
 4. Confirm:


### PR DESCRIPTION
Closes #45

## Summary
- Replace the non-functional `pip.main(["install", "toyo-battery"])` snippet in the README's "Installing into Origin's embedded Python" section with the sanctioned `subprocess.check_call([sys.executable, "-m", "pip", "install", "toyo-battery"])` recipe.
- Apply the same fix to `docs/ORIGIN_SETUP.md` (preserving the `--upgrade` flag used there).
- Motivation: `pip` does not support `pip.main` as a library entry point, and the README will be the PyPI landing page for the upcoming v0.0.1 publish.

## Test plan
- [x] `uv run ruff check .` passes (all checks passed)
- [x] `uv run mkdocs build --strict` builds successfully with no warnings treated as errors
- [x] Grep for `pip.main` across repo returns no matches