### PR TITLE
feat(origin): auto-close Tk GUI after successful push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `echemplot.origin.launch_gui` now closes the Tk window automatically
+  after a successful Run. The launcher's `mainloop()` runs inside the
+  Origin Python Console, so previously the user had to click the window
+  close button to release the Console; the one-shot batch UX now simply
+  ends when the push completes. Error dialogs still keep the window open
+  so the inputs can be corrected and re-Run.
+
 ## [0.1.3] - 2026-04-23
 
 ### Fixed

--- a/docs/ORIGIN_SETUP.md
+++ b/docs/ORIGIN_SETUP.md
@@ -65,8 +65,11 @@ directly.
 
 Notes:
 
-- `launch_gui()` runs Tk's `mainloop()` **in the Origin process**. The Origin
-  Python Console is blocked until you close the GUI window.
+- `launch_gui()` runs Tk's `mainloop()` **in the Origin process**, so the
+  Origin Python Console is blocked while the window is open. After a
+  successful Run the window closes automatically and the Console prompt
+  returns; if the Run surfaces an error dialog, close the window manually
+  (or fix the inputs and Run again) to release the Console.
 - Origin's embedded CPython must include `_tkinter` (OriginLab 2022 and later
   do). If it doesn't, the call raises `ImportError` from `import tkinter`; use
   a separate system Python in that case.

--- a/src/echemplot/gui/tk_app.py
+++ b/src/echemplot/gui/tk_app.py
@@ -413,6 +413,14 @@ class _App:
                 self._fail(f"Error in completion hook: {exc}")
                 return
             self._status.set(f"Ran {len(result.figures)} figure(s); pushed via hook.")
+            if self._origin_mode:
+                # Origin-mode is a one-shot batch: ``launch_gui`` runs Tk's
+                # ``mainloop()`` inside the Origin Python Console, so the
+                # Console stays blocked until this root is destroyed. After
+                # a successful push there is nothing left to do, so we close
+                # the window automatically instead of forcing the user to
+                # click the OS close button to regain the Console.
+                self.root.destroy()
         else:
             for fig in result.figures:
                 self._show_figure(fig)
@@ -483,8 +491,11 @@ def launch_gui(
         entry, and the voltage/capacity/dQ-dV range entries) and shows
         an inline note explaining why. Only ``SG window_length`` stays
         editable because it flows into the dQ/dV worksheet the Origin
-        push writes. :func:`echemplot.origin.launch_gui` sets this;
-        standalone callers should leave it at the ``False`` default.
+        push writes. After a successful Run the window is destroyed
+        automatically so the Origin Python Console (which is blocked on
+        this ``mainloop()``) is released without a manual window close.
+        :func:`echemplot.origin.launch_gui` sets this; standalone callers
+        should leave it at the ``False`` default.
 
     Switches matplotlib to the TkAgg backend at call time (not import
     time): a module-level ``matplotlib.use("TkAgg")`` would crash

--- a/src/echemplot/origin/__init__.py
+++ b/src/echemplot/origin/__init__.py
@@ -223,9 +223,10 @@ def launch_gui(
         )
         # Close the figures the controller built. The Origin path
         # bypasses ``_show_figure`` (which would otherwise own the close
-        # via ``WM_DELETE_WINDOW``), so without an explicit close a long
-        # session of repeated Run clicks accumulates figures in pyplot's
-        # global registry and eventually trips ``max_open_warning``.
+        # via ``WM_DELETE_WINDOW``), so a single Run still leaves several
+        # figures pinned in pyplot's global registry — the Tk root is
+        # destroyed right after this callback returns, but pyplot doesn't
+        # know about that and would keep the figures alive indefinitely.
         import matplotlib.pyplot as plt
 
         for fig in figures:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -399,6 +399,144 @@ def test_app_default_mode_keeps_widgets_enabled() -> None:
         root.destroy()
 
 
+# ---- origin_mode auto-close ------------------------------------------------
+
+
+def test_app_origin_mode_destroys_root_after_successful_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """In origin_mode the Tk root must be destroyed after a successful
+    Run so the Origin Python Console (blocked on ``mainloop()``) is
+    released without forcing the user to click the window close button.
+    """
+    import tkinter as tk
+
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no display available for Tk: {exc}")
+
+    import echemplot.gui.tk_app as tk_app
+    from echemplot.gui._controller import RunResult
+
+    real_destroy = root.destroy
+    destroy_calls: list[None] = []
+
+    def spy_destroy() -> None:
+        destroy_calls.append(None)
+
+    try:
+        # Stub the controller so _on_run reaches the on_complete branch
+        # without touching the filesystem.
+        monkeypatch.setattr(tk_app, "run", lambda _req: RunResult(cells=[], figures=[]))
+
+        hook_calls: list[int] = []
+
+        def noop_hook(_cells: object, _figs: object, sg: int) -> None:
+            hook_calls.append(sg)
+
+        app = tk_app._App(root, origin_mode=True, on_complete=noop_hook)
+        # Non-empty dirs so the GuiRequest construction succeeds; the
+        # stubbed ``run`` ignores the value, so a placeholder Path is fine.
+        app._dirs = [tmp_path]
+        root.destroy = spy_destroy  # type: ignore[assignment,method-assign]
+
+        app._on_run()
+
+        assert hook_calls, "on_complete should have fired for a successful Run"
+        assert destroy_calls, "root.destroy must be called after successful origin-mode Run"
+    finally:
+        real_destroy()
+
+
+def test_app_origin_mode_keeps_root_when_on_complete_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the on_complete hook raises, ``_fail`` surfaces the error and
+    the root stays alive — the user needs the window to see the dialog
+    and retry.
+    """
+    import tkinter as tk
+    from tkinter import messagebox
+
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no display available for Tk: {exc}")
+
+    import echemplot.gui.tk_app as tk_app
+    from echemplot.gui._controller import RunResult
+
+    real_destroy = root.destroy
+    destroy_calls: list[None] = []
+
+    def spy_destroy() -> None:
+        destroy_calls.append(None)
+
+    try:
+        monkeypatch.setattr(tk_app, "run", lambda _req: RunResult(cells=[], figures=[]))
+        # ``_fail`` pops a modal that would hang the headless test.
+        monkeypatch.setattr(messagebox, "showerror", lambda *_a, **_kw: None)
+
+        def raising_hook(_cells: object, _figs: object, _sg: int) -> None:
+            raise RuntimeError("simulated push failure")
+
+        app = tk_app._App(root, origin_mode=True, on_complete=raising_hook)
+        app._dirs = [tmp_path]
+        root.destroy = spy_destroy  # type: ignore[assignment,method-assign]
+
+        app._on_run()
+
+        assert not destroy_calls, "root must stay alive when on_complete raises"
+    finally:
+        real_destroy()
+
+
+def test_app_standalone_mode_does_not_destroy_root_after_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression guard: the standalone GUI (``origin_mode=False``) must
+    keep the window open after Run so repeated iteration and the
+    matplotlib Toplevels remain usable.
+    """
+    import tkinter as tk
+
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no display available for Tk: {exc}")
+
+    import echemplot.gui.tk_app as tk_app
+    from echemplot.gui._controller import RunResult
+
+    real_destroy = root.destroy
+    destroy_calls: list[None] = []
+
+    def spy_destroy() -> None:
+        destroy_calls.append(None)
+
+    try:
+        monkeypatch.setattr(tk_app, "run", lambda _req: RunResult(cells=[], figures=[]))
+
+        hook_calls: list[int] = []
+
+        def noop_hook(_cells: object, _figs: object, sg: int) -> None:
+            hook_calls.append(sg)
+
+        # Same on_complete branch as origin-mode, but with the default
+        # ``origin_mode=False`` — proves the destroy is gated on the flag.
+        app = tk_app._App(root, on_complete=noop_hook)
+        app._dirs = [tmp_path]
+        root.destroy = spy_destroy  # type: ignore[assignment,method-assign]
+
+        app._on_run()
+
+        assert hook_calls, "on_complete should have fired for a successful Run"
+        assert not destroy_calls, "standalone Run must not destroy the root"
+    finally:
+        real_destroy()
+
+
 def test_add_dir_deduplicates_paths(tmp_path: Path) -> None:
     """``_add_dir`` is the single path through which both Add-button and
     drag-and-drop reach the state list; adding the same directory twice


### PR DESCRIPTION
## Summary

Origin-mode `launch_gui()` runs Tk's `mainloop()` inside the Origin Python Console, which blocks the Console until the user manually closes the window. Now the Tk root is destroyed automatically after a successful Run, so the one-shot batch UX ("configure → Run → done") no longer requires an extra click to regain the Console. Error dialogs still keep the window open so the user can correct inputs and re-Run.

## Why

- `echemplot.origin.launch_gui` is explicitly a one-shot batch entry point (`origin_mode=True` already disables every widget that has no effect on the push path). The current behavior — Console stays blocked until manual window close — is friction for that workflow.
- Subprocess separation was considered but rejected: `originpro` is a COM wrapper that only works inside Origin's embedded Python, so spawning an external Python process would require IPC and a major architectural change. Auto-close is a ~3-line change that solves the actual pain.

## Changes

- `src/echemplot/gui/tk_app.py` — in `_App._on_run`, destroy `self.root` after a successful `_on_complete` when `self._origin_mode` is True. Errors (`_fail` path) still leave the window alive. Updated the `origin_mode` docstring on `launch_gui`.
- `src/echemplot/origin/__init__.py` — kept `plt.close(fig)` in the `_push` callback but rewrote the comment to reflect the new lifecycle (single Run, figures cleaned up before Tk root is destroyed).
- `docs/ORIGIN_SETUP.md` — note that the Console is released automatically on success and must be closed manually only on error.
- `CHANGELOG.md` — Changed entry under `[Unreleased]`.
- `tests/test_gui.py` — three new tests:
  - `test_app_origin_mode_destroys_root_after_successful_run` — happy path.
  - `test_app_origin_mode_keeps_root_when_on_complete_raises` — error path keeps window alive.
  - `test_app_standalone_mode_does_not_destroy_root_after_run` — regression guard that standalone (`origin_mode=False`) is unaffected.

## Test plan

- [x] `uv run pytest` — 191 passed, 2 skipped (pre-existing optional-dep skips).
- [x] `uv run ruff check` — clean on modified files.
- [x] `uv run mypy` — clean on `tk_app.py` and `origin/__init__.py`.
- [ ] Manual verification on a real Origin install: run `from echemplot.origin import launch_gui; launch_gui()`, pick cell dirs, click Run, confirm the window closes automatically and the Python Console prompt returns.
- [ ] Manual error path: click Run with no cell directories selected and confirm the error dialog appears with the window still open.

## Notes for reviewer

- The auto-close is gated on `self._origin_mode` rather than a new independent flag. Origin's launcher is the only caller that sets `origin_mode=True`, so the coupling is intentional (YAGNI — a separate `close_on_complete` flag can be split out later if a second caller ever needs it).
- `plt.close(fig)` in `_push` is kept because a single Run still produces multiple figures (one per plot kind × cell) that pyplot's global registry would otherwise hold alive after `root.destroy()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)