### PR TITLE
meta: enrich project.urls and add CHANGELOG.md for v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1] - 2026-04-22
+
+### Added
+- Initial public scaffold ported from the private `TOYO_origin` scripts.
+- `toyo_battery.io` reader for TOYO System cycler output (Shift-JIS CSV + PTN).
+- `toyo_battery.core`: `Cell` class, capacity / charge-discharge / dQdV / stats helpers.
+- `toyo_battery.plotting`: Matplotlib and Plotly backends (`plot_chdis`, `plot_dqdv`, `plot_cycle`).
+- `toyo_battery.cli` (`toyo-battery process | plot | stats`) — requires `[cli]` extra.
+- `toyo_battery.gui` Tk app (`python -m toyo_battery.gui`) — requires `[gui]` extra.
+- `toyo_battery.origin` adapter for OriginLab's embedded Python.
+- MkDocs + mkdocstrings documentation, deployed via the `Docs` workflow.
+
+### Notes
+- **Pre-alpha.** Public API is unstable and may change without deprecation in
+  0.0.x releases.
+
+[Unreleased]: https://github.com/tomooki/toyo-battery/compare/v0.0.1...HEAD
+[0.0.1]: https://github.com/tomooki/toyo-battery/releases/tag/v0.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,11 @@ all = [
 toyo-battery = "toyo_battery.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/tomooki/toyo-battery"
-Issues = "https://github.com/tomooki/toyo-battery/issues"
+Homepage      = "https://github.com/tomooki/toyo-battery"
+Issues        = "https://github.com/tomooki/toyo-battery/issues"
+Repository    = "https://github.com/tomooki/toyo-battery"
+Documentation = "https://tomooki.github.io/toyo-battery/"
+Changelog     = "https://github.com/tomooki/toyo-battery/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Closes #44

## Summary
- Extend `[project.urls]` in `pyproject.toml` with `Repository`, `Documentation`, and `Changelog` so the PyPI landing page surfaces the docs site and changelog alongside Homepage/Issues.
- Add `CHANGELOG.md` at the repo root using Keep a Changelog 1.1.0, with the `0.0.1` entry dated 2026-04-22 summarizing the initial public scaffold (io reader, core, plotting, cli, gui, origin adapter, mkdocs site).
- Classifier `Development Status :: 2 - Pre-Alpha` is intentionally left untouched.

## Test plan
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — 36 files already formatted
- [x] `uv run --extra cli mypy` — no issues in 23 source files (bare `uv run mypy` still reports pre-existing `typer`/`rich` import errors on main; unrelated)
- [x] `uv build` — sdist + wheel built cleanly, PKG-INFO shows all five `Project-URL` entries
- [ ] CHANGELOG.md renders on GitHub