### PR TITLE
chore(release): v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2026-04-23
+
 ### Changed
 - Default Savitzky-Golay `window_length` for dQ/dV smoothing restored to
   `11` (reverting [#69]). Applies uniformly across
   `echemplot.core.dqdv.get_dqdv_df`, `Cell.dqdv_df`, `plot_dqdv`,
   `echemplot.origin.push_to_origin`, and the Tk GUI's `SG window_length`
   entry. Callers that explicitly pass `window_length=21` / `sg_window=21`
-  are unaffected.
+  are unaffected. ([#88])
 
 ## [0.1.5] - 2026-04-23
 
@@ -191,7 +193,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pre-alpha.** Public API is unstable and may change without deprecation in
   0.0.x releases.
 
-[Unreleased]: https://github.com/tomooki/toyo-battery/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/tomooki/toyo-battery/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/tomooki/toyo-battery/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/tomooki/toyo-battery/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/tomooki/toyo-battery/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/tomooki/toyo-battery/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/tomooki/toyo-battery/compare/v0.1.1...v0.1.2
@@ -206,6 +210,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#75]: https://github.com/tomooki/toyo-battery/issues/75
 [#79]: https://github.com/tomooki/toyo-battery/pull/79
 [#80]: https://github.com/tomooki/toyo-battery/pull/80
+[#86]: https://github.com/tomooki/toyo-battery/pull/86
+[#88]: https://github.com/tomooki/toyo-battery/pull/88
 [0.0.3]: https://github.com/tomooki/toyo-battery/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/tomooki/toyo-battery/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/tomooki/toyo-battery/releases/tag/v0.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "echemplot"
-version = "0.1.5"
+version = "0.1.6"
 description = "OSS Python toolkit for TOYO battery cycler data (charge/discharge, dQ/dV, cycle stats). Installable from PyPI into Origin's embedded Python."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "echemplot"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

Release **v0.1.6**. PR [#69](https://github.com/tomooki/toyo-battery/pull/69) で `21` に引き上げた Savitzky-Golay `window_length` のデフォルトを `11` に戻した [#88](https://github.com/tomooki/toyo-battery/pull/88) を取り込む patch リリース。

### Changed
- Default Savitzky-Golay `window_length` for dQ/dV smoothing restored to `11` (reverting [#69](https://github.com/tomooki/toyo-battery/pull/69)). Applies uniformly across `echemplot.core.dqdv.get_dqdv_df`, `Cell.dqdv_df`, `plot_dqdv`, `echemplot.origin.push_to_origin`, and the Tk GUI's `SG window_length` entry. Callers that explicitly pass `window_length=21` / `sg_window=21` are unaffected. ([#88](https://github.com/tomooki/toyo-battery/pull/88))

## Housekeeping
- CHANGELOG の compare links を更新（`[Unreleased]` を v0.1.6 基準に、欠けていた `[0.1.5]` / `[#86]` の参照も追加）。

## Test plan

- [x] `uv run pytest` on the release branch — 196 passed, 2 skipped (optional-dep: typer, plotly).
- [ ] After merge: tag `v0.1.6` on `main` to trigger `publish.yml` → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)