### PR TITLE
fix(origin): coerce pandas extension dtypes before originpro from_df (#75)

### DIFF
--- a/src/echemplot/origin/_worksheets.py
+++ b/src/echemplot/origin/_worksheets.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
+import numpy as np
 import pandas as pd
 
 # Origin's worksheet-name length limit. Hard-coded here rather than
@@ -84,10 +85,51 @@ def _flatten_columns(df: pd.DataFrame) -> pd.DataFrame:
         "_".join(str(lvl) for lvl in tup if str(lvl) != "") for tup in df.columns.to_flat_index()
     ]
     out = df.copy()
-    out.columns = pd.Index(flat_names)
+    # ``dtype=object`` pins the Index to numpy-compatible object dtype
+    # instead of pandas' ``StringDtype``. See :func:`_coerce_for_originpro`
+    # for why ``StringDtype`` breaks ``originpro.from_df``.
+    out.columns = pd.Index(flat_names, dtype=object)
     # Explicit DataFrame wrap pins the return type against pandas-stubs
     # occasionally inferring ``.copy`` as ``Any``. Matches the idiom used
     # in :mod:`echemplot.core.stats`.
+    return pd.DataFrame(out)
+
+
+def _coerce_for_originpro(df: pd.DataFrame) -> pd.DataFrame:
+    """Coerce pandas extension dtypes to numpy-compatible dtypes for ``from_df``.
+
+    ``originpro.worksheet.from_df`` dispatches per-column storage via
+    ``series.dtype.char`` (and also touches ``df.columns.dtype``). Pandas
+    extension dtypes — most commonly ``StringDtype`` when a user has
+    ``pd.options.future.infer_string = True`` set, or when Origin's
+    embedded Python ships a pandas build that defaults it on — do not
+    expose ``.char`` and raise ``AttributeError: 'StringDtype' object has
+    no attribute 'char'`` (issue #75).
+
+    The helper:
+
+    * Rebuilds the column ``Index`` with ``dtype=object`` if it isn't
+      already a numpy dtype.
+    * Converts any column whose dtype is not a numpy dtype to ``object``
+      (string-like extension arrays) — preserving values while giving
+      originpro a ``.char`` to read.
+
+    No-op when every dtype is already numpy-native, so the helper is
+    cheap on the numeric-only cell sheets that dominate the push path.
+    """
+    new_columns = None
+    if not isinstance(df.columns.dtype, np.dtype):
+        new_columns = pd.Index(list(df.columns), dtype=object)
+
+    conversions: dict[Any, str] = {
+        name: "object" for name, dt in zip(df.columns, df.dtypes) if not isinstance(dt, np.dtype)
+    }
+    if not conversions and new_columns is None:
+        return df
+
+    out = df.astype(conversions) if conversions else df.copy()
+    if new_columns is not None:
+        out.columns = new_columns
     return pd.DataFrame(out)
 
 
@@ -114,7 +156,7 @@ def _write_sheet(
     which is never plotted).
     """
     safe_name = _sanitize_sheet_name(sheet_name)
-    flat = _flatten_columns(df)
+    flat = _coerce_for_originpro(_flatten_columns(df))
     wks = op.new_sheet(type="w", lname=safe_name)
     wks.from_df(flat)
     # ``None`` = caller opted out (e.g. ``stat_table``). Empty string =

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -286,6 +286,112 @@ def test_flatten_columns_passes_single_level_columns_through() -> None:
     assert list(_flatten_columns(df).columns) == ["q_ch", "q_dis"]
 
 
+def test_flatten_columns_yields_numpy_object_column_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Flattened column Index must be numpy-object, not pandas ``StringDtype``.
+
+    ``originpro.worksheet.from_df`` dispatches on ``.dtype.char``, which
+    pandas extension dtypes don't expose. With
+    ``future.infer_string=True``, ``pd.Index([...])`` on strings yields
+    ``StringDtype`` and the push path fails with
+    ``AttributeError: 'StringDtype' object has no attribute 'char'``
+    (issue #75). Pinning ``dtype=object`` in ``_flatten_columns`` guards
+    against that configuration regardless of the caller's pandas option.
+    """
+    from echemplot.origin._worksheets import _flatten_columns
+
+    monkeypatch.setattr(pd.options.future, "infer_string", True)
+    df = pd.DataFrame(
+        [[1.0, 2.0]],
+        columns=pd.MultiIndex.from_tuples(
+            [(1, "ch", "q"), (1, "dis", "q")],
+            names=["cycle", "side", "quantity"],
+        ),
+    )
+    flat = _flatten_columns(df)
+    assert isinstance(flat.columns.dtype, np.dtype)
+    assert flat.columns.dtype == object
+
+
+# ----------------------------------------------------------------------
+# _coerce_for_originpro — extension-dtype defence for originpro.from_df
+# ----------------------------------------------------------------------
+
+
+def test_coerce_for_originpro_converts_stringdtype_column_to_object() -> None:
+    """StringDtype columns must become object so ``from_df`` sees ``.dtype.char``."""
+    from echemplot.origin._worksheets import _coerce_for_originpro
+
+    df = pd.DataFrame({"cell": pd.array(["a", "b"], dtype="string"), "x": [1.0, 2.0]})
+    out = _coerce_for_originpro(df)
+    assert out["cell"].dtype == object
+    assert out["cell"].dtype.char == "O"
+    assert out["x"].dtype == np.float64
+    assert list(out["cell"]) == ["a", "b"]
+
+
+def test_coerce_for_originpro_rebuilds_string_column_index_as_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``StringDtype`` column Index must be rebuilt as numpy-object.
+
+    ``from_df`` touches ``df.columns.dtype`` in addition to per-column
+    dtypes; with ``future.infer_string=True`` the Index dtype alone can
+    trip the same ``AttributeError``.
+    """
+    from echemplot.origin._worksheets import _coerce_for_originpro
+
+    monkeypatch.setattr(pd.options.future, "infer_string", True)
+    df = pd.DataFrame({"a": [1.0], "b": [2.0]})
+    # Re-constructing the Index under the opted-in option produces StringDtype.
+    df.columns = pd.Index(["a", "b"])
+    assert not isinstance(df.columns.dtype, np.dtype)  # precondition
+
+    out = _coerce_for_originpro(df)
+    assert isinstance(out.columns.dtype, np.dtype)
+    assert out.columns.dtype == object
+    assert list(out.columns) == ["a", "b"]
+
+
+def test_coerce_for_originpro_is_identity_for_numpy_dtypes() -> None:
+    """Numeric-only frames with an object-dtype column Index short-circuit."""
+    from echemplot.origin._worksheets import _coerce_for_originpro
+
+    df = pd.DataFrame({"a": [1.0], "b": [2.0]})
+    assert _coerce_for_originpro(df) is df
+
+
+def test_push_to_origin_succeeds_under_future_infer_string(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression for issue #75: completion hook failed with
+    ``'StringDtype' object has no attribute 'char'`` when the host pandas
+    had ``future.infer_string`` enabled, because the Index built in
+    ``_flatten_columns`` and the ``cell`` column from
+    ``stat_table.reset_index()`` both surfaced as ``StringDtype``. Every
+    frame handed to ``from_df`` must expose numpy-native dtypes on both
+    the values and the column Index.
+    """
+    mock_op = _install_mock_originpro(monkeypatch)
+    _stub_templates(monkeypatch, tmp_path)
+    monkeypatch.setattr(pd.options.future, "infer_string", True)
+    cell = _linear_cell("A")
+
+    from echemplot.origin import push_to_origin
+
+    push_to_origin([cell], stat_cycles=(1,))
+
+    # Every from_df call must receive numpy-native dtypes so originpro's
+    # ``.dtype.char`` dispatch survives. Guards against any future dtype
+    # inflation slipping past ``_coerce_for_originpro``.
+    for sheet_call in mock_op.new_sheet.return_value.from_df.call_args_list:
+        frame = sheet_call.args[0]
+        assert isinstance(frame.columns.dtype, np.dtype), frame.columns.dtype
+        for col in frame.columns:
+            assert isinstance(frame[col].dtype, np.dtype), (col, frame[col].dtype)
+
+
 # ----------------------------------------------------------------------
 # project_path round-trip
 # ----------------------------------------------------------------------

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -355,10 +355,19 @@ def test_coerce_for_originpro_rebuilds_string_column_index_as_object(
 
 
 def test_coerce_for_originpro_is_identity_for_numpy_dtypes() -> None:
-    """Numeric-only frames with an object-dtype column Index short-circuit."""
+    """Numeric-only frames with an object-dtype column Index short-circuit.
+
+    The column Index is pinned to ``dtype=object`` explicitly so the
+    assertion stays stable across pandas versions — recent releases
+    construct ``pd.DataFrame({...}).columns`` as ``StringDtype`` when
+    ``future.infer_string`` is on (py3.11/3.12 CI resolves a pandas
+    build where that is the case), which would legitimately send the
+    frame through the rebuild path and defeat the identity check.
+    """
     from echemplot.origin._worksheets import _coerce_for_originpro
 
     df = pd.DataFrame({"a": [1.0], "b": [2.0]})
+    df.columns = pd.Index(["a", "b"], dtype=object)
     assert _coerce_for_originpro(df) is df
 
 


### PR DESCRIPTION
## Summary

- Fix `Error in completion hook: 'StringDtype' object has no attribute 'char'` raised by `push_to_origin` / the Origin GUI path when the host pandas has `future.infer_string` enabled (issue #75, reported against v0.1.3).
- `originpro.worksheet.from_df` dispatches per-column storage via `series.dtype.char` and also touches `df.columns.dtype`; pandas extension dtypes (most commonly `StringDtype`) don't expose `.char`.
- Coerce any non-numpy dtypes to `object` right before handing the frame to originpro.

## What changed

- `_flatten_columns` now pins the rebuilt column Index to `dtype=object` instead of letting `pd.Index(...)` pick up `StringDtype` under `future.infer_string=True`.
- New `_coerce_for_originpro` helper in `echemplot.origin._worksheets`:
  - Rebuilds the column `Index` as numpy-object when its dtype is an extension dtype.
  - Converts any data column whose dtype isn't a numpy dtype to `object` (catches the `cell` column in `stat_table.reset_index()` under string inference, plus any other extension dtype users push in).
  - Early-returns the original frame when every dtype is already numpy-native, so the numeric-only per-cell sheets pay no cost.
- `_write_sheet` applies the coercion directly before `wks.from_df(flat)` — centralized so every sheet (per-cell + `stat_table`) gets the same guarantee.

## Why two sites

Both the column Index and the `stat_table.cell` column can surface as `StringDtype`:

| Source | When |
| --- | --- |
| `_flatten_columns` Index | `pd.Index(flat_names)` under `future.infer_string=True` |
| `stat_table` `cell` column | `stat_table.reset_index()` with string inference active |

Either one is enough to trip originpro's `.dtype.char` dispatch; the fix covers both.

## Tests

Added four tests in `tests/test_origin.py`:

- `test_flatten_columns_yields_numpy_object_column_index` — asserts the flattened column Index stays numpy-object under `future.infer_string=True`.
- `test_coerce_for_originpro_converts_stringdtype_column_to_object` — `StringDtype` values become `object`, numeric values unchanged.
- `test_coerce_for_originpro_rebuilds_string_column_index_as_object` — `StringDtype` Index becomes `object`.
- `test_coerce_for_originpro_is_identity_for_numpy_dtypes` — no-op path preserved.
- `test_push_to_origin_succeeds_under_future_infer_string` — end-to-end regression: runs `push_to_origin` with `future.infer_string=True` and asserts every `from_df` call receives numpy-native dtypes on both values and column Index.

## Test plan

- [x] `pytest` — 193 passed, 2 skipped (typer/plotly optional extras)
- [x] `ruff check src tests` — clean
- [x] `mypy src/echemplot` — clean
- [ ] Smoke test inside real Origin (embedded Python) to confirm the completion-hook dialog no longer fires — real-Origin verification is still tracked in #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)