### PR TITLE
docs(chdis): remove stale signed-capacity narrative from comments

### DIFF
--- a/src/toyo_battery/core/chdis.py
+++ b/src/toyo_battery/core/chdis.py
@@ -119,8 +119,9 @@ def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.Data
     pieces: dict[tuple[int, str], pd.DataFrame] = {}
     for (cycle_val, state_val), g in working.groupby([cycle_col, state_col], sort=True):
         side = _STATE_TO_SIDE[str(state_val)]
-        # abs() so the filter works whether capacity is monotone-positive
-        # (real 連続データ) or signed (reader's raw-6-digit formula output).
+        # abs() is defensive: real TOYO data (both 連続データ and raw-6-digit
+        # paths) is already monotone non-decreasing per segment; abs() keeps
+        # the filter correct under any hand-crafted signed input.
         segment = g[[cap_col, v_col]].loc[~(g[cap_col].abs().diff() < 0)].reset_index(drop=True)
         pieces[(int(cycle_val), side)] = segment
 

--- a/tests/test_chdis.py
+++ b/tests/test_chdis.py
@@ -175,8 +175,9 @@ def test_cell_chdis_df_from_all_layouts(make_cell_dir: Callable[..., Path], layo
 
     Each fixture writes exactly 2 charge rows + 1 rest + 2 discharge rows (plus 1
     extra leading/trailing row in some variants). The reversal filter runs on
-    ``|電気量|`` so the signed-capacity output of the raw-6-digit and
-    renzoku-without-precomputed-capacity paths is preserved, not silently dropped.
+    ``|電気量|`` as a defensive measure: real TOYO data (all three paths) is
+    already monotone non-decreasing per segment, so no rows are spuriously
+    dropped, and any hand-crafted signed input would still segment correctly.
     """
     cell = Cell.from_dir(make_cell_dir(layout))
     out = cell.chdis_df


### PR DESCRIPTION
Closes #20.

## Summary
- `src/toyo_battery/core/chdis.py` — the inline comment on the reversal filter described `abs()` as defending against "signed (reader's raw-6-digit formula output)" capacity. That narrative predates PR #19, which reframed the raw-6-digit path as producing monotone-non-decreasing 電気量. The comment now matches the module docstring: `abs()` is defensive against hand-crafted signed input, because real TOYO data (both paths) is already monotone non-decreasing per segment.
- `tests/test_chdis.py` — the `test_cell_chdis_df_from_all_layouts` docstring carried the same stale "signed-capacity output of the raw-6-digit and renzoku-without-precomputed-capacity paths" story. Rewritten to match.

Pure docs cleanup: no function signatures, return types, or computation changed. Important since these docstrings render on the PyPI landing page via mkdocstrings for v0.0.1.

## Test plan
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — 36 files already formatted
- [x] `uv run mypy src/toyo_battery/core/chdis.py` — no issues (full `uv run mypy` surfaces only pre-existing `cli.py` typer import errors unrelated to this change)
- [x] `uv run pytest tests/test_chdis.py -x` — 16 passed