### PR TITLE
fix(tooling): unblock pytest and mypy without [cli] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,12 @@ files = ["src/toyo_battery"]
 plugins = []
 
 [[tool.mypy.overrides]]
-module = ["originpro.*", "scipy.*", "matplotlib.*", "plotly.*", "kaleido.*"]
+module = ["originpro.*", "scipy.*", "matplotlib.*", "plotly.*", "kaleido.*", "typer.*", "rich.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "toyo_battery.cli"
+disallow_untyped_decorators = false
 
 [tool.pytest.ini_options]
 minversion = "8.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,9 @@ from typing import Callable
 
 import pandas as pd
 import pytest
+
+pytest.importorskip("typer")
+
 from typer.testing import CliRunner
 
 from toyo_battery.cli import app


### PR DESCRIPTION
## Summary
- `tests/test_cli.py` now guards with `pytest.importorskip("typer")` so collection skips cleanly on envs without the `[cli]` extra instead of erroring out and aborting the whole suite.
- `pyproject.toml` adds `typer.*` / `rich.*` to the mypy `ignore_missing_imports` overrides, and turns off `disallow_untyped_decorators` for `toyo_battery.cli` so `@app.command()` stops being flagged as an untyped decorator when typer stubs are absent.

Closes #54

## Test plan
Verified in both configurations:

**Without `[cli]` extra** (`uv sync`):
- [x] `uv run pytest -q` — 159 passed, 2 skipped (`test_cli.py` skipped cleanly, no collection error)
- [x] `uv run mypy` — `Success: no issues found in 23 source files`
- [x] `uv run ruff check` — All checks passed

**With `[cli]` extra** (`uv sync --extra cli`):
- [x] `uv run pytest -q tests/test_cli.py` — 7 passed (no regression)
- [x] `uv run mypy` — Success
- [x] `uv run ruff check` — All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)