### PR TITLE
chore: gitignore internal-only Japanese Origin setup doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ network_setting.json
 CLAUDE.md
 .claude/
 
+# Internal-only Japanese install guide
+docs/ORIGIN_SETUP_JA.md
+
 # Build artifacts
 *.whl
 *.tar.gz


### PR DESCRIPTION
## Summary
- Add `docs/ORIGIN_SETUP_JA.md` to `.gitignore` so the internal Japanese Origin install guide stays local.

## Why
- The Japanese walkthrough is intended for in-house distribution (step-by-step Origin Python Console install, Origin-mode disabled-option caveat, UFF template override). It shouldn't ship in the public repo alongside the existing English `ORIGIN_SETUP.md`.

## Test plan
- [x] `git check-ignore -v docs/ORIGIN_SETUP_JA.md` resolves to the new `.gitignore:78` rule.
- [x] `git status` is clean after committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)