### PR TITLE
feat(gui): simplify folder selection + enable multi-folder drag-and-drop (#62, #63)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 [project.optional-dependencies]
 plot = ["matplotlib>=3.7"]
 plotly = ["plotly>=5.18", "kaleido>=0.2.1"]
-gui = ["matplotlib>=3.7"]
+gui = ["matplotlib>=3.7", "tkinterdnd2>=0.3"]
 cli = ["typer>=0.12", "rich>=13"]
 origin = ["matplotlib>=3.7"]
 all = [
@@ -43,6 +43,7 @@ all = [
     "kaleido>=0.2.1",
     "typer>=0.12",
     "rich>=13",
+    "tkinterdnd2>=0.3",
 ]
 
 [project.scripts]
@@ -102,7 +103,7 @@ files = ["src/echemplot"]
 plugins = []
 
 [[tool.mypy.overrides]]
-module = ["originpro.*", "scipy.*", "matplotlib.*", "plotly.*", "kaleido.*", "typer.*", "rich.*"]
+module = ["originpro.*", "scipy.*", "matplotlib.*", "plotly.*", "kaleido.*", "typer.*", "rich.*", "tkinterdnd2"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/echemplot/gui/tk_app.py
+++ b/src/echemplot/gui/tk_app.py
@@ -15,6 +15,11 @@ Matplotlib and tkinter are imported at module scope so an
 ``ImportError`` raised when the ``[gui]`` extra is missing propagates
 immediately (the expected UX for an optional feature).
 
+``tkinterdnd2`` is an optional dependency (also shipped via the ``[gui]``
+extra): when present the directory Listbox accepts multi-folder
+drag-and-drop from the host file manager; when absent the GUI silently
+falls back to the Add-button-only workflow.
+
 The matplotlib / tkinter stubs are permissive and emit ``no-untyped-call``
 or ``arg-type`` errors for a handful of standard invocations
 (``FigureCanvasTkAgg``, ``NavigationToolbar2Tk``, ``Listbox.curselection``).
@@ -37,6 +42,13 @@ from matplotlib.backends.backend_tkagg import (  # type: ignore[attr-defined]
 )
 
 from echemplot.gui._controller import GuiRequest, run
+
+try:
+    from tkinterdnd2 import DND_FILES, TkinterDnD
+
+    _DND_AVAILABLE = True
+except ImportError:
+    _DND_AVAILABLE = False
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
@@ -143,6 +155,17 @@ class _App:
 
         self._dirs_list = tk.Listbox(dirs_frame, height=6, width=60)
         self._dirs_list.grid(row=0, column=0, rowspan=3, sticky="nsew", padx=_PADX, pady=_PADY)
+
+        # Enable multi-folder drag-and-drop when tkinterdnd2 is installed AND
+        # the current root was constructed with TkinterDnD.Tk (plain tk.Tk
+        # roots don't carry the dnd extension, so the listbox won't have
+        # drop_target_register bound even if the import above succeeded).
+        if _DND_AVAILABLE and hasattr(self.root, "tk") and callable(
+            getattr(self._dirs_list, "drop_target_register", None)
+        ):
+            self._dirs_list.drop_target_register(DND_FILES)  # type: ignore[attr-defined]
+            self._dirs_list.dnd_bind("<<Drop>>", self._on_drop)  # type: ignore[attr-defined]
+
         ttk.Button(dirs_frame, text="Add...", command=self._on_add).grid(
             row=0, column=1, sticky="ew", padx=_PADX, pady=_PADY
         )
@@ -217,21 +240,43 @@ class _App:
     # ----- directory list handlers ----------------------------------
 
     def _on_add(self) -> None:
-        """Open ``askdirectory`` in a loop so the user can add multiple dirs.
+        """Open ``askdirectory`` once and append the chosen directory.
 
-        An empty return from ``askdirectory`` (the user cancelled) breaks
-        the loop; otherwise each selection is appended to both the state
-        list and the display listbox.
+        Cancel (empty return from ``askdirectory``) is a no-op. Users who
+        want to add multiple directories can either click Add repeatedly
+        or drag-and-drop multiple folders onto the list when
+        ``tkinterdnd2`` is installed.
         """
-        while True:
-            selected = filedialog.askdirectory(
-                parent=self.root, title="Select a cell directory (cancel to stop)"
-            )
-            if not selected:
-                break
-            path = Path(selected)
-            self._dirs.append(path)
-            self._dirs_list.insert(tk.END, str(path))
+        selected = filedialog.askdirectory(parent=self.root, title="Select a cell directory")
+        if not selected:
+            return
+        self._add_dir(Path(selected))
+
+    def _on_drop(self, event: object) -> None:
+        """Handle a ``<<Drop>>`` event from tkinterdnd2.
+
+        ``event.data`` is a Tcl list string (brace-quoted for paths with
+        spaces); ``tk.splitlist`` unpacks it into a tuple of tokens.
+        Non-directory tokens are silently dropped so stray file drops
+        don't pollute the cell-directory list.
+        """
+        raw = getattr(event, "data", "")
+        for token in self.root.tk.splitlist(raw):
+            path = Path(token)
+            if path.is_dir():
+                self._add_dir(path)
+
+    def _add_dir(self, path: Path) -> None:
+        """Append ``path`` to the state list and Listbox if not already present.
+
+        Listbox allows duplicate rows but they make Remove-selected
+        ambiguous and produce redundant Cell loads at Run time, so we
+        de-dupe here.
+        """
+        if path in self._dirs:
+            return
+        self._dirs.append(path)
+        self._dirs_list.insert(tk.END, str(path))
 
     def _on_remove(self) -> None:
         # Walk selected indices in reverse so the remaining indices stay
@@ -359,9 +404,29 @@ def launch_gui(*, on_complete: OnComplete | None = None) -> None:
     import matplotlib
 
     matplotlib.use("TkAgg")
-    root = tk.Tk()
+    root = _make_root()
     _App(root, on_complete=on_complete)
     root.mainloop()
+
+
+def _make_root() -> tk.Tk:
+    """Return a Tk root, preferring ``TkinterDnD.Tk`` when the extra is installed.
+
+    ``TkinterDnD.Tk`` is a drop-in subclass that loads the tkdnd Tcl
+    extension into the interpreter so widgets can register as drop
+    targets. We fall back to plain ``tk.Tk`` silently when the package
+    isn't importable so the GUI still launches without the optional
+    drag-and-drop feature.
+    """
+    if _DND_AVAILABLE:
+        try:
+            return TkinterDnD.Tk()  # type: ignore[no-any-return]
+        except tk.TclError:
+            # The Python package imported but the underlying tkdnd Tcl
+            # extension failed to load (missing shared library on the
+            # host). Fall through to plain Tk rather than crash.
+            pass
+    return tk.Tk()
 
 
 if __name__ == "__main__":

--- a/src/echemplot/gui/tk_app.py
+++ b/src/echemplot/gui/tk_app.py
@@ -157,14 +157,21 @@ class _App:
         self._dirs_list.grid(row=0, column=0, rowspan=3, sticky="nsew", padx=_PADX, pady=_PADY)
 
         # Enable multi-folder drag-and-drop when tkinterdnd2 is installed AND
-        # the current root was constructed with TkinterDnD.Tk (plain tk.Tk
-        # roots don't carry the dnd extension, so the listbox won't have
-        # drop_target_register bound even if the import above succeeded).
-        if _DND_AVAILABLE and hasattr(self.root, "tk") and callable(
-            getattr(self._dirs_list, "drop_target_register", None)
-        ):
-            self._dirs_list.drop_target_register(DND_FILES)  # type: ignore[attr-defined]
-            self._dirs_list.dnd_bind("<<Drop>>", self._on_drop)  # type: ignore[attr-defined]
+        # the tkdnd Tcl extension actually loaded into this interpreter.
+        # Importing tkinterdnd2 monkey-patches ``drop_target_register`` onto
+        # every Tk widget regardless of whether the root is a ``TkinterDnD.Tk``
+        # instance, so ``hasattr`` / ``callable`` checks are not sufficient —
+        # calling the method on a plain ``tk.Tk`` root raises ``TclError:
+        # invalid command name "tkdnd::drop_target"``. We wrap the
+        # registration in ``try/except`` so the GUI still launches if
+        # ``_make_root`` fell back to plain ``tk.Tk`` (tkdnd shared library
+        # unavailable on the host).
+        if _DND_AVAILABLE:
+            try:
+                self._dirs_list.drop_target_register(DND_FILES)  # type: ignore[attr-defined]
+                self._dirs_list.dnd_bind("<<Drop>>", self._on_drop)  # type: ignore[attr-defined]
+            except tk.TclError:
+                pass
 
         ttk.Button(dirs_frame, text="Add...", command=self._on_add).grid(
             row=0, column=1, sticky="ew", padx=_PADX, pady=_PADY

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -328,3 +328,37 @@ def test_gui_package_reexports_launch_gui() -> None:
     import echemplot.gui as gui
 
     assert callable(gui.launch_gui)
+
+
+def test_add_dir_deduplicates_paths(tmp_path: Path) -> None:
+    """``_add_dir`` is the single path through which both Add-button and
+    drag-and-drop reach the state list; adding the same directory twice
+    must leave exactly one entry so Remove-selected / Run stays
+    unambiguous.
+
+    Exercised without a live Tk — we stub the Listbox ``insert`` call
+    since we only care about the ``self._dirs`` invariant and asserting
+    ``insert`` is not called on the duplicate attempt.
+    """
+    import echemplot.gui.tk_app as tk_app
+
+    class _FakeListbox:
+        def __init__(self) -> None:
+            self.inserts: list[str] = []
+
+        def insert(self, _where: object, value: str) -> None:
+            self.inserts.append(value)
+
+    app = tk_app._App.__new__(tk_app._App)
+    app._dirs = []  # type: ignore[attr-defined]
+    app._dirs_list = _FakeListbox()  # type: ignore[attr-defined]
+
+    d = tmp_path / "cell_a"
+    d.mkdir()
+
+    app._add_dir(d)
+    app._add_dir(d)  # duplicate — should be ignored
+    app._add_dir(tmp_path / "cell_b")  # different path — counted even though missing
+
+    assert app._dirs == [d, tmp_path / "cell_b"]
+    assert app._dirs_list.inserts == [str(d), str(tmp_path / "cell_b")]  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- Fixes #62 — `_on_add` no longer loops; one click = one folder (cancel is a no-op).
- Fixes #63 — Listbox now accepts multi-folder drag-and-drop via tkinterdnd2 (optional; falls back silently when the package isn't installed).
- Added `tkinterdnd2>=0.3` to the `[gui]` and `[all]` extras as an optional dependency.

## Test plan
- [ ] `ruff check` / `mypy` / `pytest` all green locally
- [ ] Manual: `python -m echemplot.gui` -> single click on Add adds exactly one folder; cancel adds nothing
- [ ] Manual: drag 2+ folders from Explorer onto the list -> all appear
- [ ] Manual: uninstall tkinterdnd2 -> GUI still launches; Add button still works; D&D silently disabled

Generated with [Claude Code](https://claude.com/claude-code)