### PR TITLE
fix(origin): bind columns so template-backed graphs render data

### DIFF
--- a/src/toyo_battery/origin/__init__.py
+++ b/src/toyo_battery/origin/__init__.py
@@ -103,7 +103,7 @@ def push_to_origin(
         per_cell_sheets.append(sheets)
 
     if len(cells) > 1:
-        create_comparison_plots(op, per_cell_sheets)
+        create_comparison_plots(op, list(cells), per_cell_sheets)
 
     stat_df = stat_table(cells, target_cycles=list(stat_cycles))
     write_stat_table(op, stat_df)

--- a/src/toyo_battery/origin/__init__.py
+++ b/src/toyo_battery/origin/__init__.py
@@ -103,7 +103,7 @@ def push_to_origin(
         per_cell_sheets.append(sheets)
 
     if len(cells) > 1:
-        create_comparison_plots(op, list(cells), per_cell_sheets)
+        create_comparison_plots(op, cells, per_cell_sheets)
 
     stat_df = stat_table(cells, target_cycles=list(stat_cycles))
     write_stat_table(op, stat_df)

--- a/src/toyo_battery/origin/_plots.py
+++ b/src/toyo_battery/origin/_plots.py
@@ -39,6 +39,7 @@ remediation message rather than spreading that concern across callers.
 from __future__ import annotations
 
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -155,7 +156,7 @@ def create_cell_plots(op: Any, cell: Any, sheets: dict[str, Any]) -> list[Any]:
 
 def create_comparison_plots(
     op: Any,
-    cells: list[Any],
+    cells: Sequence[Any],
     per_cell_sheets: list[dict[str, Any]],
 ) -> list[Any]:
     """Create three overlay graphs that combine every cell's sheets.
@@ -164,6 +165,12 @@ def create_comparison_plots(
     sheet contributes its own set of ``add_plot`` calls. Graph names are
     fixed (``comparison_chdis_plot`` etc.) since there is no per-cell
     disambiguation to perform.
+
+    Per-category bind shape mirrors :func:`create_cell_plots`:
+    ``chdis`` / ``dqdv`` emit one ``add_plot`` per ``(cycle, side)``
+    column pair on ``graph[0]``; ``cycle`` emits two calls per cell, one
+    per dual-Y layer (``graph[0]`` = discharge capacity,
+    ``graph[1]`` = Coulombic efficiency).
     """
     chdis_graph = _new_graph_from_template(op, _TEMPLATE_CHDIS, "comparison_chdis_plot")
     for cell, sheets in zip(cells, per_cell_sheets):

--- a/src/toyo_battery/origin/_plots.py
+++ b/src/toyo_battery/origin/_plots.py
@@ -12,12 +12,24 @@ confirm them — see issue #15):
 * ``op.new_graph(template=<otpu_path>, lname=<graph_name>)`` creates a
   graph from the template and returns a graph-like object with at least
   ``.name`` and ``.lname`` attributes.
-* The returned graph exposes a ``set_xy`` / ``add_plot`` mechanism. We
-  use the lowest-common-denominator path here: resolve the first layer
-  via ``graph[0]`` (real ``originpro`` graphs are indexable by layer
-  index) and call ``add_plot(sheet, coly=<col>, colx=<col>)``. Real
-  ``.otpu`` templates supply their own plot types + axis scaling, so the
-  data bind is the only thing we do from Python.
+* The returned graph is indexable by layer (``graph[0]``, ``graph[1]``).
+  Each layer exposes ``add_plot(sheet, colx=<int>, coly=<int>)`` where
+  ``colx`` / ``coly`` are 0-based column indices on the bound sheet.
+  Passing only the sheet (``add_plot(sheet)``) leaves the plot with no
+  column designation and Origin renders an empty graph window — the
+  column indices are mandatory for data to appear, even when the
+  template already provides plot types and axis scaling.
+
+The three templates expect distinct column layouts; the bind helpers in
+this module encode the layout per category:
+
+* ``chdis`` — flatten columns come in ``(電気量, 電圧)`` pairs, one pair
+  per ``(cycle, side)``. One ``add_plot`` call per pair.
+* ``cycle`` — flat columns ``[cycle, q_ch, q_dis, ce]``. The template
+  is a dual-Y layout: left-Y layer plots ``q_dis`` vs ``cycle``, right-Y
+  layer plots ``ce`` vs ``cycle``.
+* ``dqdv`` — flatten columns come in ``(電圧, dqdv)`` pairs, one pair
+  per ``(cycle, side)``. One ``add_plot`` call per pair.
 
 Because the template handling depends on a runtime file that may not be
 present, the helpers here centralize the ``FileNotFoundError`` with a
@@ -33,6 +45,14 @@ from typing import Any
 _TEMPLATE_CHDIS = "charge_discharge.otpu"
 _TEMPLATE_CYCLE = "cycle_efficiency.otpu"
 _TEMPLATE_DQDV = "dqdv.otpu"
+
+# Column indices for cap_df after reset_index(): [cycle, q_ch, q_dis, ce].
+# Pinned here so the cycle_efficiency bind is resilient to cap_df column
+# reorderings — a future refactor that changes the order must also touch
+# these constants (and would fail a focused test).
+_CYCLE_COL_CYCLE = 0
+_CYCLE_COL_QDIS = 2
+_CYCLE_COL_CE = 3
 
 _TEMPLATE_ENV_VAR = "TOYO_ORIGIN_TEMPLATE_DIR"
 
@@ -83,60 +103,78 @@ def _require_template(name: str) -> Path:
     return path
 
 
-def _make_graph(op: Any, template_name: str, graph_name: str, sheet: Any) -> Any:
-    """Instantiate a graph from a template and bind it to a sheet.
-
-    The sheet-binding step is a single ``add_plot`` call on the graph's
-    first layer. We intentionally do not specify a plot type — the
-    ``.otpu`` template carries the type, axis limits, legend, etc.
-    """
+def _new_graph_from_template(op: Any, template_name: str, graph_name: str) -> Any:
+    """Return a graph instantiated from a template, with no data bound yet."""
     template_path = _require_template(template_name)
-    graph = op.new_graph(template=str(template_path), lname=graph_name)
-    # ``graph[0]`` is the first layer. Real ``originpro`` graphs are
-    # indexable; the mocked test uses a MagicMock where indexing returns
-    # another MagicMock, so this line is exercised in tests.
-    layer = graph[0]
-    layer.add_plot(sheet)
-    return graph
+    return op.new_graph(template=str(template_path), lname=graph_name)
+
+
+def _bind_xy_pairs(layer: Any, sheet: Any, ncols: int) -> None:
+    """Bind every ``(colx, coly)`` pair from ``sheet`` onto ``layer``.
+
+    Used for ``chdis`` and ``dqdv`` sheets, whose flattened columns line
+    up in contiguous pairs: ``(電気量, 電圧)`` for chdis,
+    ``(電圧, dqdv)`` for dqdv. Trailing odd columns — which should never
+    occur given the upstream pair-producing pipeline — are skipped
+    rather than bound as an orphan plot.
+    """
+    for i in range(0, ncols - 1, 2):
+        layer.add_plot(sheet, colx=i, coly=i + 1)
+
+
+def _bind_cycle(graph: Any, sheet: Any) -> None:
+    """Bind the cycle_efficiency dual-Y layout.
+
+    The template has two layers: ``graph[0]`` is the left Y (discharge
+    capacity), ``graph[1]`` is the right Y (Coulombic efficiency). Both
+    share ``cycle`` as X.
+    """
+    graph[0].add_plot(sheet, colx=_CYCLE_COL_CYCLE, coly=_CYCLE_COL_QDIS)
+    graph[1].add_plot(sheet, colx=_CYCLE_COL_CYCLE, coly=_CYCLE_COL_CE)
 
 
 def create_cell_plots(op: Any, cell: Any, sheets: dict[str, Any]) -> list[Any]:
     """Create the three per-cell graphs from templates.
 
     ``sheets`` is the mapping returned by
-    :func:`toyo_battery.origin._worksheets.write_cell_sheets`.
+    :func:`toyo_battery.origin._worksheets.write_cell_sheets`. ``cell``
+    is used to read the per-category column counts so the bind helpers
+    know how many plot pairs to emit.
     """
-    graphs: list[Any] = []
-    graphs.append(
-        _make_graph(op, _TEMPLATE_CHDIS, f"{cell.name}_chdis_plot", sheets["chdis"]),
-    )
-    graphs.append(
-        _make_graph(op, _TEMPLATE_CYCLE, f"{cell.name}_cycle_plot", sheets["cycle"]),
-    )
-    graphs.append(
-        _make_graph(op, _TEMPLATE_DQDV, f"{cell.name}_dqdv_plot", sheets["dqdv"]),
-    )
-    return graphs
+    chdis_graph = _new_graph_from_template(op, _TEMPLATE_CHDIS, f"{cell.name}_chdis_plot")
+    _bind_xy_pairs(chdis_graph[0], sheets["chdis"], cell.chdis_df.shape[1])
+
+    cycle_graph = _new_graph_from_template(op, _TEMPLATE_CYCLE, f"{cell.name}_cycle_plot")
+    _bind_cycle(cycle_graph, sheets["cycle"])
+
+    dqdv_graph = _new_graph_from_template(op, _TEMPLATE_DQDV, f"{cell.name}_dqdv_plot")
+    _bind_xy_pairs(dqdv_graph[0], sheets["dqdv"], cell.dqdv_df.shape[1])
+
+    return [chdis_graph, cycle_graph, dqdv_graph]
 
 
-def create_comparison_plots(op: Any, per_cell_sheets: list[dict[str, Any]]) -> list[Any]:
+def create_comparison_plots(
+    op: Any,
+    cells: list[Any],
+    per_cell_sheets: list[dict[str, Any]],
+) -> list[Any]:
     """Create three overlay graphs that combine every cell's sheets.
 
-    One graph per category (``chdis``, ``cycle``, ``dqdv``); each graph's
-    first layer has one ``add_plot`` call per cell. Graph names are
+    One graph per category (``chdis``, ``cycle``, ``dqdv``); each cell's
+    sheet contributes its own set of ``add_plot`` calls. Graph names are
     fixed (``comparison_chdis_plot`` etc.) since there is no per-cell
     disambiguation to perform.
     """
-    graphs: list[Any] = []
-    for category, template_name, graph_name in (
-        ("chdis", _TEMPLATE_CHDIS, "comparison_chdis_plot"),
-        ("cycle", _TEMPLATE_CYCLE, "comparison_cycle_plot"),
-        ("dqdv", _TEMPLATE_DQDV, "comparison_dqdv_plot"),
-    ):
-        template_path = _require_template(template_name)
-        graph = op.new_graph(template=str(template_path), lname=graph_name)
-        layer = graph[0]
-        for sheets in per_cell_sheets:
-            layer.add_plot(sheets[category])
-        graphs.append(graph)
-    return graphs
+    chdis_graph = _new_graph_from_template(op, _TEMPLATE_CHDIS, "comparison_chdis_plot")
+    for cell, sheets in zip(cells, per_cell_sheets):
+        _bind_xy_pairs(chdis_graph[0], sheets["chdis"], cell.chdis_df.shape[1])
+
+    cycle_graph = _new_graph_from_template(op, _TEMPLATE_CYCLE, "comparison_cycle_plot")
+    for _cell, sheets in zip(cells, per_cell_sheets):
+        _bind_cycle(cycle_graph, sheets["cycle"])
+
+    dqdv_graph = _new_graph_from_template(op, _TEMPLATE_DQDV, "comparison_dqdv_plot")
+    for cell, sheets in zip(cells, per_cell_sheets):
+        _bind_xy_pairs(dqdv_graph[0], sheets["dqdv"], cell.dqdv_df.shape[1])
+
+    return [chdis_graph, cycle_graph, dqdv_graph]

--- a/src/toyo_battery/origin/_worksheets.py
+++ b/src/toyo_battery/origin/_worksheets.py
@@ -19,6 +19,11 @@ confirm them — see issue #15):
   also expose a ``name`` attribute; helpers here return the sheet object
   so the caller can read ``.name`` / ``.lname`` if it wants to wire the
   sheet into a plot template.
+* The returned object also exposes ``cols_axis(types)``, where ``types``
+  is a string like ``"XYY"`` assigning one plot role per column. We call
+  this after ``from_df`` because ``from_df`` leaves every column as
+  default-``"Y"``; template-backed plots need at least one ``"X"`` column
+  designated or they render with an empty data binding.
 * Origin's sheet-name length limit is 32 characters. This module enforces
   that cap in ``_sanitize_sheet_name`` before calling ``new_sheet``.
 
@@ -86,19 +91,47 @@ def _flatten_columns(df: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(out)
 
 
-def _write_sheet(op: Any, sheet_name: str, df: pd.DataFrame) -> Any:
+def _write_sheet(
+    op: Any,
+    sheet_name: str,
+    df: pd.DataFrame,
+    *,
+    axis_types: str | None = None,
+) -> Any:
     """Create a worksheet and populate it from a DataFrame.
 
     Assumes ``op.new_sheet(type="w", lname=sheet_name)`` returns a
     worksheet-like object with a ``from_df`` method. Returns that object
     so callers (e.g. :mod:`._plots`) can reference the sheet when
     instantiating a template-backed graph.
+
+    ``axis_types`` — when given, is forwarded to ``wks.cols_axis`` after
+    the DataFrame is written. Each character designates one column's
+    plot role (``"X"``, ``"Y"``, ``"Z"``, ``"E"`` etc.). Without this
+    call, ``from_df`` leaves every column as plain ``"Y"``, which means
+    template-backed plots have no X source to bind against and render
+    empty. Pass ``None`` to keep the default (e.g. for ``stat_table``,
+    which is never plotted).
     """
     safe_name = _sanitize_sheet_name(sheet_name)
     flat = _flatten_columns(df)
     wks = op.new_sheet(type="w", lname=safe_name)
     wks.from_df(flat)
+    if axis_types:
+        wks.cols_axis(axis_types)
     return wks
+
+
+def _xy_pairs_axis(ncols: int) -> str:
+    """Return ``"XY"`` repeated for ``ncols // 2`` pairs.
+
+    Used for ``chdis`` / ``dqdv`` sheets whose flattened columns come in
+    ``(X, Y)`` pairs — ``(電気量, 電圧)`` for chdis and ``(電圧, dqdv)``
+    for dqdv. Odd column counts fall back to ``"Y"`` for the trailing
+    column, matching Origin's per-column default.
+    """
+    pairs, tail = divmod(ncols, 2)
+    return "XY" * pairs + ("Y" if tail else "")
 
 
 def write_cell_sheets(op: Any, cell: Any) -> dict[str, Any]:
@@ -122,10 +155,36 @@ def write_cell_sheets(op: Any, cell: Any) -> dict[str, Any]:
         callers can look up each sheet without re-computing the
         sanitized full name.
     """
+    chdis = cell.chdis_df
+    # cap_df carries the cycle number in its index; surface it as a
+    # regular column so Origin has an X source for the cycle_efficiency
+    # plot. Matches the pattern :func:`write_stat_table` already uses.
+    cap = cell.cap_df.reset_index()
+    dqdv = cell.dqdv_df
+
     sheets: dict[str, Any] = {}
-    sheets["chdis"] = _write_sheet(op, f"{cell.name}_chdis", cell.chdis_df)
-    sheets["cycle"] = _write_sheet(op, f"{cell.name}_cycle", cell.cap_df)
-    sheets["dqdv"] = _write_sheet(op, f"{cell.name}_dqdv", cell.dqdv_df)
+    sheets["chdis"] = _write_sheet(
+        op,
+        f"{cell.name}_chdis",
+        chdis,
+        axis_types=_xy_pairs_axis(chdis.shape[1]),
+    )
+    # cap_df after reset_index: [cycle, q_ch, q_dis, ce] → "XYYY".
+    # q_ch is kept as Y rather than dropped so the user can easily
+    # re-plot it without re-running the pipeline.
+    cycle_axis = ("X" + "Y" * (cap.shape[1] - 1)) if cap.shape[1] else None
+    sheets["cycle"] = _write_sheet(
+        op,
+        f"{cell.name}_cycle",
+        cap,
+        axis_types=cycle_axis,
+    )
+    sheets["dqdv"] = _write_sheet(
+        op,
+        f"{cell.name}_dqdv",
+        dqdv,
+        axis_types=_xy_pairs_axis(dqdv.shape[1]),
+    )
     return sheets
 
 

--- a/src/toyo_battery/origin/_worksheets.py
+++ b/src/toyo_battery/origin/_worksheets.py
@@ -117,7 +117,10 @@ def _write_sheet(
     flat = _flatten_columns(df)
     wks = op.new_sheet(type="w", lname=safe_name)
     wks.from_df(flat)
-    if axis_types:
+    # ``None`` = caller opted out (e.g. ``stat_table``). Empty string =
+    # zero-column sheet (``_xy_pairs_axis(0)`` or ``_single_x_axis(0)``);
+    # both skip the call since there is nothing to designate.
+    if axis_types is not None and axis_types:
         wks.cols_axis(axis_types)
     return wks
 
@@ -132,6 +135,19 @@ def _xy_pairs_axis(ncols: int) -> str:
     """
     pairs, tail = divmod(ncols, 2)
     return "XY" * pairs + ("Y" if tail else "")
+
+
+def _single_x_axis(ncols: int) -> str:
+    """Return ``"X"`` followed by ``"Y"`` repeated ``ncols - 1`` times.
+
+    Used for the ``cycle`` sheet whose flattened layout is
+    ``[cycle, q_ch, q_dis, ce]`` — one leading X column and the rest Y.
+    Empty input yields ``""`` so the ``_write_sheet`` no-op guard
+    handles the zero-cycle degenerate case without a ``cols_axis`` call.
+    """
+    if ncols <= 0:
+        return ""
+    return "X" + "Y" * (ncols - 1)
 
 
 def write_cell_sheets(op: Any, cell: Any) -> dict[str, Any]:
@@ -172,12 +188,11 @@ def write_cell_sheets(op: Any, cell: Any) -> dict[str, Any]:
     # cap_df after reset_index: [cycle, q_ch, q_dis, ce] → "XYYY".
     # q_ch is kept as Y rather than dropped so the user can easily
     # re-plot it without re-running the pipeline.
-    cycle_axis = ("X" + "Y" * (cap.shape[1] - 1)) if cap.shape[1] else None
     sheets["cycle"] = _write_sheet(
         op,
         f"{cell.name}_cycle",
         cap,
-        axis_types=cycle_axis,
+        axis_types=_single_x_axis(cap.shape[1]),
     )
     sheets["dqdv"] = _write_sheet(
         op,

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -387,9 +387,7 @@ def test_each_per_cell_graph_binds_its_own_sheet(
             )
 
 
-def test_add_plot_passes_column_indices(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_add_plot_passes_column_indices(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Every ``add_plot`` call must carry ``colx`` and ``coly`` kwargs.
 
     Without these, Origin renders the template's axes/legend but binds
@@ -411,9 +409,7 @@ def test_add_plot_passes_column_indices(
             assert "coly" in call.kwargs, f"missing coly on {graph!r}: {call}"
 
 
-def test_cycle_plot_binds_both_layers(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_cycle_plot_binds_both_layers(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """cycle_efficiency's dual-Y template has two layers — bind both.
 
     ``graph[0]`` takes discharge capacity (col 2), ``graph[1]`` takes
@@ -441,9 +437,7 @@ def test_cycle_plot_binds_both_layers(
     assert all(call.kwargs["colx"] == 0 for call in call_list), call_list
 
 
-def test_cols_axis_is_set_per_category(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_cols_axis_is_set_per_category(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Worksheets for plot-targeted categories must declare X/Y designations.
 
     ``from_df`` leaves every column as ``"Y"``; without a ``cols_axis``

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -326,12 +326,17 @@ def test_push_to_origin_skips_open_save_when_project_path_none(
 # ----------------------------------------------------------------------
 
 
-def test_each_per_cell_graph_binds_its_own_sheet(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """Each per-cell graph's add_plot must bind exactly its corresponding sheet."""
+def _install_tracking_originpro(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[MagicMock, list[MagicMock], list[MagicMock]]:
+    """Install a mock originpro that returns a fresh MagicMock per sheet/graph.
+
+    Returning distinct mocks (instead of the default single shared
+    ``return_value``) lets tests correlate individual sheet objects with
+    the ``add_plot`` calls bound to them. Worksheet mocks also get a
+    ``cols_axis`` spec so assertions on column designation stay honest.
+    """
     mock_op = _install_mock_originpro(monkeypatch)
-    _stub_templates(monkeypatch, tmp_path)
 
     sheet_objs: list[MagicMock] = []
 
@@ -349,17 +354,153 @@ def test_each_per_cell_graph_binds_its_own_sheet(
 
     mock_op.new_sheet.side_effect = _fake_new_sheet
     mock_op.new_graph.side_effect = _fake_new_graph
+    return mock_op, sheet_objs, graph_objs
 
+
+def test_each_per_cell_graph_binds_its_own_sheet(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Each per-cell graph's add_plot calls must reference only its own sheet."""
+    _stub_templates(monkeypatch, tmp_path)
+    _, sheet_objs, graph_objs = _install_tracking_originpro(monkeypatch)
     cell = _linear_cell("A")
 
     from toyo_battery.origin import push_to_origin
 
     push_to_origin([cell], stat_cycles=(1,))
 
-    # write_cell_sheets adds sheets in order chdis → cycle → dqdv (the
+    # write_cell_sheets creates sheets in order chdis → cycle → dqdv (the
     # stat_table sheet comes last, see push_to_origin orchestration).
     # create_cell_plots emits graphs in the same chdis → cycle → dqdv order.
-    # So the i-th graph's first layer must add_plot the i-th sheet.
     assert len(graph_objs) >= 3, "expected at least 3 per-cell graphs"
-    for graph, expected_sheet in zip(graph_objs, sheet_objs[:3]):
-        graph.__getitem__.return_value.add_plot.assert_called_once_with(expected_sheet)
+    for graph, expected_sheet in zip(graph_objs[:3], sheet_objs[:3]):
+        # MagicMock's __getitem__ returns the same inner mock regardless
+        # of index, so both graph[0] and graph[1] share call_args_list.
+        # chdis / dqdv emit multiple add_plot calls (one per cycle×side
+        # pair); cycle emits two (one per layer). Every call must point
+        # at the same sheet.
+        calls = graph.__getitem__.return_value.add_plot.call_args_list
+        assert calls, f"no add_plot calls on {graph!r}"
+        for call in calls:
+            assert call.args[0] is expected_sheet, (
+                f"add_plot bound wrong sheet on {graph!r}: {call}"
+            )
+
+
+def test_add_plot_passes_column_indices(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Every ``add_plot`` call must carry ``colx`` and ``coly`` kwargs.
+
+    Without these, Origin renders the template's axes/legend but binds
+    no data — the v0.0.2 regression that this test guards against.
+    """
+    _stub_templates(monkeypatch, tmp_path)
+    _, _, graph_objs = _install_tracking_originpro(monkeypatch)
+    cell = _linear_cell("A")
+
+    from toyo_battery.origin import push_to_origin
+
+    push_to_origin([cell], stat_cycles=(1,))
+
+    for graph in graph_objs[:3]:
+        calls = graph.__getitem__.return_value.add_plot.call_args_list
+        assert calls, f"no add_plot calls on {graph!r}"
+        for call in calls:
+            assert "colx" in call.kwargs, f"missing colx on {graph!r}: {call}"
+            assert "coly" in call.kwargs, f"missing coly on {graph!r}: {call}"
+
+
+def test_cycle_plot_binds_both_layers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cycle_efficiency's dual-Y template has two layers — bind both.
+
+    ``graph[0]`` takes discharge capacity (col 2), ``graph[1]`` takes
+    Coulombic efficiency (col 3). Both share ``cycle`` (col 0) as X.
+    """
+    _stub_templates(monkeypatch, tmp_path)
+    _, _, graph_objs = _install_tracking_originpro(monkeypatch)
+    cell = _linear_cell("A")
+
+    from toyo_battery.origin import push_to_origin
+
+    push_to_origin([cell], stat_cycles=(1,))
+
+    # Per-cell graphs emit in order chdis → cycle → dqdv.
+    cycle_graph = graph_objs[1]
+    # MagicMock indexing history: __getitem__.call_args_list records each
+    # access. We expect both 0 and 1 to have been accessed.
+    indexed = {call.args[0] for call in cycle_graph.__getitem__.call_args_list}
+    assert 0 in indexed and 1 in indexed, f"cycle graph accessed only {indexed}"
+
+    # Two add_plot calls total on the shared inner mock: one per layer.
+    call_list = cycle_graph.__getitem__.return_value.add_plot.call_args_list
+    colys = sorted(call.kwargs["coly"] for call in call_list)
+    assert colys == [2, 3], f"expected q_dis + ce bound, got coly={colys}"
+    assert all(call.kwargs["colx"] == 0 for call in call_list), call_list
+
+
+def test_cols_axis_is_set_per_category(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Worksheets for plot-targeted categories must declare X/Y designations.
+
+    ``from_df`` leaves every column as ``"Y"``; without a ``cols_axis``
+    call the template-backed plot has no X to bind against and renders
+    empty. ``stat_table`` is never plotted so it skips the call.
+    """
+    _stub_templates(monkeypatch, tmp_path)
+    mock_op, sheet_objs, _ = _install_tracking_originpro(monkeypatch)
+    cell = _linear_cell("A")
+
+    from toyo_battery.origin import push_to_origin
+
+    push_to_origin([cell], stat_cycles=(1,))
+
+    # Sheet creation order: chdis → cycle → dqdv → stat_table.
+    chdis_sheet, cycle_sheet, dqdv_sheet, stat_sheet = sheet_objs[:4]
+
+    # chdis / dqdv: "XY" repeated — one pair per (cycle, side) column pair.
+    for sheet in (chdis_sheet, dqdv_sheet):
+        args = sheet.cols_axis.call_args
+        assert args is not None, f"cols_axis not called on {sheet!r}"
+        types = args.args[0]
+        assert set(types) <= {"X", "Y"}, types
+        assert types.startswith("XY"), types
+        assert len(types) % 2 == 0, types
+
+    # cycle: [cycle, q_ch, q_dis, ce] → "XYYY".
+    cycle_sheet.cols_axis.assert_called_once_with("XYYY")
+
+    # stat_table must NOT have a cols_axis call (never plotted).
+    assert not stat_sheet.cols_axis.called
+
+
+def test_cap_df_written_with_cycle_as_column(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cap_df's ``cycle`` index must be surfaced as a column before from_df.
+
+    Without ``reset_index``, Origin receives only ``[q_ch, q_dis, ce]``
+    and the cycle_efficiency plot has no X source — graph window opens
+    but nothing is plotted.
+    """
+    _stub_templates(monkeypatch, tmp_path)
+    mock_op, sheet_objs, _ = _install_tracking_originpro(monkeypatch)
+    cell = _linear_cell("A")
+
+    from toyo_battery.origin import push_to_origin
+
+    push_to_origin([cell], stat_cycles=(1,))
+
+    # Second sheet created is the cycle sheet (chdis=0, cycle=1, dqdv=2).
+    cycle_sheet = sheet_objs[1]
+    from_df_call = cycle_sheet.from_df.call_args
+    assert from_df_call is not None, "from_df not called on cycle sheet"
+    written = from_df_call.args[0]
+    assert "cycle" in written.columns, (
+        f"cycle column missing from cap_df write: {list(written.columns)}"
+    )
+    # Order must match the _CYCLE_COL_* constants in _plots.py.
+    assert list(written.columns)[0] == "cycle", list(written.columns)

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -376,9 +376,9 @@ def test_each_per_cell_graph_binds_its_own_sheet(
     for graph, expected_sheet in zip(graph_objs[:3], sheet_objs[:3]):
         # MagicMock's __getitem__ returns the same inner mock regardless
         # of index, so both graph[0] and graph[1] share call_args_list.
-        # chdis / dqdv emit multiple add_plot calls (one per cycle×side
-        # pair); cycle emits two (one per layer). Every call must point
-        # at the same sheet.
+        # chdis / dqdv emit multiple add_plot calls (one per (cycle,
+        # side) pair); cycle emits two (one per layer). Every call must
+        # point at the same sheet.
         calls = graph.__getitem__.return_value.add_plot.call_args_list
         assert calls, f"no add_plot calls on {graph!r}"
         for call in calls:
@@ -451,7 +451,7 @@ def test_cols_axis_is_set_per_category(
     empty. ``stat_table`` is never plotted so it skips the call.
     """
     _stub_templates(monkeypatch, tmp_path)
-    mock_op, sheet_objs, _ = _install_tracking_originpro(monkeypatch)
+    _, sheet_objs, _ = _install_tracking_originpro(monkeypatch)
     cell = _linear_cell("A")
 
     from toyo_battery.origin import push_to_origin
@@ -487,7 +487,7 @@ def test_cap_df_written_with_cycle_as_column(
     but nothing is plotted.
     """
     _stub_templates(monkeypatch, tmp_path)
-    mock_op, sheet_objs, _ = _install_tracking_originpro(monkeypatch)
+    _, sheet_objs, _ = _install_tracking_originpro(monkeypatch)
     cell = _linear_cell("A")
 
     from toyo_battery.origin import push_to_origin
@@ -503,4 +503,4 @@ def test_cap_df_written_with_cycle_as_column(
         f"cycle column missing from cap_df write: {list(written.columns)}"
     )
     # Order must match the _CYCLE_COL_* constants in _plots.py.
-    assert list(written.columns)[0] == "cycle", list(written.columns)
+    assert next(iter(written.columns)) == "cycle", list(written.columns)


### PR DESCRIPTION
## Summary

- `push_to_origin` を呼ぶと Origin 上にグラフウィンドウは開くのにデータが描画されない不具合を修正。根本原因は [`_plots.py`](src/toyo_battery/origin/_plots.py) で `layer.add_plot(sheet)` を `colx`/`coly` 抜きで呼んでいたこと。`originpro` の `add_plot` はデフォルト `coly=-1` だと**プロット実体を生成しない**ため、テンプレート由来の軸・凡例だけが残って中身が空になっていた（docstring には `add_plot(sheet, coly=<col>, colx=<col>)` と書いてあり、実装とズレていた）。
- 副因として `cap_df` を `index=cycle` のまま `from_df` していたため、そもそも Origin 側に `cycle` 列が存在せず `cycle_efficiency` の X 軸に束縛する先がなかった。これも併せて修正。

### 変更点

- **`_plots.py`**: `add_plot` 呼び出しを category ごとのヘルパ（`_bind_xy_pairs` / `_bind_cycle`）に分離し、`colx` / `coly` を明示的に渡すよう変更。`cycle_efficiency` のテンプレートは dual-Y（左 Y=容量、右 Y=CE）なので `graph[0]` と `graph[1]` 両方にバインド。`create_comparison_plots` は ncols を計算するため `cells` 引数も受け取るようにシグネチャを拡張。
- **`_worksheets.py`**: `cap_df.reset_index()` で cycle を列化（`write_stat_table` の既存パターンに揃える）。`_write_sheet` に `axis_types` kwarg を追加し、`from_df` 直後に `wks.cols_axis("XYY...")` を呼んで列属性を X/Y で明示。これをしないと `from_df` は全列を Y として書き、テンプレート側の plot に束縛可能な X が無い。
- **`test_origin.py`**: 既存の `assert_called_once_with(expected_sheet)` は `chdis`/`dqdv` が cycle×side 回 `add_plot` を呼ぶ新仕様下で成立しないので緩和。加えて 4 本追加:
  - `test_add_plot_passes_column_indices` — 全 `add_plot` 呼び出しに `colx`/`coly` kwarg が乗っているか
  - `test_cycle_plot_binds_both_layers` — `graph[0]` / `graph[1]` 両方に `add_plot` され、`coly=[2, 3]` (q_dis, ce) になっているか
  - `test_cols_axis_is_set_per_category` — chdis/dqdv は XY パターン、cycle は `"XYYY"`、stat_table は呼ばれないこと
  - `test_cap_df_written_with_cycle_as_column` — `from_df` に渡された DataFrame の先頭列が `cycle` であること

関連: `_plots.py` の docstring が参照していた issue #15（real-Origin verification）の修正条件に相当。

## Test plan

- [x] `uv run pytest` → 167 passed / 2 skipped（CLI/plotly extra 無しスキップは事前と同じ）
- [x] `uv run mypy src/toyo_battery/origin` → clean
- [ ] **Origin 実機での目視検証**（ここは手動、レビュア or メインテナ側で実施お願いします）:
  - [ ] `pip install -e .[origin]` を Origin embedded Python で実行
  - [ ] `from toyo_battery.origin import launch_gui; launch_gui()` を Origin の Python コンソールで叩き、サンプル CSV ディレクトリを選択して Run
  - [ ] `{cell}_chdis_plot` に V-Q 曲線がサイクル数ぶん描画される
  - [ ] `{cell}_cycle_plot` に discharge capacity（左 Y）と CE（右 Y）が dual-Y で描画される
  - [ ] `{cell}_dqdv_plot` に dQ/dV-V 曲線が描画される
  - [ ] 複数セル時に `comparison_*_plot` がそれぞれ全セル分オーバレイされる
  - [ ] テンプレート側に placeholder plot が残って二重描画になっていないか（出ていたら続報 PR で `remove_plot(0)` を足す）

🤖 Generated with [Claude Code](https://claude.com/claude-code)