### PR TITLE
fix(origin): guard numpy.typing.NDArray imports under TYPE_CHECKING

### DIFF
--- a/src/echemplot/core/dqdv.py
+++ b/src/echemplot/core/dqdv.py
@@ -51,23 +51,25 @@ Rewrite notes (vs. legacy TOYO_Origin_2.01 ``plot_dQdV_curve`` L378-453):
 
 from __future__ import annotations
 
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
-from numpy.typing import NDArray
 from scipy.signal import savgol_filter
 
 from echemplot.io.schema import JA_TO_EN, ColumnLang
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    # Per-segment result: (V-grid, dQ/dV samples), both same length.
+    _SegPair = tuple[NDArray[np.float64], NDArray[np.float64]]
 
 _JA_COLS: dict[str, str] = {
     "voltage": "電圧",
     "capacity": "電気量",
     "dqdv": "dQ/dV",
 }
-
-# Per-segment result: (V-grid, dQ/dV samples), both same length.
-_SegPair = tuple[NDArray[np.float64], NDArray[np.float64]]
 
 
 def _resolve_cols(column_lang: ColumnLang) -> dict[str, str]:

--- a/src/echemplot/core/stats.py
+++ b/src/echemplot/core/stats.py
@@ -63,12 +63,13 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
-from numpy.typing import NDArray
 from scipy.integrate import simpson, trapezoid
 
 from echemplot.io.schema import JA_TO_EN, ColumnLang
 
 if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
     from echemplot.core.cell import Cell
 
 _JA_COLS: dict[str, str] = {


### PR DESCRIPTION
## Summary

- Origin's embedded Python 3.11 ships an older NumPy whose `numpy.typing` module does not expose `NDArray` (added in NumPy 1.21). Importing `echemplot.core.cell` in Origin blew up with `ImportError: cannot import name 'NDArray' from 'numpy.typing'`.
- `NDArray` is used purely for static type hints in `core/dqdv.py` and `core/stats.py`. Both modules already declare `from __future__ import annotations`, so annotations are stringified at runtime and `NDArray` does not need to be importable.
- Move the `NDArray` import — and the `_SegPair` type alias in `dqdv.py`, which was the only module-scope runtime consumer — under `TYPE_CHECKING`. No behavioral change; mypy still resolves the alias.

## Why not bump the numpy floor instead?

`pyproject.toml` already declares `numpy>=1.23`, but Origin's bundled NumPy wins in practice — pip cannot reliably upgrade NumPy inside Origin's site-packages, and users should not have to debug that. Removing the runtime dependency on `numpy.typing.NDArray` is the cleanest fix and works out of the box.

## Test plan

- [x] `uv run ruff check src/echemplot/core/dqdv.py src/echemplot/core/stats.py` — clean
- [x] `uv run mypy src/echemplot/core/dqdv.py src/echemplot/core/stats.py` — no issues (annotations still fully typed under `TYPE_CHECKING`)
- [x] `uv run pytest tests/ -q` — 195 passed, 3 skipped (unrelated optional deps)
- [ ] Install the resulting wheel into Origin's embedded Python 3.11 and confirm `from echemplot.origin import launch_gui; launch_gui()` no longer raises `ImportError` at `core/dqdv.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)