### PR TITLE
feat(origin): autoscale template graphs with a shared scale across cells (#61)

### DIFF
--- a/src/echemplot/origin/__init__.py
+++ b/src/echemplot/origin/__init__.py
@@ -26,7 +26,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
-from echemplot.origin._plots import create_cell_plots, create_comparison_plots
+from echemplot.origin._plots import (
+    compute_global_ranges,
+    create_cell_plots,
+    create_comparison_plots,
+)
 from echemplot.origin._worksheets import write_cell_sheets, write_stat_table
 
 if TYPE_CHECKING:
@@ -96,14 +100,21 @@ def push_to_origin(
     if project_path is not None:
         op.open(project_path)  # type: ignore[attr-defined]
 
+    # Compute one shared axis range over the full cell sequence, applied
+    # uniformly to every per-cell graph AND the comparison overlays. With
+    # a single cell this collapses to "autoscale to that cell's data";
+    # with multiple cells every graph shares a directly-comparable scale
+    # (issue #61).
+    ranges = compute_global_ranges(cells)
+
     per_cell_sheets: list[dict[str, object]] = []
     for cell in cells:
         sheets = write_cell_sheets(op, cell)
-        create_cell_plots(op, cell, sheets)
+        create_cell_plots(op, cell, sheets, ranges=ranges)
         per_cell_sheets.append(sheets)
 
     if len(cells) > 1:
-        create_comparison_plots(op, cells, per_cell_sheets)
+        create_comparison_plots(op, cells, per_cell_sheets, ranges=ranges)
 
     stat_df = stat_table(cells, target_cycles=list(stat_cycles))
     write_stat_table(op, stat_df)

--- a/src/echemplot/origin/_plots.py
+++ b/src/echemplot/origin/_plots.py
@@ -22,9 +22,15 @@ confirm them — see issue #15):
 * Each layer exposes ``layer.axis(<"x"|"y">)`` returning an axis object
   with mutable ``begin`` and ``end`` float attributes. Setting these
   overrides the template's default scaling so per-cell and comparison
-  graphs can share a common axis range (see issue #61). When the
-  attribute-style access raises, :func:`_set_axis_limits` falls back to
-  LabTalk via ``layer.lt_exec("x.from=<lo>;x.to=<hi>;")``.
+  graphs can share a common axis range (see issue #61). The attribute
+  path is treated as "tentative": :func:`_set_axis_limits` writes the
+  values, then reads them back and — if the round-trip disagrees or
+  the attribute access raised — falls back to LabTalk via
+  ``op.lt_exec("x.from=<lo>;x.to=<hi>;")``. The module-level
+  :func:`op.lt_exec` targets the currently-active graph, which is the
+  graph we just created via :func:`op.new_graph`; it is the documented
+  scripting entry point and does not assume any per-layer attribute
+  contract.
 
 The three templates expect distinct column layouts; the bind helpers in
 this module encode the layout per category:
@@ -44,6 +50,7 @@ remediation message rather than spreading that concern across callers.
 
 from __future__ import annotations
 
+import math
 import os
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -173,33 +180,73 @@ def compute_global_ranges(cells: Sequence[Any]) -> _GraphRanges:
     )
 
 
-def _set_axis_limits(layer: Any, axis: str, limits: tuple[float, float] | None) -> None:
+def _set_axis_limits(
+    layer: Any,
+    axis: str,
+    limits: tuple[float, float] | None,
+    *,
+    op: Any | None = None,
+) -> None:
     """Apply ``(lo, hi)`` to ``layer``'s named axis. No-op when ``limits`` is ``None``.
 
-    Tries attribute-style originpro API first (``layer.axis(axis).begin``
-    and ``.end``) and falls back to LabTalk via ``layer.lt_exec`` when
-    that raises. The fallback path is exercised only in real Origin —
-    our mocks satisfy the attribute-style call so it never trips in
-    CI. Both paths need to be confirmed against real Origin; see issue
-    #15 for the tracking checklist.
+    Strategy: try the attribute-style originpro API
+    (``layer.axis(axis).begin`` / ``.end``), then **verify** by reading
+    the values back — a plain Python object silently accepts unknown
+    attribute writes, which would let a missing real-Origin contract
+    slip through as a degraded "template default scaling" graph instead
+    of a raised error. If either the set or the readback disagrees with
+    ``(lo, hi)``, fall back to LabTalk via ``op.lt_exec`` (documented
+    module-level function) against the currently-active graph, which
+    is the one the caller just created.
+
+    ``op`` is optional for backward compatibility with call sites that
+    don't thread the module through; when omitted the fallback is
+    suppressed. Callers that care about the degraded case
+    (:func:`create_cell_plots`, :func:`create_comparison_plots`) always
+    pass ``op`` explicitly.
 
     Degenerate ``lo == hi`` ranges are left alone so the template's own
     scaling picks a sensible unit-wide window rather than collapsing the
-    axis to a zero-width line.
+    axis to a zero-width line. NaN / inf are filtered upstream by
+    :func:`_safe_range`, so they never reach this helper.
+
+    Both the attribute and LabTalk paths ultimately need real-Origin
+    verification (see issue #15). The round-trip check is the best-effort
+    safety net we can run from the Python side.
     """
     if limits is None:
         return
     lo, hi = limits
     if lo == hi:
         return  # degenerate range; leave template scaling in place
+
+    attr_ok = False
     try:
         ax = layer.axis(axis)
         ax.begin = lo
         ax.end = hi
+        # Round-trip verification: if ``ax`` is a plain Python object it
+        # accepted the writes silently but the real Origin axis is
+        # untouched — the graph would render with template defaults and
+        # no error would surface. ``math.isclose`` guards against
+        # float-roundtrip noise from the originpro C bridge; the abs_tol
+        # covers near-zero ranges (e.g. dQ/dV around the baseline).
+        attr_ok = math.isclose(float(ax.begin), lo, rel_tol=1e-9, abs_tol=1e-12) and math.isclose(
+            float(ax.end), hi, rel_tol=1e-9, abs_tol=1e-12
+        )
     except Exception:  # pragma: no cover - exercised only in real Origin
-        # LabTalk fallback. ``layer.lt_exec`` selects ``layer`` implicitly.
-        cmd = "x" if axis == "x" else "y"
-        layer.lt_exec(f"{cmd}.from={lo};{cmd}.to={hi};")
+        attr_ok = False
+
+    if attr_ok:
+        return
+
+    # Fallback: LabTalk against the active graph. ``op.lt_exec`` is the
+    # documented module-level entry point; individual layer objects do
+    # not reliably expose ``lt_exec``.
+    if op is None:  # pragma: no cover - defensive; call sites always pass op
+        return
+    cmd = "x" if axis == "x" else "y"
+    op.lt_exec(f"{cmd}.from={lo};{cmd}.to={hi};")
 
 
 def _template_path(name: str) -> Path:
@@ -283,22 +330,22 @@ def create_cell_plots(
     chdis_graph = _new_graph_from_template(op, _TEMPLATE_CHDIS, f"{cell.name}_chdis_plot")
     _bind_xy_pairs(chdis_graph[0], sheets["chdis"], cell.chdis_df.shape[1])
     if ranges is not None:
-        _set_axis_limits(chdis_graph[0], "x", ranges.chdis_x)
-        _set_axis_limits(chdis_graph[0], "y", ranges.chdis_y)
+        _set_axis_limits(chdis_graph[0], "x", ranges.chdis_x, op=op)
+        _set_axis_limits(chdis_graph[0], "y", ranges.chdis_y, op=op)
 
     cycle_graph = _new_graph_from_template(op, _TEMPLATE_CYCLE, f"{cell.name}_cycle_plot")
     _bind_cycle(cycle_graph, sheets["cycle"])
     if ranges is not None:
-        _set_axis_limits(cycle_graph[0], "x", ranges.cycle_x)
-        _set_axis_limits(cycle_graph[0], "y", ranges.cycle_left_y)
-        _set_axis_limits(cycle_graph[1], "x", ranges.cycle_x)
-        _set_axis_limits(cycle_graph[1], "y", ranges.cycle_right_y)
+        _set_axis_limits(cycle_graph[0], "x", ranges.cycle_x, op=op)
+        _set_axis_limits(cycle_graph[0], "y", ranges.cycle_left_y, op=op)
+        _set_axis_limits(cycle_graph[1], "x", ranges.cycle_x, op=op)
+        _set_axis_limits(cycle_graph[1], "y", ranges.cycle_right_y, op=op)
 
     dqdv_graph = _new_graph_from_template(op, _TEMPLATE_DQDV, f"{cell.name}_dqdv_plot")
     _bind_xy_pairs(dqdv_graph[0], sheets["dqdv"], cell.dqdv_df.shape[1])
     if ranges is not None:
-        _set_axis_limits(dqdv_graph[0], "x", ranges.dqdv_x)
-        _set_axis_limits(dqdv_graph[0], "y", ranges.dqdv_y)
+        _set_axis_limits(dqdv_graph[0], "x", ranges.dqdv_x, op=op)
+        _set_axis_limits(dqdv_graph[0], "y", ranges.dqdv_y, op=op)
 
     return [chdis_graph, cycle_graph, dqdv_graph]
 
@@ -331,23 +378,23 @@ def create_comparison_plots(
     for cell, sheets in zip(cells, per_cell_sheets):
         _bind_xy_pairs(chdis_graph[0], sheets["chdis"], cell.chdis_df.shape[1])
     if ranges is not None:
-        _set_axis_limits(chdis_graph[0], "x", ranges.chdis_x)
-        _set_axis_limits(chdis_graph[0], "y", ranges.chdis_y)
+        _set_axis_limits(chdis_graph[0], "x", ranges.chdis_x, op=op)
+        _set_axis_limits(chdis_graph[0], "y", ranges.chdis_y, op=op)
 
     cycle_graph = _new_graph_from_template(op, _TEMPLATE_CYCLE, "comparison_cycle_plot")
     for _cell, sheets in zip(cells, per_cell_sheets):
         _bind_cycle(cycle_graph, sheets["cycle"])
     if ranges is not None:
-        _set_axis_limits(cycle_graph[0], "x", ranges.cycle_x)
-        _set_axis_limits(cycle_graph[0], "y", ranges.cycle_left_y)
-        _set_axis_limits(cycle_graph[1], "x", ranges.cycle_x)
-        _set_axis_limits(cycle_graph[1], "y", ranges.cycle_right_y)
+        _set_axis_limits(cycle_graph[0], "x", ranges.cycle_x, op=op)
+        _set_axis_limits(cycle_graph[0], "y", ranges.cycle_left_y, op=op)
+        _set_axis_limits(cycle_graph[1], "x", ranges.cycle_x, op=op)
+        _set_axis_limits(cycle_graph[1], "y", ranges.cycle_right_y, op=op)
 
     dqdv_graph = _new_graph_from_template(op, _TEMPLATE_DQDV, "comparison_dqdv_plot")
     for cell, sheets in zip(cells, per_cell_sheets):
         _bind_xy_pairs(dqdv_graph[0], sheets["dqdv"], cell.dqdv_df.shape[1])
     if ranges is not None:
-        _set_axis_limits(dqdv_graph[0], "x", ranges.dqdv_x)
-        _set_axis_limits(dqdv_graph[0], "y", ranges.dqdv_y)
+        _set_axis_limits(dqdv_graph[0], "x", ranges.dqdv_x, op=op)
+        _set_axis_limits(dqdv_graph[0], "y", ranges.dqdv_y, op=op)
 
     return [chdis_graph, cycle_graph, dqdv_graph]

--- a/src/echemplot/origin/_plots.py
+++ b/src/echemplot/origin/_plots.py
@@ -19,6 +19,12 @@ confirm them — see issue #15):
   column designation and Origin renders an empty graph window — the
   column indices are mandatory for data to appear, even when the
   template already provides plot types and axis scaling.
+* Each layer exposes ``layer.axis(<"x"|"y">)`` returning an axis object
+  with mutable ``begin`` and ``end`` float attributes. Setting these
+  overrides the template's default scaling so per-cell and comparison
+  graphs can share a common axis range (see issue #61). When the
+  attribute-style access raises, :func:`_set_axis_limits` falls back to
+  LabTalk via ``layer.lt_exec("x.from=<lo>;x.to=<hi>;")``.
 
 The three templates expect distinct column layouts; the bind helpers in
 this module encode the layout per category:
@@ -40,8 +46,12 @@ from __future__ import annotations
 
 import os
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+import numpy as np
+import pandas as pd
 
 _TEMPLATE_CHDIS = "charge_discharge.otpu"
 _TEMPLATE_CYCLE = "cycle_efficiency.otpu"
@@ -74,6 +84,122 @@ _NOT_FOUND_MSG = (
     "missing one of charge_discharge.otpu, cycle_efficiency.otpu, or "
     "dqdv.otpu. Unset the env var to fall back to the bundled templates."
 )
+
+
+@dataclass(frozen=True)
+class _GraphRanges:
+    """Global (min, max) tuples across a Sequence of cells, one per axis.
+
+    Used by :func:`compute_global_ranges` to share a single axis scale
+    across every template-backed graph ``push_to_origin`` produces so
+    per-cell and comparison plots are directly comparable (issue #61).
+    ``None`` on a field means ``_safe_range`` found no finite values for
+    that axis — the :func:`_set_axis_limits` helper treats ``None`` as
+    "leave the template default in place".
+    """
+
+    chdis_x: tuple[float, float] | None
+    chdis_y: tuple[float, float] | None
+    cycle_x: tuple[float, float] | None
+    cycle_left_y: tuple[float, float] | None
+    cycle_right_y: tuple[float, float] | None
+    dqdv_x: tuple[float, float] | None
+    dqdv_y: tuple[float, float] | None
+
+
+def _safe_range(values: pd.DataFrame | pd.Series | np.ndarray) -> tuple[float, float] | None:
+    """Return ``(min, max)`` of ``values`` ignoring NaN; ``None`` if no finite entries.
+
+    Empty inputs and all-NaN / all-inf inputs both yield ``None`` so
+    callers can pass the result straight to :func:`_set_axis_limits`,
+    which treats ``None`` as a no-op and falls back to the template's
+    default axis range.
+    """
+    arr = np.asarray(values, dtype=float).ravel()
+    arr = arr[np.isfinite(arr)]
+    if arr.size == 0:
+        return None
+    return float(arr.min()), float(arr.max())
+
+
+def compute_global_ranges(cells: Sequence[Any]) -> _GraphRanges:
+    """Compute axis ranges across all cells' dataframes for template-backed graphs.
+
+    The function walks every cell once and collects per-axis values from
+    ``cell.chdis_df`` (even columns = capacity X, odd = voltage Y),
+    ``cell.cap_df`` (``[cycle, q_ch, q_dis, ce]`` with indices pinned by
+    ``_CYCLE_COL_*`` constants), and ``cell.dqdv_df`` (even columns =
+    voltage X, odd = dQ/dV Y). Concatenated arrays are reduced by
+    :func:`_safe_range` so empty / all-NaN inputs surface as ``None`` on
+    the returned :class:`_GraphRanges` rather than raising.
+
+    When the input is a single cell, "global" and "that cell's range"
+    coincide — the autoscale for a one-cell push is simply the cell's
+    own data range.
+    """
+    chdis_x_vals: list[np.ndarray] = []
+    chdis_y_vals: list[np.ndarray] = []
+    dqdv_x_vals: list[np.ndarray] = []
+    dqdv_y_vals: list[np.ndarray] = []
+    cycle_x_vals: list[np.ndarray] = []
+    cycle_left_vals: list[np.ndarray] = []
+    cycle_right_vals: list[np.ndarray] = []
+    for cell in cells:
+        chdis = cell.chdis_df
+        if chdis.shape[1] >= 2:
+            # even = capacity (x), odd = voltage (y)
+            chdis_x_vals.append(chdis.iloc[:, 0::2].to_numpy(dtype=float))
+            chdis_y_vals.append(chdis.iloc[:, 1::2].to_numpy(dtype=float))
+        dqdv = cell.dqdv_df
+        if dqdv.shape[1] >= 2:
+            dqdv_x_vals.append(dqdv.iloc[:, 0::2].to_numpy(dtype=float))
+            dqdv_y_vals.append(dqdv.iloc[:, 1::2].to_numpy(dtype=float))
+        # cap_df carries the cycle number in its index; surface it as a
+        # column to match the post-``reset_index`` layout used when
+        # writing the sheet. See :func:`._worksheets.write_cell_sheets`.
+        cap = cell.cap_df.reset_index()
+        if cap.shape[1] > _CYCLE_COL_CE:
+            cycle_x_vals.append(cap.iloc[:, _CYCLE_COL_CYCLE].to_numpy(dtype=float))
+            cycle_left_vals.append(cap.iloc[:, _CYCLE_COL_QDIS].to_numpy(dtype=float))
+            cycle_right_vals.append(cap.iloc[:, _CYCLE_COL_CE].to_numpy(dtype=float))
+    return _GraphRanges(
+        chdis_x=_safe_range(np.concatenate(chdis_x_vals)) if chdis_x_vals else None,
+        chdis_y=_safe_range(np.concatenate(chdis_y_vals)) if chdis_y_vals else None,
+        cycle_x=_safe_range(np.concatenate(cycle_x_vals)) if cycle_x_vals else None,
+        cycle_left_y=_safe_range(np.concatenate(cycle_left_vals)) if cycle_left_vals else None,
+        cycle_right_y=_safe_range(np.concatenate(cycle_right_vals)) if cycle_right_vals else None,
+        dqdv_x=_safe_range(np.concatenate(dqdv_x_vals)) if dqdv_x_vals else None,
+        dqdv_y=_safe_range(np.concatenate(dqdv_y_vals)) if dqdv_y_vals else None,
+    )
+
+
+def _set_axis_limits(layer: Any, axis: str, limits: tuple[float, float] | None) -> None:
+    """Apply ``(lo, hi)`` to ``layer``'s named axis. No-op when ``limits`` is ``None``.
+
+    Tries attribute-style originpro API first (``layer.axis(axis).begin``
+    and ``.end``) and falls back to LabTalk via ``layer.lt_exec`` when
+    that raises. The fallback path is exercised only in real Origin —
+    our mocks satisfy the attribute-style call so it never trips in
+    CI. Both paths need to be confirmed against real Origin; see issue
+    #15 for the tracking checklist.
+
+    Degenerate ``lo == hi`` ranges are left alone so the template's own
+    scaling picks a sensible unit-wide window rather than collapsing the
+    axis to a zero-width line.
+    """
+    if limits is None:
+        return
+    lo, hi = limits
+    if lo == hi:
+        return  # degenerate range; leave template scaling in place
+    try:
+        ax = layer.axis(axis)
+        ax.begin = lo
+        ax.end = hi
+    except Exception:  # pragma: no cover - exercised only in real Origin
+        # LabTalk fallback. ``layer.lt_exec`` selects ``layer`` implicitly.
+        cmd = "x" if axis == "x" else "y"
+        layer.lt_exec(f"{cmd}.from={lo};{cmd}.to={hi};")
 
 
 def _template_path(name: str) -> Path:
@@ -134,22 +260,45 @@ def _bind_cycle(graph: Any, sheet: Any) -> None:
     graph[1].add_plot(sheet, colx=_CYCLE_COL_CYCLE, coly=_CYCLE_COL_CE)
 
 
-def create_cell_plots(op: Any, cell: Any, sheets: dict[str, Any]) -> list[Any]:
+def create_cell_plots(
+    op: Any,
+    cell: Any,
+    sheets: dict[str, Any],
+    *,
+    ranges: _GraphRanges | None = None,
+) -> list[Any]:
     """Create the three per-cell graphs from templates.
 
     ``sheets`` is the mapping returned by
     :func:`echemplot.origin._worksheets.write_cell_sheets`. ``cell``
     is used to read the per-category column counts so the bind helpers
     know how many plot pairs to emit.
+
+    ``ranges`` — when given, the ``(lo, hi)`` tuples on this
+    :class:`_GraphRanges` are applied to the corresponding axes on each
+    graph via :func:`_set_axis_limits`. Pass ``None`` (the default) to
+    keep the template's built-in axis scaling, matching the legacy
+    pre-#61 behaviour.
     """
     chdis_graph = _new_graph_from_template(op, _TEMPLATE_CHDIS, f"{cell.name}_chdis_plot")
     _bind_xy_pairs(chdis_graph[0], sheets["chdis"], cell.chdis_df.shape[1])
+    if ranges is not None:
+        _set_axis_limits(chdis_graph[0], "x", ranges.chdis_x)
+        _set_axis_limits(chdis_graph[0], "y", ranges.chdis_y)
 
     cycle_graph = _new_graph_from_template(op, _TEMPLATE_CYCLE, f"{cell.name}_cycle_plot")
     _bind_cycle(cycle_graph, sheets["cycle"])
+    if ranges is not None:
+        _set_axis_limits(cycle_graph[0], "x", ranges.cycle_x)
+        _set_axis_limits(cycle_graph[0], "y", ranges.cycle_left_y)
+        _set_axis_limits(cycle_graph[1], "x", ranges.cycle_x)
+        _set_axis_limits(cycle_graph[1], "y", ranges.cycle_right_y)
 
     dqdv_graph = _new_graph_from_template(op, _TEMPLATE_DQDV, f"{cell.name}_dqdv_plot")
     _bind_xy_pairs(dqdv_graph[0], sheets["dqdv"], cell.dqdv_df.shape[1])
+    if ranges is not None:
+        _set_axis_limits(dqdv_graph[0], "x", ranges.dqdv_x)
+        _set_axis_limits(dqdv_graph[0], "y", ranges.dqdv_y)
 
     return [chdis_graph, cycle_graph, dqdv_graph]
 
@@ -158,6 +307,8 @@ def create_comparison_plots(
     op: Any,
     cells: Sequence[Any],
     per_cell_sheets: list[dict[str, Any]],
+    *,
+    ranges: _GraphRanges | None = None,
 ) -> list[Any]:
     """Create three overlay graphs that combine every cell's sheets.
 
@@ -171,17 +322,32 @@ def create_comparison_plots(
     column pair on ``graph[0]``; ``cycle`` emits two calls per cell, one
     per dual-Y layer (``graph[0]`` = discharge capacity,
     ``graph[1]`` = Coulombic efficiency).
+
+    ``ranges`` applies the same per-axis ``(lo, hi)`` overrides as in
+    :func:`create_cell_plots`, so per-cell and comparison graphs share a
+    single axis scale — the core of the issue #61 fix.
     """
     chdis_graph = _new_graph_from_template(op, _TEMPLATE_CHDIS, "comparison_chdis_plot")
     for cell, sheets in zip(cells, per_cell_sheets):
         _bind_xy_pairs(chdis_graph[0], sheets["chdis"], cell.chdis_df.shape[1])
+    if ranges is not None:
+        _set_axis_limits(chdis_graph[0], "x", ranges.chdis_x)
+        _set_axis_limits(chdis_graph[0], "y", ranges.chdis_y)
 
     cycle_graph = _new_graph_from_template(op, _TEMPLATE_CYCLE, "comparison_cycle_plot")
     for _cell, sheets in zip(cells, per_cell_sheets):
         _bind_cycle(cycle_graph, sheets["cycle"])
+    if ranges is not None:
+        _set_axis_limits(cycle_graph[0], "x", ranges.cycle_x)
+        _set_axis_limits(cycle_graph[0], "y", ranges.cycle_left_y)
+        _set_axis_limits(cycle_graph[1], "x", ranges.cycle_x)
+        _set_axis_limits(cycle_graph[1], "y", ranges.cycle_right_y)
 
     dqdv_graph = _new_graph_from_template(op, _TEMPLATE_DQDV, "comparison_dqdv_plot")
     for cell, sheets in zip(cells, per_cell_sheets):
         _bind_xy_pairs(dqdv_graph[0], sheets["dqdv"], cell.dqdv_df.shape[1])
+    if ranges is not None:
+        _set_axis_limits(dqdv_graph[0], "x", ranges.dqdv_x)
+        _set_axis_limits(dqdv_graph[0], "y", ranges.dqdv_y)
 
     return [chdis_graph, cycle_graph, dqdv_graph]

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -550,7 +550,12 @@ def test_compute_global_ranges_extracts_per_axis_min_max() -> None:
         {"cycle": [1, 2], "q_ch": [1000.0, 990.0], "q_dis": [990.0, 980.0], "ce": [99.0, 98.9]}
     ).set_index("cycle")
     cap_b = pd.DataFrame(
-        {"cycle": [1, 2, 3], "q_ch": [800.0, 790.0, 780.0], "q_dis": [760.0, 755.0, 750.0], "ce": [95.0, 95.5, 96.1]}
+        {
+            "cycle": [1, 2, 3],
+            "q_ch": [800.0, 790.0, 780.0],
+            "q_dis": [760.0, 755.0, 750.0],
+            "ce": [95.0, 95.5, 96.1],
+        }
     ).set_index("cycle")
 
     # dqdv: even cols = voltage (x), odd = dQ/dV (y).
@@ -599,7 +604,12 @@ def test_compute_global_ranges_nan_only_yields_none() -> None:
 
     nan_df = pd.DataFrame({"a": [np.nan, np.nan], "b": [np.nan, np.nan]})
     cap_nan = pd.DataFrame(
-        {"cycle": [1, 2], "q_ch": [np.nan, np.nan], "q_dis": [np.nan, np.nan], "ce": [np.nan, np.nan]}
+        {
+            "cycle": [1, 2],
+            "q_ch": [np.nan, np.nan],
+            "q_dis": [np.nan, np.nan],
+            "ce": [np.nan, np.nan],
+        }
     ).set_index("cycle")
 
     cell = _fake_cell(chdis=nan_df, cap=cap_nan, dqdv=nan_df)
@@ -664,15 +674,78 @@ def test_set_axis_limits_sets_begin_and_end_via_attribute_api() -> None:
 
 
 def test_set_axis_limits_falls_back_to_lt_exec_when_attr_api_raises() -> None:
+    """When ``layer.axis()`` itself raises, the fallback runs on ``op.lt_exec``.
+
+    The fallback uses the module-level :func:`op.lt_exec` rather than
+    ``layer.lt_exec`` because originpro's Python bindings reliably expose
+    ``lt_exec`` at the module level but not consistently on per-layer
+    proxies. :func:`op.lt_exec` targets the currently-active graph, which
+    is the one :func:`_new_graph_from_template` just created.
+    """
     from echemplot.origin._plots import _set_axis_limits
 
     layer = MagicMock()
     layer.axis.side_effect = RuntimeError("no axis() on this layer build")
-    _set_axis_limits(layer, "y", (1.0, 5.0))
-    layer.lt_exec.assert_called_once()
-    cmd = layer.lt_exec.call_args.args[0]
+    op = MagicMock()
+    _set_axis_limits(layer, "y", (1.0, 5.0), op=op)
+    op.lt_exec.assert_called_once()
+    cmd = op.lt_exec.call_args.args[0]
     assert cmd.startswith("y.from=1.0")
     assert "y.to=5.0" in cmd
+    # ``layer.lt_exec`` must NOT be called — that was the old contract.
+    layer.lt_exec.assert_not_called()
+
+
+def test_set_axis_limits_falls_back_when_readback_disagrees() -> None:
+    """Silent no-op detection: if ``ax.begin`` readback != ``lo`` then fall back.
+
+    Covers the case where ``layer.axis()`` returns an object that
+    accepts attribute writes (plain Python objects always do) but
+    doesn't actually propagate them to Origin — the graph would render
+    with template defaults and no exception would surface. A round-trip
+    read guards against that.
+    """
+    from echemplot.origin._plots import _set_axis_limits
+
+    # Custom axis proxy: accepts writes but returns stale readbacks.
+    class _StaleAxis:
+        def __init__(self) -> None:
+            self.begin = 999.0
+            self.end = 999.0
+
+        def __setattr__(self, name: str, value: object) -> None:
+            # Accept the write but don't actually update (simulates a
+            # proxy whose setter doesn't wire through to Origin).
+            if not hasattr(self, name):
+                # Allow the initial __init__ writes.
+                object.__setattr__(self, name, value)
+
+    stale_axis = _StaleAxis()
+    layer = MagicMock()
+    layer.axis.return_value = stale_axis
+    op = MagicMock()
+    _set_axis_limits(layer, "x", (0.0, 10.0), op=op)
+    # Round-trip failed (begin/end still 999.0) → fallback fires.
+    op.lt_exec.assert_called_once()
+    cmd = op.lt_exec.call_args.args[0]
+    assert cmd.startswith("x.from=0.0")
+    assert "x.to=10.0" in cmd
+
+
+def test_set_axis_limits_no_fallback_when_op_is_none() -> None:
+    """Without an ``op`` handle the fallback is suppressed, not crashed.
+
+    Preserves the pre-#67 call-site ergonomics: unit tests that call
+    :func:`_set_axis_limits` directly without plumbing ``op`` through
+    must not raise when the attribute path is unreliable.
+    """
+    from echemplot.origin._plots import _set_axis_limits
+
+    layer = MagicMock()
+    layer.axis.side_effect = RuntimeError("no axis() on this layer build")
+    # Must not raise despite no fallback being available.
+    _set_axis_limits(layer, "y", (1.0, 5.0))
+    layer.lt_exec.assert_not_called()
 
 
 def test_create_cell_plots_applies_ranges_to_every_layer(

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -498,3 +498,314 @@ def test_cap_df_written_with_cycle_as_column(
     )
     # Order must match the _CYCLE_COL_* constants in _plots.py.
     assert next(iter(written.columns)) == "cycle", list(written.columns)
+
+
+# ----------------------------------------------------------------------
+# Shared-scale autoscaling (issue #61)
+# ----------------------------------------------------------------------
+
+
+def _fake_cell(
+    *,
+    chdis: pd.DataFrame | None = None,
+    cap: pd.DataFrame | None = None,
+    dqdv: pd.DataFrame | None = None,
+    name: str = "fake",
+) -> MagicMock:
+    """Build a duck-typed Cell exposing only the three dataframes + name.
+
+    ``compute_global_ranges`` touches nothing else, so the full
+    :class:`Cell` construction (raw_df parsing, mass, etc.) is
+    unnecessary for range-computation tests.
+    """
+    cell = MagicMock(spec=["name", "chdis_df", "cap_df", "dqdv_df"])
+    cell.name = name
+    cell.chdis_df = chdis if chdis is not None else pd.DataFrame()
+    # ``compute_global_ranges`` calls ``cap_df.reset_index()``; a
+    # DataFrame provides that out of the box so no extra plumbing is
+    # needed on the mock.
+    cell.cap_df = cap if cap is not None else pd.DataFrame()
+    cell.dqdv_df = dqdv if dqdv is not None else pd.DataFrame()
+    return cell
+
+
+def test_safe_range_ignores_nan_and_returns_none_for_empty() -> None:
+    from echemplot.origin._plots import _safe_range
+
+    assert _safe_range(np.array([1.0, 2.0, np.nan, 3.0])) == (1.0, 3.0)
+    assert _safe_range(np.array([np.nan, np.nan])) is None
+    assert _safe_range(np.array([])) is None
+
+
+def test_compute_global_ranges_extracts_per_axis_min_max() -> None:
+    """Hand-crafted cells → exact min/max tuples across the sequence."""
+    from echemplot.origin._plots import compute_global_ranges
+
+    # chdis: even cols = capacity (x), odd = voltage (y).
+    chdis_a = pd.DataFrame({"q_ch": [0.0, 500.0], "v_ch": [3.0, 4.0]})
+    chdis_b = pd.DataFrame({"q_ch": [0.0, 800.0], "v_ch": [3.1, 4.2]})
+
+    # cap after reset_index → [cycle, q_ch, q_dis, ce].
+    cap_a = pd.DataFrame(
+        {"cycle": [1, 2], "q_ch": [1000.0, 990.0], "q_dis": [990.0, 980.0], "ce": [99.0, 98.9]}
+    ).set_index("cycle")
+    cap_b = pd.DataFrame(
+        {"cycle": [1, 2, 3], "q_ch": [800.0, 790.0, 780.0], "q_dis": [760.0, 755.0, 750.0], "ce": [95.0, 95.5, 96.1]}
+    ).set_index("cycle")
+
+    # dqdv: even cols = voltage (x), odd = dQ/dV (y).
+    dqdv_a = pd.DataFrame({"v": [3.0, 3.5, 4.0], "dqdv": [10.0, 20.0, -5.0]})
+    dqdv_b = pd.DataFrame({"v": [3.1, 3.6, 4.1], "dqdv": [12.0, 22.0, -8.0]})
+
+    a = _fake_cell(chdis=chdis_a, cap=cap_a, dqdv=dqdv_a, name="A")
+    b = _fake_cell(chdis=chdis_b, cap=cap_b, dqdv=dqdv_b, name="B")
+
+    ranges = compute_global_ranges([a, b])
+
+    assert ranges.chdis_x == (0.0, 800.0)
+    assert ranges.chdis_y == (3.0, 4.2)
+    assert ranges.cycle_x == (1.0, 3.0)
+    assert ranges.cycle_left_y == (750.0, 990.0)
+    assert ranges.cycle_right_y == (95.0, 99.0)
+    assert ranges.dqdv_x == (3.0, 4.1)
+    assert ranges.dqdv_y == (-8.0, 22.0)
+
+
+def test_compute_global_ranges_single_cell_equals_cell_range() -> None:
+    """With a single cell, global == that cell's own data range."""
+    from echemplot.origin._plots import compute_global_ranges
+
+    chdis = pd.DataFrame({"q_ch": [0.0, 1000.0], "v_ch": [3.0, 4.2]})
+    cap = pd.DataFrame(
+        {"cycle": [1, 2], "q_ch": [1000.0, 990.0], "q_dis": [990.0, 980.0], "ce": [99.0, 98.9]}
+    ).set_index("cycle")
+    dqdv = pd.DataFrame({"v": [3.0, 4.0], "dqdv": [5.0, 15.0]})
+
+    cell = _fake_cell(chdis=chdis, cap=cap, dqdv=dqdv)
+    ranges = compute_global_ranges([cell])
+
+    assert ranges.chdis_x == (0.0, 1000.0)
+    assert ranges.chdis_y == (3.0, 4.2)
+    assert ranges.cycle_x == (1.0, 2.0)
+    assert ranges.cycle_left_y == (980.0, 990.0)
+    assert ranges.cycle_right_y == (98.9, 99.0)
+    assert ranges.dqdv_x == (3.0, 4.0)
+    assert ranges.dqdv_y == (5.0, 15.0)
+
+
+def test_compute_global_ranges_nan_only_yields_none() -> None:
+    """All-NaN columns produce ``None`` per-axis instead of NaN tuples."""
+    from echemplot.origin._plots import compute_global_ranges
+
+    nan_df = pd.DataFrame({"a": [np.nan, np.nan], "b": [np.nan, np.nan]})
+    cap_nan = pd.DataFrame(
+        {"cycle": [1, 2], "q_ch": [np.nan, np.nan], "q_dis": [np.nan, np.nan], "ce": [np.nan, np.nan]}
+    ).set_index("cycle")
+
+    cell = _fake_cell(chdis=nan_df, cap=cap_nan, dqdv=nan_df)
+    ranges = compute_global_ranges([cell])
+
+    assert ranges.chdis_x is None
+    assert ranges.chdis_y is None
+    assert ranges.cycle_x == (1.0, 2.0)  # cycle index is finite
+    assert ranges.cycle_left_y is None
+    assert ranges.cycle_right_y is None
+    assert ranges.dqdv_x is None
+    assert ranges.dqdv_y is None
+
+
+def test_compute_global_ranges_empty_dataframes_are_safe() -> None:
+    """Empty cell dataframes → ``_GraphRanges`` with all ``None`` fields, no raises."""
+    from echemplot.origin._plots import compute_global_ranges
+
+    cell = _fake_cell()
+    ranges = compute_global_ranges([cell])
+
+    for field_name in (
+        "chdis_x",
+        "chdis_y",
+        "cycle_x",
+        "cycle_left_y",
+        "cycle_right_y",
+        "dqdv_x",
+        "dqdv_y",
+    ):
+        assert getattr(ranges, field_name) is None, field_name
+
+
+def test_set_axis_limits_is_noop_when_limits_none() -> None:
+    from echemplot.origin._plots import _set_axis_limits
+
+    layer = MagicMock()
+    _set_axis_limits(layer, "x", None)
+    layer.axis.assert_not_called()
+    layer.lt_exec.assert_not_called()
+
+
+def test_set_axis_limits_skips_degenerate_range() -> None:
+    """``lo == hi`` → leave template scaling alone (no axis API call)."""
+    from echemplot.origin._plots import _set_axis_limits
+
+    layer = MagicMock()
+    _set_axis_limits(layer, "x", (3.0, 3.0))
+    layer.axis.assert_not_called()
+    layer.lt_exec.assert_not_called()
+
+
+def test_set_axis_limits_sets_begin_and_end_via_attribute_api() -> None:
+    from echemplot.origin._plots import _set_axis_limits
+
+    layer = MagicMock()
+    _set_axis_limits(layer, "x", (0.0, 10.0))
+    layer.axis.assert_called_once_with("x")
+    axis_obj = layer.axis.return_value
+    assert axis_obj.begin == 0.0
+    assert axis_obj.end == 10.0
+
+
+def test_set_axis_limits_falls_back_to_lt_exec_when_attr_api_raises() -> None:
+    from echemplot.origin._plots import _set_axis_limits
+
+    layer = MagicMock()
+    layer.axis.side_effect = RuntimeError("no axis() on this layer build")
+    _set_axis_limits(layer, "y", (1.0, 5.0))
+    layer.lt_exec.assert_called_once()
+    cmd = layer.lt_exec.call_args.args[0]
+    assert cmd.startswith("y.from=1.0")
+    assert "y.to=5.0" in cmd
+
+
+def test_create_cell_plots_applies_ranges_to_every_layer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``ranges`` is passed, each layer receives begin/end writes per axis.
+
+    Calls ``create_cell_plots`` directly with a non-degenerate
+    ``_GraphRanges`` so every axis triggers an ``axis()`` setter — the
+    single-cycle ``_linear_cell`` would otherwise collapse cycle ranges
+    to ``lo == hi`` and short-circuit :func:`_set_axis_limits`.
+    """
+    import echemplot.origin._plots as plots_mod
+    from echemplot.origin._plots import _GraphRanges, create_cell_plots
+
+    # Make graph[0] and graph[1] share the same inner layer mock so
+    # axis() call history is observable in one place.
+    created_graphs: list[MagicMock] = []
+
+    def _fake_new_graph(*_args: Any, **_kwargs: Any) -> MagicMock:
+        g = MagicMock()
+        created_graphs.append(g)
+        return g
+
+    monkeypatch.setattr(plots_mod, "_new_graph_from_template", _fake_new_graph)
+
+    cell = _linear_cell("A")
+    sheets = {"chdis": MagicMock(), "cycle": MagicMock(), "dqdv": MagicMock()}
+    ranges = _GraphRanges(
+        chdis_x=(0.0, 1000.0),
+        chdis_y=(3.0, 4.2),
+        cycle_x=(1.0, 5.0),
+        cycle_left_y=(900.0, 1000.0),
+        cycle_right_y=(95.0, 99.0),
+        dqdv_x=(3.0, 4.2),
+        dqdv_y=(-10.0, 10.0),
+    )
+    create_cell_plots(MagicMock(), cell, sheets, ranges=ranges)
+
+    chdis_graph, cycle_graph, dqdv_graph = created_graphs
+
+    # chdis: one layer, two axis() calls (x + y).
+    chdis_axes = [c.args[0] for c in chdis_graph.__getitem__.return_value.axis.call_args_list]
+    assert chdis_axes == ["x", "y"], chdis_axes
+
+    # cycle: two layers but MagicMock collapses graph[0] / graph[1]
+    # into the same return value, so we see 4 axis() calls in order.
+    cycle_axes = [c.args[0] for c in cycle_graph.__getitem__.return_value.axis.call_args_list]
+    assert cycle_axes == ["x", "y", "x", "y"], cycle_axes
+
+    # dqdv: one layer, two axis() calls.
+    dqdv_axes = [c.args[0] for c in dqdv_graph.__getitem__.return_value.axis.call_args_list]
+    assert dqdv_axes == ["x", "y"], dqdv_axes
+
+
+def test_comparison_plots_share_the_per_cell_ranges(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Comparison graphs must receive the same ``(lo, hi)`` as per-cell graphs."""
+    _stub_templates(monkeypatch, tmp_path)
+    _, _, graph_objs = _install_tracking_originpro(monkeypatch)
+    cell_a = _linear_cell("A")
+    cell_b = _linear_cell("B", q_ch=800.0, q_dis=760.0)
+
+    from echemplot.origin import push_to_origin
+    from echemplot.origin._plots import compute_global_ranges
+
+    push_to_origin([cell_a, cell_b], stat_cycles=(1,))
+
+    # Order: per-cell A (3), per-cell B (3), comparison (3) = 9 graphs.
+    assert len(graph_objs) == 9
+
+    expected = compute_global_ranges([cell_a, cell_b])
+
+    # Per-cell A chdis graph (index 0) and comparison chdis graph
+    # (index 6) should both have begin/end set to the shared range.
+    per_cell_chdis_axis = graph_objs[0].__getitem__.return_value.axis
+    comparison_chdis_axis = graph_objs[6].__getitem__.return_value.axis
+
+    # Both must have been called with "x" and "y" at least once.
+    per_cell_axes = {c.args[0] for c in per_cell_chdis_axis.call_args_list}
+    comparison_axes = {c.args[0] for c in comparison_chdis_axis.call_args_list}
+    assert per_cell_axes == {"x", "y"}
+    assert comparison_axes == {"x", "y"}
+
+    # Same axis object is returned by MagicMock for every axis() call,
+    # so the last begin/end written wins. Assert on that final value
+    # which is the comparison graph's y-range write — matching the
+    # global chdis_y range.
+    assert expected.chdis_y is not None
+    final_begin = comparison_chdis_axis.return_value.begin
+    final_end = comparison_chdis_axis.return_value.end
+    assert final_begin == expected.chdis_y[0]
+    assert final_end == expected.chdis_y[1]
+
+
+def test_ranges_not_applied_when_dataframes_yield_no_finite_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """All-None ranges → no axis() or lt_exec() calls on any layer."""
+    _stub_templates(monkeypatch, tmp_path)
+    _install_mock_originpro(monkeypatch)
+
+    from echemplot.origin._plots import _GraphRanges, create_cell_plots
+
+    layer = MagicMock()
+    # Make graph[0] and graph[1] both return the same layer mock.
+    graph = MagicMock()
+    graph.__getitem__.return_value = layer
+
+    # Patch _new_graph_from_template to return our tracked graph every
+    # call, avoiding any template-file resolution concerns here.
+    import echemplot.origin._plots as plots_mod
+
+    monkeypatch.setattr(plots_mod, "_new_graph_from_template", lambda *a, **kw: graph)
+
+    empty_ranges = _GraphRanges(
+        chdis_x=None,
+        chdis_y=None,
+        cycle_x=None,
+        cycle_left_y=None,
+        cycle_right_y=None,
+        dqdv_x=None,
+        dqdv_y=None,
+    )
+
+    cell = _linear_cell("A")
+    sheets = {
+        "chdis": MagicMock(),
+        "cycle": MagicMock(),
+        "dqdv": MagicMock(),
+    }
+    create_cell_plots(MagicMock(), cell, sheets, ranges=empty_ranges)
+
+    layer.axis.assert_not_called()
+    layer.lt_exec.assert_not_called()


### PR DESCRIPTION
## Summary
- Fixes #61 — Origin template graphs now scale to the full data range instead of the template's fixed limits.
- A single global `_GraphRanges` is computed once from all input cells and applied to every per-cell graph AND the comparison graphs, so multi-cell runs share one comparable scale.
- The rescaling is a no-op when cells yield no finite values (empty DataFrames, all-NaN columns) — falls back to the template's default scaling.
- Adds `layer.axis(axis).begin/end` to the documented originpro API assumptions (see module docstring in `_plots.py`). A LabTalk fallback is in place for environments where attribute-style access raises.

## Test plan
- [ ] `ruff check` / `mypy` / `pytest` all green
- [ ] Manual in Origin: `push_to_origin([cell_A])` → all three graphs autoscale to cell_A's data
- [ ] Manual in Origin: `push_to_origin([A, B, C])` → per-cell and comparison graphs share identical axis ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)