### PR TITLE
feat(gui): expose launch_gui() for in-process Origin launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `toyo_battery.gui.launch_gui()` public entry point for launching the Tk GUI
+  from a host Python process (including Origin's embedded Python Console).
+  Documented in `docs/ORIGIN_SETUP.md`.
+
+### Changed
+- Renamed internal `toyo_battery.gui.main` → `launch_gui`. The CLI entry
+  `python -m toyo_battery.gui` is unaffected.
+
 ## [0.0.1] - 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ subprocess.check_call([sys.executable, "-m", "pip", "install", "toyo-battery"])
 The `toyo_battery.origin` submodule uses `originpro` (shipped with Origin)
 and is only importable inside Origin's Python environment.
 
+With the `[gui]` extra installed, the Tk GUI can also be launched from
+Origin's Python Console via `from toyo_battery.gui import launch_gui;
+launch_gui()` — see [docs/ORIGIN_SETUP.md](./docs/ORIGIN_SETUP.md) for caveats.
+
 ## Quick start
 
 ```python

--- a/docs/ORIGIN_SETUP.md
+++ b/docs/ORIGIN_SETUP.md
@@ -35,6 +35,24 @@ OriginLab's embedded Python the same way as numpy/pandas/scipy.
    still works — calling `push_to_origin` will raise `ImportError` with a clear
    message.)
 
+## Launching the GUI from Origin
+
+With the `[gui]` extra installed (`pip install "toyo-battery[gui]"`), the Tk
+GUI can be launched directly from Origin's Python Console:
+
+```python
+from toyo_battery.gui import launch_gui
+launch_gui()
+```
+
+Notes:
+
+- `launch_gui()` runs Tk's `mainloop()` **in the Origin process**. The Origin
+  Python Console is blocked until you close the GUI window.
+- Origin's embedded CPython must include `_tkinter` (OriginLab 2022 and later
+  do). If it doesn't, the call raises `ImportError` from `import tkinter`; use
+  a separate system Python in that case.
+
 ## Origin Python version check (please report back)
 
 Please run this inside Origin's Python Console and paste the result into the

--- a/src/toyo_battery/gui/__init__.py
+++ b/src/toyo_battery/gui/__init__.py
@@ -1,5 +1,5 @@
 """Standalone Tk GUI. Requires the [gui] extra."""
 
-from toyo_battery.gui.tk_app import main
+from toyo_battery.gui.tk_app import launch_gui
 
-__all__ = ["main"]
+__all__ = ["launch_gui"]

--- a/src/toyo_battery/gui/__main__.py
+++ b/src/toyo_battery/gui/__main__.py
@@ -1,6 +1,6 @@
 """Enable ``python -m toyo_battery.gui`` as a shortcut for the Tk entry point."""
 
-from toyo_battery.gui.tk_app import main
+from toyo_battery.gui.tk_app import launch_gui
 
 if __name__ == "__main__":
-    main()
+    launch_gui()

--- a/src/toyo_battery/gui/tk_app.py
+++ b/src/toyo_battery/gui/tk_app.py
@@ -108,8 +108,8 @@ class _App:
     """The single Tk window that owns all widgets and event handlers.
 
     Kept as a class (rather than a pile of module-level closures) so
-    ``main`` can construct one instance per ``mainloop`` call and all
-    inter-widget state lives on ``self``.
+    ``launch_gui`` can construct one instance per ``mainloop`` call and
+    all inter-widget state lives on ``self``.
     """
 
     def __init__(self, root: tk.Tk) -> None:
@@ -309,8 +309,16 @@ class _App:
         self._status.set(message)
 
 
-def main() -> None:
-    """Entry point for ``python -m toyo_battery.gui.tk_app``.
+def launch_gui() -> None:
+    """Start the Tk GUI and run its event loop.
+
+    Callable two ways:
+
+    * ``python -m toyo_battery.gui`` — standalone CLI (via
+      :mod:`toyo_battery.gui.__main__`).
+    * ``from toyo_battery.gui import launch_gui; launch_gui()`` — direct
+      call from any host Python process, including Origin's embedded
+      Python Console. The call blocks until the window is closed.
 
     Switches matplotlib to the TkAgg backend at call time (not import
     time): a module-level ``matplotlib.use("TkAgg")`` would crash
@@ -327,4 +335,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    launch_gui()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -315,10 +315,15 @@ def test_tk_app_module_importable_without_display() -> None:
     """
     import toyo_battery.gui.tk_app as tk_app
 
-    assert callable(tk_app.main)
+    assert callable(tk_app.launch_gui)
 
 
-def test_gui_package_reexports_main() -> None:
+def test_gui_package_reexports_launch_gui() -> None:
+    """``launch_gui`` is the public entry point — callable from CLI
+    (``python -m toyo_battery.gui``) and from host Python processes such
+    as Origin's embedded console (``from toyo_battery.gui import
+    launch_gui``). Guarding the re-export keeps that import path stable.
+    """
     import toyo_battery.gui as gui
 
-    assert callable(gui.main)
+    assert callable(gui.launch_gui)


### PR DESCRIPTION
## Summary
- Rename the Tk entry point `main()` → `launch_gui()` and re-export it from `toyo_battery.gui` so Origin's embedded Python Console can open the GUI with `from toyo_battery.gui import launch_gui; launch_gui()`.
- Add a **Launching the GUI from Origin** section to `docs/ORIGIN_SETUP.md` covering the mainloop-blocks-the-console caveat, the `[gui]` extra, and the `_tkinter` requirement. `README.md` gains a one-line pointer.
- `python -m toyo_battery.gui` continues to work — `__main__.py` imports the renamed symbol. `tests/test_gui.py` smoke checks updated to the new name.

Rationale: closes the missing piece between `pip install toyo-battery` into Origin and actually using the Tk frontend without leaving Origin. In-process `mainloop()` was chosen over a `subprocess.Popen` fallback per the approved plan — Origin 2022+ ships `_tkinter`, and blocking the console is acceptable UX.

## Test plan
- [x] `uv run pytest --ignore=tests/test_cli.py -q` — 159 passed, 1 skipped (plotly extra not installed; unrelated)
- [x] `uv run python -c "from toyo_battery.gui import launch_gui; print(launch_gui)"` — resolves to `<function launch_gui ...>`
- [ ] Manual: `python -m toyo_battery.gui` still opens the Tk window
- [ ] Manual (requires Origin): paste the two-line recipe from `docs/ORIGIN_SETUP.md` into Origin's Python Console → window opens, closing it returns control to the console

Note: `test_cli.py` and `mypy` report pre-existing failures from missing `typer`/`rich` dev deps; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)