### PR TITLE
feat(gui): grey out ineffective options in Origin mode (#60)

### DIFF
--- a/src/echemplot/gui/tk_app.py
+++ b/src/echemplot/gui/tk_app.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
     from echemplot.core.cell import Cell
 
-OnComplete = Callable[[Sequence["Cell"], Sequence["Figure"]], None]
+OnComplete = Callable[[Sequence["Cell"], Sequence["Figure"], int], None]
 
 _DEFAULT_CYCLES_TEXT = "1 10 50"
 _DEFAULT_SG_WINDOW_TEXT = "11"
@@ -144,7 +144,11 @@ class _App:
         # #60): ``push_to_origin`` always writes all three worksheets and
         # the full per-cell DataFrames, and the matplotlib figures the
         # controller returns are closed before their axis-range overrides
-        # can affect any visible plot.
+        # can affect any visible plot. ``SG window_length`` stays
+        # editable because the ``on_complete`` callback forwards it to
+        # :func:`echemplot.origin.push_to_origin`, which recomputes the
+        # dQ/dV DataFrame on non-default values so the user's choice
+        # actually lands in the worksheet.
         self._origin_mode = origin_mode
 
         self._build_widgets()
@@ -177,17 +181,11 @@ class _App:
         # Kept as instance attributes so ``_build_widgets`` can toggle
         # their ``state`` in origin-mode below (and so tests can assert
         # the disabled-state without reaching into grid slaves).
-        self._chk_chdis = ttk.Checkbutton(
-            kinds_frame, text="chdis", variable=self._var_chdis
-        )
+        self._chk_chdis = ttk.Checkbutton(kinds_frame, text="chdis", variable=self._var_chdis)
         self._chk_chdis.grid(row=0, column=0, sticky="w", padx=_PADX, pady=_PADY)
-        self._chk_cycle = ttk.Checkbutton(
-            kinds_frame, text="cycle", variable=self._var_cycle
-        )
+        self._chk_cycle = ttk.Checkbutton(kinds_frame, text="cycle", variable=self._var_cycle)
         self._chk_cycle.grid(row=1, column=0, sticky="w", padx=_PADX, pady=_PADY)
-        self._chk_dqdv = ttk.Checkbutton(
-            kinds_frame, text="dQ/dV", variable=self._var_dqdv
-        )
+        self._chk_dqdv = ttk.Checkbutton(kinds_frame, text="dQ/dV", variable=self._var_dqdv)
         self._chk_dqdv.grid(row=2, column=0, sticky="w", padx=_PADX, pady=_PADY)
 
         # Parameters
@@ -233,10 +231,7 @@ class _App:
         if self._origin_mode:
             note = ttk.Label(
                 self.root,
-                text=(
-                    "Origin mode: only SG window_length is applied. "
-                    "Other options are disabled."
-                ),
+                text=("Origin mode: only SG window_length is applied. Other options are disabled."),
                 foreground="#666",
                 wraplength=520,
             )
@@ -355,7 +350,13 @@ class _App:
 
         if self._on_complete is not None:
             try:
-                self._on_complete(result.cells, result.figures)
+                # ``sg_window`` is surfaced so the Origin launcher can
+                # propagate a non-default Savitzky-Golay window into the
+                # worksheet data — ``Cell.dqdv_df`` is cached at defaults
+                # and ignores per-run overrides, so without this argument
+                # the Origin-mode ``SG window_length`` field would have no
+                # effect on the pushed output. See issue #60.
+                self._on_complete(result.cells, result.figures, request.sg_window)
             except Exception as exc:
                 self._fail(f"Error in completion hook: {exc}")
                 return

--- a/src/echemplot/gui/tk_app.py
+++ b/src/echemplot/gui/tk_app.py
@@ -117,7 +117,13 @@ class _App:
     all inter-widget state lives on ``self``.
     """
 
-    def __init__(self, root: tk.Tk, *, on_complete: OnComplete | None = None) -> None:
+    def __init__(
+        self,
+        root: tk.Tk,
+        *,
+        on_complete: OnComplete | None = None,
+        origin_mode: bool = False,
+    ) -> None:
         self.root = root
         root.title("echemplot GUI")
 
@@ -131,6 +137,15 @@ class _App:
         # launcher injects a callback that pushes results into the active
         # Origin project instead.
         self._on_complete: OnComplete | None = on_complete
+
+        # When ``True``, widgets whose values never reach Origin's push
+        # path are disabled and annotated with a note. See
+        # :func:`echemplot.origin.launch_gui` for the motivation (issue
+        # #60): ``push_to_origin`` always writes all three worksheets and
+        # the full per-cell DataFrames, and the matplotlib figures the
+        # controller returns are closed before their axis-range overrides
+        # can affect any visible plot.
+        self._origin_mode = origin_mode
 
         self._build_widgets()
 
@@ -159,15 +174,21 @@ class _App:
         self._var_chdis = tk.BooleanVar(value=True)
         self._var_cycle = tk.BooleanVar(value=True)
         self._var_dqdv = tk.BooleanVar(value=False)
-        ttk.Checkbutton(kinds_frame, text="chdis", variable=self._var_chdis).grid(
-            row=0, column=0, sticky="w", padx=_PADX, pady=_PADY
+        # Kept as instance attributes so ``_build_widgets`` can toggle
+        # their ``state`` in origin-mode below (and so tests can assert
+        # the disabled-state without reaching into grid slaves).
+        self._chk_chdis = ttk.Checkbutton(
+            kinds_frame, text="chdis", variable=self._var_chdis
         )
-        ttk.Checkbutton(kinds_frame, text="cycle", variable=self._var_cycle).grid(
-            row=1, column=0, sticky="w", padx=_PADX, pady=_PADY
+        self._chk_chdis.grid(row=0, column=0, sticky="w", padx=_PADX, pady=_PADY)
+        self._chk_cycle = ttk.Checkbutton(
+            kinds_frame, text="cycle", variable=self._var_cycle
         )
-        ttk.Checkbutton(kinds_frame, text="dQ/dV", variable=self._var_dqdv).grid(
-            row=2, column=0, sticky="w", padx=_PADX, pady=_PADY
+        self._chk_cycle.grid(row=1, column=0, sticky="w", padx=_PADX, pady=_PADY)
+        self._chk_dqdv = ttk.Checkbutton(
+            kinds_frame, text="dQ/dV", variable=self._var_dqdv
         )
+        self._chk_dqdv.grid(row=2, column=0, sticky="w", padx=_PADX, pady=_PADY)
 
         # Parameters
         params_frame = ttk.LabelFrame(self.root, text="Parameters")
@@ -205,13 +226,45 @@ class _App:
         self._entry_drange = ttk.Entry(params_frame, width=24)
         self._entry_drange.grid(row=4, column=1, sticky="ew", padx=_PADX, pady=_PADY)
 
+        # Origin-mode note + grey-out. The note shifts Run/status down one
+        # row; we thread ``run_row`` / ``status_row`` through the two
+        # ``.grid()`` calls below so the non-origin layout stays pixel
+        # identical to what it was before this switch existed.
+        if self._origin_mode:
+            note = ttk.Label(
+                self.root,
+                text=(
+                    "Origin mode: only SG window_length is applied. "
+                    "Other options are disabled."
+                ),
+                foreground="#666",
+                wraplength=520,
+            )
+            note.grid(row=2, column=0, columnspan=2, sticky="ew", padx=_PADX, pady=_PADY)
+            run_row = 3
+            status_row = 4
+
+            for widget in (
+                self._chk_chdis,
+                self._chk_cycle,
+                self._chk_dqdv,
+                self._entry_cycles,
+                self._entry_vrange,
+                self._entry_qrange,
+                self._entry_drange,
+            ):
+                widget.configure(state="disabled")
+        else:
+            run_row = 2
+            status_row = 3
+
         # Run + status
         ttk.Button(self.root, text="Run", command=self._on_run).grid(
-            row=2, column=0, columnspan=2, sticky="ew", padx=_PADX, pady=_PADY
+            row=run_row, column=0, columnspan=2, sticky="ew", padx=_PADX, pady=_PADY
         )
         self._status = tk.StringVar(value="Ready.")
         ttk.Label(self.root, textvariable=self._status, relief=tk.SUNKEN, anchor="w").grid(
-            row=3, column=0, columnspan=2, sticky="ew", padx=_PADX, pady=_PADY
+            row=status_row, column=0, columnspan=2, sticky="ew", padx=_PADX, pady=_PADY
         )
 
     # ----- directory list handlers ----------------------------------
@@ -259,15 +312,33 @@ class _App:
 
     def _on_run(self) -> None:
         try:
-            request = GuiRequest(
-                dirs=tuple(self._dirs),
-                kinds=self._collect_kinds(),
-                cycles=tuple(_parse_cycles(self._entry_cycles.get())),
-                sg_window=_parse_sg_window(self._entry_sg.get()),
-                voltage_range=_parse_range(self._entry_vrange.get(), "Voltage range"),
-                capacity_range=_parse_range(self._entry_qrange.get(), "Capacity range"),
-                dqdv_range=_parse_range(self._entry_drange.get(), "dQ/dV range"),
-            )
+            if self._origin_mode:
+                # Skip the disabled widgets entirely so a stale value
+                # left behind from a toggle can't feed into the request
+                # (and so an accidentally non-odd SG placeholder in a
+                # disabled entry can't fail validation). ``push_to_origin``
+                # always writes all three worksheets and the full
+                # DataFrames, so the kinds / cycles / range fields have no
+                # effect on the Origin output regardless.
+                request = GuiRequest(
+                    dirs=tuple(self._dirs),
+                    kinds=frozenset({"chdis", "cycle", "dqdv"}),
+                    cycles=(),
+                    sg_window=_parse_sg_window(self._entry_sg.get()),
+                    voltage_range=None,
+                    capacity_range=None,
+                    dqdv_range=None,
+                )
+            else:
+                request = GuiRequest(
+                    dirs=tuple(self._dirs),
+                    kinds=self._collect_kinds(),
+                    cycles=tuple(_parse_cycles(self._entry_cycles.get())),
+                    sg_window=_parse_sg_window(self._entry_sg.get()),
+                    voltage_range=_parse_range(self._entry_vrange.get(), "Voltage range"),
+                    capacity_range=_parse_range(self._entry_qrange.get(), "Capacity range"),
+                    dqdv_range=_parse_range(self._entry_drange.get(), "dQ/dV range"),
+                )
         except ValueError as exc:
             self._fail(f"Invalid input: {exc}")
             return
@@ -328,7 +399,11 @@ class _App:
         self._status.set(message)
 
 
-def launch_gui(*, on_complete: OnComplete | None = None) -> None:
+def launch_gui(
+    *,
+    on_complete: OnComplete | None = None,
+    origin_mode: bool = False,
+) -> None:
     """Start the Tk GUI and run its event loop.
 
     Callable two ways:
@@ -349,6 +424,14 @@ def launch_gui(*, on_complete: OnComplete | None = None) -> None:
         forwards to :func:`echemplot.origin.push_to_origin` instead,
         so figures are not shown and the results land directly in the
         active Origin project.
+    origin_mode
+        When ``True``, the GUI greys out the options that have no effect
+        on the Origin push path (the plot-kind checkboxes, the cycles
+        entry, and the voltage/capacity/dQ-dV range entries) and shows
+        an inline note explaining why. Only ``SG window_length`` stays
+        editable because it flows into the dQ/dV worksheet the Origin
+        push writes. :func:`echemplot.origin.launch_gui` sets this;
+        standalone callers should leave it at the ``False`` default.
 
     Switches matplotlib to the TkAgg backend at call time (not import
     time): a module-level ``matplotlib.use("TkAgg")`` would crash
@@ -360,7 +443,7 @@ def launch_gui(*, on_complete: OnComplete | None = None) -> None:
 
     matplotlib.use("TkAgg")
     root = tk.Tk()
-    _App(root, on_complete=on_complete)
+    _App(root, on_complete=on_complete, origin_mode=origin_mode)
     root.mainloop()
 
 

--- a/src/echemplot/origin/__init__.py
+++ b/src/echemplot/origin/__init__.py
@@ -46,11 +46,17 @@ def _require_originpro() -> object:
     return op
 
 
+_DEFAULT_SG_WINDOW = 11
+_DEFAULT_SG_POLYORDER = 2
+
+
 def push_to_origin(
     cells: Sequence[Cell],
     *,
     project_path: str | None = None,
     stat_cycles: Sequence[int] = (10, 50),
+    sg_window: int = _DEFAULT_SG_WINDOW,
+    sg_polyorder: int = _DEFAULT_SG_POLYORDER,
 ) -> None:
     """Populate the current Origin project with per-cell sheets + plots + stats.
 
@@ -74,18 +80,30 @@ def push_to_origin(
     stat_cycles
         Cycle numbers forwarded to
         :func:`echemplot.core.stats.stat_table` as ``target_cycles``.
+    sg_window, sg_polyorder
+        Savitzky-Golay parameters for the dQ/dV worksheet. At the defaults
+        (``11`` / ``2``) the cached :attr:`Cell.dqdv_df` is reused verbatim;
+        any override triggers a one-off :func:`echemplot.core.dqdv.get_dqdv_df`
+        recompute per cell so the worksheet values reflect the caller's
+        choice. ``Cell`` instances are not mutated. ``sg_window`` must be a
+        positive odd integer.
 
     Raises
     ------
     ImportError
         From :func:`_require_originpro` when ``originpro`` is not available
         (i.e. when the caller is not running inside Origin).
+    ValueError
+        If ``sg_window`` is not a positive odd integer.
     FileNotFoundError
         When a required ``.otpu`` template cannot be located under the
         package ``templates/`` directory or
         ``$ECHEMPLOT_ORIGIN_TEMPLATE_DIR``. The message names both remediation
         paths.
     """
+    if sg_window < 1 or sg_window % 2 == 0:
+        raise ValueError(f"sg_window must be a positive odd integer, got {sg_window}")
+
     op = _require_originpro()
 
     # Import inside the function so users who only ever call the helpers
@@ -93,12 +111,28 @@ def push_to_origin(
     # scipy.integrate at import time.
     from echemplot.core.stats import stat_table
 
+    # Only recompute when the caller actually wants non-default SG
+    # parameters; at the defaults the cached ``Cell.dqdv_df`` suffices and
+    # we avoid paying the scipy interp/savgol cost a second time.
+    sg_is_default = sg_window == _DEFAULT_SG_WINDOW and sg_polyorder == _DEFAULT_SG_POLYORDER
+    if not sg_is_default:
+        from echemplot.core.dqdv import get_dqdv_df
+
     if project_path is not None:
         op.open(project_path)  # type: ignore[attr-defined]
 
     per_cell_sheets: list[dict[str, object]] = []
     for cell in cells:
-        sheets = write_cell_sheets(op, cell)
+        if sg_is_default:
+            sheets = write_cell_sheets(op, cell)
+        else:
+            dqdv_df = get_dqdv_df(
+                cell.chdis_df,
+                window_length=sg_window,
+                polyorder=sg_polyorder,
+                column_lang=cell.column_lang,
+            )
+            sheets = write_cell_sheets(op, cell, dqdv_df=dqdv_df)
         create_cell_plots(op, cell, sheets)
         per_cell_sheets.append(sheets)
 
@@ -164,8 +198,18 @@ def launch_gui(
     # call below resolves it via ``matplotlib.pyplot``.
     from echemplot.gui import launch_gui as _launch_tk_gui
 
-    def _push(cells: Sequence[Cell], figures: Sequence[Figure]) -> None:
-        push_to_origin(cells, project_path=project_path, stat_cycles=stat_cycles)
+    def _push(cells: Sequence[Cell], figures: Sequence[Figure], sg_window: int) -> None:
+        # ``sg_window`` is forwarded so the dQ/dV worksheet reflects the
+        # value the user typed in the GUI. ``Cell.dqdv_df`` is cached at
+        # defaults and can't surface per-run overrides on its own (see
+        # issue #60), so ``push_to_origin`` recomputes the frame when the
+        # caller supplies a non-default window.
+        push_to_origin(
+            cells,
+            project_path=project_path,
+            stat_cycles=stat_cycles,
+            sg_window=sg_window,
+        )
         # Close the figures the controller built. The Origin path
         # bypasses ``_show_figure`` (which would otherwise own the close
         # via ``WM_DELETE_WINDOW``), so without an explicit close a long

--- a/src/echemplot/origin/__init__.py
+++ b/src/echemplot/origin/__init__.py
@@ -128,6 +128,13 @@ def launch_gui(
     graphs, and a ``stat_table`` sheet without writing any PNG/CSV
     intermediates.
 
+    The Tk GUI is launched with ``origin_mode=True``, which greys out
+    the options that have no effect on the Origin push path (plot-kind
+    checkboxes, cycles entry, and the voltage/capacity/dQ-dV range
+    entries) and shows an inline note; only ``SG window_length`` stays
+    editable because it flows into the dQ/dV worksheet written by
+    :func:`push_to_origin`.
+
     The originpro check runs **before** Tk is constructed so a missing
     embedded-Python build fails fast with the canonical
     :func:`_require_originpro` message rather than after the user has
@@ -169,7 +176,7 @@ def launch_gui(
         for fig in figures:
             plt.close(fig)
 
-    _launch_tk_gui(on_complete=_push)
+    _launch_tk_gui(on_complete=_push, origin_mode=True)
 
 
 __all__ = [

--- a/src/echemplot/origin/_worksheets.py
+++ b/src/echemplot/origin/_worksheets.py
@@ -150,7 +150,12 @@ def _single_x_axis(ncols: int) -> str:
     return "X" + "Y" * (ncols - 1)
 
 
-def write_cell_sheets(op: Any, cell: Any) -> dict[str, Any]:
+def write_cell_sheets(
+    op: Any,
+    cell: Any,
+    *,
+    dqdv_df: pd.DataFrame | None = None,
+) -> dict[str, Any]:
     """Materialize the three per-cell worksheets.
 
     Parameters
@@ -161,6 +166,15 @@ def write_cell_sheets(op: Any, cell: Any) -> dict[str, Any]:
     cell
         A :class:`echemplot.core.cell.Cell` (typed as ``Any`` here to
         keep the mocked-originpro test path import-light).
+    dqdv_df
+        Optional pre-computed dQ/dV DataFrame. When ``None`` (the
+        default) the cached :attr:`Cell.dqdv_df` property is used, which
+        hard-codes the Savitzky-Golay defaults. Callers that need the
+        dQ/dV worksheet to reflect a non-default SG ``window_length`` /
+        ``polyorder`` must compute the frame via
+        :func:`echemplot.core.dqdv.get_dqdv_df` and pass it here —
+        :func:`push_to_origin` does so on behalf of GUI callers when
+        the user edits the SG window.
 
     Returns
     -------
@@ -176,7 +190,7 @@ def write_cell_sheets(op: Any, cell: Any) -> dict[str, Any]:
     # regular column so Origin has an X source for the cycle_efficiency
     # plot. Matches the pattern :func:`write_stat_table` already uses.
     cap = cell.cap_df.reset_index()
-    dqdv = cell.dqdv_df
+    dqdv = cell.dqdv_df if dqdv_df is None else dqdv_df
 
     sheets: dict[str, Any] = {}
     sheets["chdis"] = _write_sheet(

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -328,3 +328,69 @@ def test_gui_package_reexports_launch_gui() -> None:
     import echemplot.gui as gui
 
     assert callable(gui.launch_gui)
+
+
+# ---- origin_mode -----------------------------------------------------------
+
+
+def test_app_origin_mode_disables_ineffective_widgets() -> None:
+    """Issue #60: in origin_mode every option that ``push_to_origin``
+    ignores must be disabled; ``SG window_length`` (which flows into the
+    dQ/dV worksheet via ``get_dqdv_df``) must remain editable.
+    """
+    import tkinter as tk
+
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no display available for Tk: {exc}")
+
+    try:
+        from echemplot.gui.tk_app import _App
+
+        app = _App(root, origin_mode=True)
+
+        # Disabled: the widgets whose values are discarded by push_to_origin.
+        assert str(app._chk_chdis["state"]) == "disabled"
+        assert str(app._chk_cycle["state"]) == "disabled"
+        assert str(app._chk_dqdv["state"]) == "disabled"
+        assert str(app._entry_cycles["state"]) == "disabled"
+        assert str(app._entry_vrange["state"]) == "disabled"
+        assert str(app._entry_qrange["state"]) == "disabled"
+        assert str(app._entry_drange["state"]) == "disabled"
+
+        # SG window_length stays editable — it regenerates the dQ/dV data.
+        assert str(app._entry_sg["state"]) != "disabled"
+    finally:
+        root.destroy()
+
+
+def test_app_default_mode_keeps_widgets_enabled() -> None:
+    """Regression guard: the standalone (default) GUI must not acquire
+    disabled widgets from the origin_mode plumbing.
+    """
+    import tkinter as tk
+
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no display available for Tk: {exc}")
+
+    try:
+        from echemplot.gui.tk_app import _App
+
+        app = _App(root)
+
+        for widget in (
+            app._chk_chdis,
+            app._chk_cycle,
+            app._chk_dqdv,
+            app._entry_cycles,
+            app._entry_sg,
+            app._entry_vrange,
+            app._entry_qrange,
+            app._entry_drange,
+        ):
+            assert str(widget["state"]) != "disabled"
+    finally:
+        root.destroy()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -397,6 +397,8 @@ def test_app_default_mode_keeps_widgets_enabled() -> None:
             assert str(widget["state"]) != "disabled"
     finally:
         root.destroy()
+
+
 def test_add_dir_deduplicates_paths(tmp_path: Path) -> None:
     """``_add_dir`` is the single path through which both Add-button and
     drag-and-drop reach the state list; adding the same directory twice

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -498,3 +498,107 @@ def test_cap_df_written_with_cycle_as_column(
     )
     # Order must match the _CYCLE_COL_* constants in _plots.py.
     assert next(iter(written.columns)) == "cycle", list(written.columns)
+
+
+# ----------------------------------------------------------------------
+# Savitzky-Golay override propagation (issue #60 follow-up)
+# ----------------------------------------------------------------------
+
+
+def test_push_to_origin_non_default_sg_window_reaches_dqdv_sheet(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A non-default ``sg_window`` must change the dQ/dV worksheet content.
+
+    ``Cell.dqdv_df`` is cached at the SG defaults (window=11, polyorder=2),
+    so if :func:`push_to_origin` blindly reused that cached frame the user's
+    GUI ``SG window_length`` edit (issue #60) would silently be ignored —
+    exactly the failure mode this test guards against. Here we compare the
+    dQ/dV DataFrame handed to ``from_df`` against the cached default and
+    assert it differs when ``sg_window`` is overridden.
+    """
+    _stub_templates(monkeypatch, tmp_path)
+    _, sheet_objs, _ = _install_tracking_originpro(monkeypatch)
+    cell = _linear_cell("A")
+
+    # Cache the default-SG frame before push; push_to_origin must override
+    # with a freshly-computed frame using sg_window=5 rather than reuse this.
+    default_dqdv = cell.dqdv_df.copy()
+
+    from echemplot.origin import push_to_origin
+
+    push_to_origin([cell], stat_cycles=(1,), sg_window=5)
+
+    # sheet_objs: chdis=0, cycle=1, dqdv=2 (stat_table created last).
+    dqdv_sheet = sheet_objs[2]
+    from_df_call = dqdv_sheet.from_df.call_args
+    assert from_df_call is not None, "from_df not called on dqdv sheet"
+    written = from_df_call.args[0]
+
+    # Column structure must be preserved — only the values should differ.
+    assert written.shape == default_dqdv.shape, (
+        f"shape drift: default={default_dqdv.shape} overridden={written.shape}"
+    )
+    # Values must differ for at least one column (the SG smoothing window
+    # changed, so the derivative estimates cannot coincide everywhere).
+    import numpy as np
+
+    assert not np.allclose(
+        written.to_numpy(dtype=float),
+        default_dqdv.to_numpy(dtype=float),
+        equal_nan=True,
+    ), "dqdv sheet content identical to default-SG cached frame; override not applied"
+
+
+def test_push_to_origin_default_sg_window_writes_cached_dqdv_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """At the defaults, the dQ/dV sheet content matches the cached frame.
+
+    ``_write_sheet`` flattens MultiIndex columns before handing the frame to
+    ``from_df``, so object identity does not survive; we compare values
+    instead. If a future refactor accidentally starts recomputing at the
+    defaults, this test still guards against value drift.
+    """
+    _stub_templates(monkeypatch, tmp_path)
+    _, sheet_objs, _ = _install_tracking_originpro(monkeypatch)
+    cell = _linear_cell("A")
+
+    default_dqdv = cell.dqdv_df.copy()
+
+    from echemplot.origin import push_to_origin
+
+    push_to_origin([cell], stat_cycles=(1,))
+
+    dqdv_sheet = sheet_objs[2]
+    from_df_call = dqdv_sheet.from_df.call_args
+    assert from_df_call is not None
+    written = from_df_call.args[0]
+
+    import numpy as np
+
+    assert written.shape == default_dqdv.shape
+    assert np.allclose(
+        written.to_numpy(dtype=float),
+        default_dqdv.to_numpy(dtype=float),
+        equal_nan=True,
+    )
+
+
+def test_push_to_origin_rejects_even_sg_window(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Even ``sg_window`` values are invalid Savitzky-Golay inputs.
+
+    Validation lives in ``push_to_origin`` itself so an even value fails
+    before any Origin sheets are created, mirroring the controller-side
+    ``GuiRequest`` validation.
+    """
+    _install_mock_originpro(monkeypatch)
+    _stub_templates(monkeypatch, tmp_path)
+    cell = _linear_cell("A")
+
+    from echemplot.origin import push_to_origin
+
+    with pytest.raises(ValueError, match="sg_window"):
+        push_to_origin([cell], stat_cycles=(1,), sg_window=10)

--- a/tests/test_origin_launcher.py
+++ b/tests/test_origin_launcher.py
@@ -92,13 +92,17 @@ def test_launch_gui_passes_callback_that_calls_push_to_origin(
 
     sentinel_cells = ["cell-A", "cell-B"]  # opaque to push_to_origin in this fake
     sentinel_figs = ["fig0", "fig1", "fig2"]
-    on_complete(sentinel_cells, sentinel_figs)  # type: ignore[operator]
+    # Third positional arg is ``sg_window`` — the Tk view surfaces it so
+    # the Origin launcher can propagate a non-default value through to
+    # the dQ/dV worksheet (issue #60 follow-up).
+    on_complete(sentinel_cells, sentinel_figs, 11)  # type: ignore[operator]
 
     assert len(push_calls) == 1
     call = push_calls[0]
     assert call["cells"] is sentinel_cells
     assert call["project_path"] == str(tmp_path / "p.opju")
     assert call["stat_cycles"] == (7, 13)
+    assert call["sg_window"] == 11
 
 
 def test_launch_gui_defaults_match_push_to_origin_defaults(
@@ -132,8 +136,9 @@ def test_launch_gui_defaults_match_push_to_origin_defaults(
 
     on_complete = captured.get("on_complete")
     assert callable(on_complete)
-    on_complete(["c"], ["f"])  # type: ignore[operator]
+    on_complete(["c"], ["f"], 11)  # type: ignore[operator]
 
     call = push_calls[0]
     assert call["project_path"] is None
     assert call["stat_cycles"] == (10, 50)
+    assert call["sg_window"] == 11

--- a/tests/test_origin_launcher.py
+++ b/tests/test_origin_launcher.py
@@ -83,6 +83,10 @@ def test_launch_gui_passes_callback_that_calls_push_to_origin(
 
     origin_mod.launch_gui(project_path=str(tmp_path / "p.opju"), stat_cycles=(7, 13))
 
+    # Issue #60: the Origin launcher must put the Tk GUI into its
+    # constrained ``origin_mode`` so ineffective options are greyed out.
+    assert captured.get("origin_mode") is True
+
     on_complete = captured.get("on_complete")
     assert callable(on_complete), "launcher must inject an on_complete callback"
 


### PR DESCRIPTION
## Summary
- Fixes #60 — when the GUI is launched via `echemplot.origin.launch_gui()`, the plot-kind checkboxes, cycles entry, and the three range entries are now disabled and annotated with a note so the user understands only `SG window_length` reaches the Origin project.
- Added `origin_mode` keyword to `gui.launch_gui`; the Origin launcher sets it to `True`.

## Test plan
- [ ] `ruff check` / `mypy` / `pytest` all green
- [ ] Manual standalone: `python -m echemplot.gui` → all options enabled as before
- [ ] Manual Origin: `from echemplot.origin import launch_gui; launch_gui()` → checkboxes/cycles/range entries greyed out, note visible, `SG window_length` still editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)