### PR TITLE
feat: raise default SG window_length from 11 to 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Default Savitzky-Golay `window_length` for dQ/dV smoothing raised from
+  `11` to `21`. Applies uniformly across `echemplot.core.dqdv.get_dqdv_df`,
+  `Cell.dqdv_df`, `plot_dqdv`, `echemplot.origin.push_to_origin`, and the
+  Tk GUI's `SG window_length` entry. Callers that explicitly pass
+  `window_length=11` / `sg_window=11` are unaffected.
+
 ## [0.1.1] - 2026-04-22
 
 ### Added

--- a/src/echemplot/core/dqdv.py
+++ b/src/echemplot/core/dqdv.py
@@ -111,7 +111,7 @@ def get_dqdv_df(
     chdis_df: pd.DataFrame,
     *,
     inter_num: int = 100,
-    window_length: int = 11,
+    window_length: int = 21,
     polyorder: int = 2,
     column_lang: ColumnLang = "ja",
 ) -> pd.DataFrame:

--- a/src/echemplot/gui/_controller.py
+++ b/src/echemplot/gui/_controller.py
@@ -98,7 +98,7 @@ class GuiRequest:
     dirs: Sequence[Path]
     kinds: frozenset[str]
     cycles: Sequence[int] = field(default_factory=tuple)
-    sg_window: int = 11
+    sg_window: int = 21
     voltage_range: tuple[float, float] | None = None
     capacity_range: tuple[float, float] | None = None
     dqdv_range: tuple[float, float] | None = None

--- a/src/echemplot/gui/tk_app.py
+++ b/src/echemplot/gui/tk_app.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
 OnComplete = Callable[[Sequence["Cell"], Sequence["Figure"], int], None]
 
 _DEFAULT_CYCLES_TEXT = "1 10 50"
-_DEFAULT_SG_WINDOW_TEXT = "11"
+_DEFAULT_SG_WINDOW_TEXT = "21"
 _PADX = 6
 _PADY = 4
 

--- a/src/echemplot/origin/__init__.py
+++ b/src/echemplot/origin/__init__.py
@@ -50,7 +50,7 @@ def _require_originpro() -> object:
     return op
 
 
-_DEFAULT_SG_WINDOW = 11
+_DEFAULT_SG_WINDOW = 21
 _DEFAULT_SG_POLYORDER = 2
 
 
@@ -86,7 +86,7 @@ def push_to_origin(
         :func:`echemplot.core.stats.stat_table` as ``target_cycles``.
     sg_window, sg_polyorder
         Savitzky-Golay parameters for the dQ/dV worksheet. At the defaults
-        (``11`` / ``2``) the cached :attr:`Cell.dqdv_df` is reused verbatim;
+        (``21`` / ``2``) the cached :attr:`Cell.dqdv_df` is reused verbatim;
         any override triggers a one-off :func:`echemplot.core.dqdv.get_dqdv_df`
         recompute per cell so the worksheet values reflect the caller's
         choice. ``Cell`` instances are not mutated. ``sg_window`` must be a

--- a/src/echemplot/plotting/matplotlib_backend.py
+++ b/src/echemplot/plotting/matplotlib_backend.py
@@ -269,7 +269,7 @@ def plot_dqdv(
     cells: Sequence[Cell],
     cycles: Sequence[int] | None = None,
     *,
-    sg_window_length: int = 11,
+    sg_window_length: int = 21,
     sg_polyorder: int = 2,
 ) -> Figure:
     """dQ/dV vs voltage, cycle 1 red / other cycles black.
@@ -291,7 +291,7 @@ def plot_dqdv(
     sg_window_length
         Savitzky-Golay ``window_length`` forwarded to
         :func:`echemplot.core.dqdv.get_dqdv_df`. When this and
-        ``sg_polyorder`` are both at their defaults (``11`` / ``2``), the
+        ``sg_polyorder`` are both at their defaults (``21`` / ``2``), the
         cached :attr:`Cell.dqdv_df` is reused; otherwise a fresh
         ``dqdv_df`` is computed per cell with the requested parameters.
         Must be a positive odd integer strictly greater than
@@ -318,7 +318,7 @@ def plot_dqdv(
     # Reuse the cached property only at the defaults; any override forces a
     # recompute via ``get_dqdv_df`` so the requested SG parameters actually
     # land in the output.
-    use_default = sg_window_length == 11 and sg_polyorder == 2
+    use_default = sg_window_length == 21 and sg_polyorder == 2
 
     for ax, cell in zip(axes, cells):
         v_name = _quantity(cell.column_lang, "voltage")

--- a/tests/test_dqdv.py
+++ b/tests/test_dqdv.py
@@ -215,7 +215,7 @@ def test_in_memory_cell_dqdv_exercises_interpolation_path() -> None:
 
     cell = Cell(name="synthetic", mass_g=0.001, raw_df=raw)
     dqdv = cell.dqdv_df
-    # Wide V range (1.2 V) → ipnum = 120, well above window_length = 11.
+    # Wide V range (1.2 V) → ipnum = 120, well above window_length = 21.
     # Real populated rows on both sides.
     assert dqdv[(1, "ch", "dQ/dV")].notna().any()
     assert dqdv[(1, "dis", "dQ/dV")].notna().any()
@@ -273,7 +273,7 @@ def test_cell_dqdv_df_is_cached(make_cell_dir: Callable[..., Path]) -> None:
     second = cell.dqdv_df
     assert first is second
     # The synthetic renzoku fixture has a very small voltage span (0.1 V for
-    # ch, 0.2 V for dis) so ipnum=int(100*0.1)=10 < window_length=11 → both
+    # ch, 0.2 V for dis) so ipnum=int(100*0.1)=10 < window_length=21 → both
     # segments produce NaN columns by design. The shape + column layout must
     # still be correct.
     assert list(first.columns.names) == ["cycle", "side", "quantity"]

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -135,9 +135,9 @@ def test_sg_window_override_changes_dqdv_values(wide_cell_dir: Path) -> None:
     """A non-default ``sg_window`` must actually flow into the dQ/dV
     computation, not silently fall back to the cached-property default.
 
-    Compares the y-data of the first dQ/dV line between a default-window
-    run (11) and an override (21); the smoother window produces numerically
-    distinct values across the curve.
+    Compares the y-data of the first dQ/dV line between two distinct
+    window_length values (11 vs 21); the smoother window produces
+    numerically distinct values across the curve.
     """
     fig_default = run(
         GuiRequest(
@@ -184,7 +184,7 @@ def test_controller_passes_sg_window_to_plot_dqdv(
         cells: object,
         cycles: object = None,
         *,
-        sg_window_length: int = 11,
+        sg_window_length: int = 21,
         sg_polyorder: int = 2,
     ) -> object:
         calls.append(

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -256,7 +256,7 @@ def test_plot_dqdv_sg_override_changes_curve() -> None:
     cell = _linear_cell(n_cycles=1)
 
     fig_default = plot_dqdv([cell])
-    fig_wide = plot_dqdv([cell], sg_window_length=21)
+    fig_wide = plot_dqdv([cell], sg_window_length=31)
 
     y_default = np.asarray(_first_visible(fig_default).lines[0].get_ydata(), dtype=float)
     y_wide = np.asarray(_first_visible(fig_wide).lines[0].get_ydata(), dtype=float)


### PR DESCRIPTION
## Summary
- Default Savitzky-Golay `window_length` for dQ/dV smoothing raised from `11` to `21` across all entry points: `get_dqdv_df`, `Cell.dqdv_df`, `plot_dqdv`, `push_to_origin`, and the Tk GUI's `SG window_length` entry.
- Cache fast-path literal in [matplotlib_backend.py:321](src/echemplot/plotting/matplotlib_backend.py) and `_DEFAULT_SG_WINDOW` in [origin/__init__.py:53](src/echemplot/origin/__init__.py) advance with the default so cached-vs-recomputed dQ/dV stays equivalent at the new default.
- Docstrings and a couple of test comments that named the old default updated to 21. `test_plot_dqdv_sg_override_changes_curve` now overrides with `31` instead of `21` (21 is no longer the override).

## Why
11-point smoothing is weak on real data, leaving visible noise in the default dQ/dV curve. 21 is the value users were reaching for manually; making it the baseline saves a round-trip through the GUI entry.

## Test plan
- [x] `uv run pytest` passes (187 passed, 2 skipped)
- [ ] Launch the Tk GUI and confirm `SG window_length` entry prefills as `21`
- [ ] Compare a sample cell's dQ/dV plot against the previous default to confirm the smoother curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)