### PR TITLE
fix(origin): rescale every layer after add_plot

### DIFF
--- a/src/echemplot/origin/_plots.py
+++ b/src/echemplot/origin/_plots.py
@@ -31,6 +31,14 @@ confirm them — see issue #15):
   graph we just created via :func:`op.new_graph`; it is the documented
   scripting entry point and does not assume any per-layer attribute
   contract.
+* Each layer exposes ``layer.rescale()``, which fits the axes to the
+  currently-bound data. The template defaults do not know the data
+  range, so without this call the graph renders with the template's
+  original scale and data outside that window is clipped. The bind
+  helpers below call ``rescale`` after their ``add_plot`` loop;
+  :func:`_set_axis_limits` (called later from the orchestrators when
+  explicit ``ranges`` are provided) subsequently overrides those
+  autoscaled values, so the issue #61 shared-axis path is unaffected.
 
 The three templates expect distinct column layouts; the bind helpers in
 this module encode the layout per category:
@@ -291,9 +299,17 @@ def _bind_xy_pairs(layer: Any, sheet: Any, ncols: int) -> None:
     ``(電圧, dqdv)`` for dqdv. Trailing odd columns — which should never
     occur given the upstream pair-producing pipeline — are skipped
     rather than bound as an orphan plot.
+
+    ``layer.rescale()`` fits the axes to the just-bound data so the
+    template's default scaling does not clip the plot. When called
+    repeatedly on the same layer from a comparison loop the call is
+    idempotent — each invocation expands the axes to cover everything
+    currently bound — so the final state is correct regardless of the
+    number of cells.
     """
     for i in range(0, ncols - 1, 2):
         layer.add_plot(sheet, colx=i, coly=i + 1)
+    layer.rescale()
 
 
 def _bind_cycle(graph: Any, sheet: Any) -> None:
@@ -301,10 +317,13 @@ def _bind_cycle(graph: Any, sheet: Any) -> None:
 
     The template has two layers: ``graph[0]`` is the left Y (discharge
     capacity), ``graph[1]`` is the right Y (Coulombic efficiency). Both
-    share ``cycle`` as X.
+    share ``cycle`` as X. Each layer is rescaled after binding so the
+    autoscale survives the template's default axis range.
     """
     graph[0].add_plot(sheet, colx=_CYCLE_COL_CYCLE, coly=_CYCLE_COL_QDIS)
     graph[1].add_plot(sheet, colx=_CYCLE_COL_CYCLE, coly=_CYCLE_COL_CE)
+    graph[0].rescale()
+    graph[1].rescale()
 
 
 def create_cell_plots(

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -437,6 +437,31 @@ def test_cycle_plot_binds_both_layers(monkeypatch: pytest.MonkeyPatch, tmp_path:
     assert all(call.kwargs["colx"] == 0 for call in call_list), call_list
 
 
+def test_every_per_cell_graph_layer_is_rescaled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Every template-backed layer must be rescaled after ``add_plot``.
+
+    Without an explicit ``layer.rescale()`` call, Origin keeps the
+    template's default axis range and data outside that window renders
+    clipped — the autoscale-not-working regression this test guards.
+    ``MagicMock.__getitem__`` returns the same inner mock for every
+    index, so the cycle graph's two layers share a single ``rescale``
+    counter; we assert ``>= 1`` rather than an exact count.
+    """
+    _stub_templates(monkeypatch, tmp_path)
+    _, _, graph_objs = _install_tracking_originpro(monkeypatch)
+    cell = _linear_cell("A")
+
+    from echemplot.origin import push_to_origin
+
+    push_to_origin([cell], stat_cycles=(1,))
+
+    for graph in graph_objs[:3]:
+        layer = graph.__getitem__.return_value
+        assert layer.rescale.called, f"rescale not called on layer of {graph!r}"
+
+
 def test_cols_axis_is_set_per_category(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Worksheets for plot-targeted categories must declare X/Y designations.
 


### PR DESCRIPTION
## Summary
- Origin モードで生成したグラフがテンプレート既定の軸スケールのまま表示され、データが軸外にクリップされる autoscale 不具合の暫定対応
- `_bind_xy_pairs` / `_bind_cycle` の `add_plot` ループ完了後に `layer.rescale()` を呼び、テンプレ既定スケールを上書き
- issue #61 の明示レンジ機能（`_set_axis_limits`）はオーケストレータから bind helper の**後**に呼ばれるため、`ranges` を渡したケースでは rescale が上書きされて従来通り動作

## Why
テンプレ `.otpu` はデータ範囲を知らないので、`add_plot` 直後のグラフは軸がテンプレ既定のまま。`originpro` の `layer.rescale()` を明示的に呼ばないと autoscale されない。

## Changes
- `src/echemplot/origin/_plots.py`
  - `_bind_xy_pairs`: `add_plot` ループ直後に `layer.rescale()` 追加
  - `_bind_cycle`: 両レイヤ bind 後に `graph[0].rescale()` / `graph[1].rescale()` 追加
  - モジュール docstring に `layer.rescale()` の API 前提を追記
- `tests/test_origin.py`
  - `test_every_per_cell_graph_layer_is_rescaled`: `push_to_origin` 経由で chdis / cycle / dqdv の全レイヤに `rescale` が呼ばれることを検証する回帰テストを追加

## Test plan
- [x] `pytest tests/test_origin.py` — 37 passed (既存テスト + 新規 rescale テスト)
- [x] `pytest` 全体 — 188 passed, 2 skipped (optional deps 未導入分)
- [ ] 実機 Origin で 1 セル push して chdis / cycle / dqdv の 3 グラフがデータ範囲にフィットすること目視確認
- [ ] 複数セル push + `ranges` 指定で comparison グラフが明示レンジで揃うこと（rescale が上書きされないこと）確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)