### PR TITLE
fix(io): handle older PTN dialect where token[2] is the flag

### DIFF
--- a/src/echemplot/io/reader.py
+++ b/src/echemplot/io/reader.py
@@ -80,12 +80,24 @@ _METADATA_SCAN_ROWS = 4
 def read_ptn_mass(ptn_path: str | Path) -> float:
     """Extract active-material mass (grams) from a ``.PTN`` file.
 
-    TOYO convention: the mass is the third whitespace-separated token on
-    line 0 of a main pattern file. Auxiliary ``.PTN`` files that TOYO ships
-    alongside the main one (``*_OPTION.PTN``, ``*_Option2.PTN``, etc.)
-    carry INI- or CSV-style configuration, not a mass; calling this on
-    them will raise ``ValueError``, which :func:`_resolve_mass_from_ptn`
-    relies on to skip them.
+    TOYO ships at least two PTN dialects that differ in how the mass field
+    is rendered on line 0. Both encode the field as a 9-byte composite of
+    ``<flag><mass>``:
+
+    * Older dialect (e.g. cycler "No6"): ``"0 0.00116"`` — flag, space,
+      ``%.5f`` mass. ``str.split()`` yields the flag at ``tokens[2]`` and
+      the mass at ``tokens[3]``.
+    * Newer dialect (e.g. cyclers "No5"/"No1"): ``"00.000358"`` — flag
+      glued to a ``%.6f`` mass. ``tokens[2]`` parses directly as the mass.
+
+    Match the legacy ``TOYO_Origin_2.01`` heuristic: take ``tokens[2]``,
+    and if it parses as exactly zero, fall back to ``tokens[3]``.
+
+    Auxiliary ``.PTN`` files that TOYO ships alongside the main one
+    (``*_OPTION.PTN``, ``*_Option2.PTN``, etc.) carry INI- or CSV-style
+    configuration, not a mass; calling this on them will raise
+    ``ValueError``, which :func:`_resolve_mass_from_ptn` relies on to
+    skip them.
     """
     path = Path(ptn_path)
     with path.open(encoding="shift_jis", errors="replace") as f:
@@ -96,9 +108,20 @@ def read_ptn_mass(ptn_path: str | Path) -> float:
             f"{path} line 0 has fewer than 3 tokens; cannot extract active-material mass"
         )
     try:
-        return float(tokens[2])
+        candidate = float(tokens[2])
     except ValueError as e:
         raise ValueError(f"{path} line 0 token[2]={tokens[2]!r} is not a valid float mass") from e
+    if candidate != 0.0:
+        return candidate
+    if len(tokens) >= 4:
+        try:
+            return float(tokens[3])
+        except ValueError:
+            pass
+    raise ValueError(
+        f"{path} line 0: token[2]=0 and token[3] absent or non-numeric; "
+        "cannot extract active-material mass"
+    )
 
 
 def read_cell_dir(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from typing import Callable, Literal
 import pytest
 
 Layout = Literal["renzoku", "renzoku_py", "raw_6digit"]
+PtnDialect = Literal["concat", "spaced"]
 
 # Row template shared between layouts so the three fixtures stay in sync.
 # Each tuple: (cycle, mode, state_int, voltage, elapsed_s, current_mA,
@@ -53,6 +54,7 @@ def make_cell_dir(tmp_path: Path) -> Callable[..., Path]:
         *,
         name: str = "cell_A",
         mass: float = _DEFAULT_MASS_G,
+        ptn_dialect: PtnDialect = "concat",
     ) -> Path:
         d = tmp_path / name
         d.mkdir()
@@ -61,7 +63,7 @@ def make_cell_dir(tmp_path: Path) -> Callable[..., Path]:
         elif layout == "renzoku_py":
             _write_renzoku_py(d)
         elif layout == "raw_6digit":
-            _write_raw_6digit(d, mass_g=mass)
+            _write_raw_6digit(d, mass_g=mass, ptn_dialect=ptn_dialect)
         else:
             raise ValueError(f"unknown layout: {layout}")
         return d
@@ -120,7 +122,12 @@ def _write_renzoku_py(cell_dir: Path) -> None:
     (cell_dir / "連続データ_py.csv").write_text("\n".join(lines) + "\n", encoding="shift_jis")
 
 
-def _write_raw_6digit(cell_dir: Path, *, mass_g: float) -> None:
+def _write_raw_6digit(
+    cell_dir: Path,
+    *,
+    mass_g: float,
+    ptn_dialect: PtnDialect = "concat",
+) -> None:
     """Write a real-format 6-digit raw file plus ``.PTN`` mass files.
 
     Real format:
@@ -153,15 +160,39 @@ def _write_raw_6digit(cell_dir: Path, *, mass_g: float) -> None:
         )
     (cell_dir / "000001").write_text("\n".join(lines) + "\n", encoding="shift_jis")
 
-    # Main PTN: fixed-column. ``split()[2]`` extracts the mass in grams.
-    ptn_main = (
-        f" 1Synthetic                                 2 {mass_g:09.6f}       1{mass_g:09.6f}"
-        f"TestCell                                 24 00000"
-    )
-    (cell_dir / "pattern.PTN").write_text(ptn_main + "\n", encoding="shift_jis")
+    write_ptn_main(cell_dir / "pattern.PTN", mass_g=mass_g, dialect=ptn_dialect)
 
     # Companion PTN: INI-style header, no mass. `read_ptn_mass` raises on this
     # and the reader falls through to the main PTN.
     (cell_dir / "pattern_OPTION.PTN").write_text(
         "[BaseCellCapacity]\nCapacity=0.1\n", encoding="shift_jis"
     )
+
+
+def write_ptn_main(
+    path: Path,
+    *,
+    mass_g: float,
+    dialect: PtnDialect = "concat",
+    operator: str = "Synthetic",
+    sample: str = "TestCell",
+) -> None:
+    """Write a single main ``.PTN`` first-line in the requested TOYO dialect.
+
+    ``concat`` is the newer dialect (cyclers No5/No1) where the per-electrode
+    flag is glued to the mass: ``"00.001000"``. ``spaced`` is the older
+    dialect (cycler No6) where flag and mass are space-separated and the
+    mass uses ``%.5f``: ``"0 0.00100"``. Both occupy a 9-char composite
+    field and the surrounding fixed-width layout is otherwise identical.
+    """
+    operator_field = f" 1{operator}".ljust(42)
+    if dialect == "concat":
+        field1 = f"0{mass_g:.6f}".rjust(9)
+        field2 = f"1{mass_g:.6f}".rjust(9)
+    elif dialect == "spaced":
+        field1 = f"0 {mass_g:.5f}".rjust(9)
+        field2 = f"1 {mass_g:.5f}".rjust(9)
+    else:
+        raise ValueError(f"unknown dialect: {dialect}")
+    line0 = f"{operator_field}2 {field1}       {field2}{sample}"
+    path.write_text(line0 + "\n", encoding="shift_jis")

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -13,6 +13,8 @@ from echemplot.core.cell import Cell
 from echemplot.io.reader import read_cell_dir, read_ptn_mass
 from echemplot.io.schema import CANONICAL_COLUMNS_EN, CANONICAL_COLUMNS_JA
 
+from .conftest import write_ptn_main
+
 
 def _write_fixed_column_ptn(path: Path, mass_g: float) -> None:
     """Write a TOYO-style fixed-column PTN whose first line has the mass at token[2]."""
@@ -377,6 +379,99 @@ def test_read_ptn_mass_ini_style_raises(tmp_path: Path) -> None:
     ptn.write_text("[BaseCellCapacity]\nCapacity=0.1\n", encoding="shift_jis")
     with pytest.raises(ValueError):
         read_ptn_mass(ptn)
+
+
+# ---- read_ptn_mass dialect handling --------------------------------------
+#
+# TOYO ships at least two PTN dialects on real cyclers. Both encode the
+# active-material mass in a 9-byte ``<flag><mass>`` composite field on
+# line 0:
+#   * "concat" (No5 / No1): flag is glued to a %.6f mass — ``"00.000358"``
+#     → ``split()[2]`` parses directly as a non-zero float.
+#   * "spaced" (No6): flag, space, then a %.5f mass — ``"0 0.00116"``
+#     → ``split()[2]`` is the flag ``"0"``; the mass is at ``[3]``.
+# The reader collapses both via the v2.01 "if token[2]==0 then token[3]"
+# heuristic.
+
+
+def test_read_ptn_mass_concat_dialect_no5(tmp_path: Path) -> None:
+    ptn = tmp_path / "x.PTN"
+    write_ptn_main(ptn, mass_g=0.000358, dialect="concat")
+    assert read_ptn_mass(ptn) == pytest.approx(0.000358)
+
+
+def test_read_ptn_mass_spaced_dialect_no6(tmp_path: Path) -> None:
+    """Older No6-cycler dialect — token[2] is ``"0"``, real mass at token[3]."""
+    ptn = tmp_path / "x.PTN"
+    write_ptn_main(ptn, mass_g=0.00116, dialect="spaced")
+    assert read_ptn_mass(ptn) == pytest.approx(0.00116)
+
+
+def test_read_ptn_mass_japanese_operator_name_spaced(tmp_path: Path) -> None:
+    """No1 cycler renders the operator name in Japanese (e.g. ``ともい``).
+
+    cp932 encodes each kana as 2 bytes; after shift-jis decode the line
+    becomes shorter in characters than in bytes, so any column-slice
+    parser would shift. Token-based parsing must stay correct regardless.
+    """
+    ptn = tmp_path / "x.PTN"
+    write_ptn_main(ptn, mass_g=0.00116, dialect="spaced", operator="ともい")
+    assert read_ptn_mass(ptn) == pytest.approx(0.00116)
+
+
+def test_read_ptn_mass_zero_with_unparseable_token3_raises(tmp_path: Path) -> None:
+    """token[2]==0 + token[3] not numeric → ValueError so the file is skipped.
+
+    The skip path is essential: ``_resolve_mass_from_ptn`` iterates over
+    every ``.PTN`` in a cell dir and treats ``ValueError`` as "not the
+    main pattern, skip me". Pathological lines must keep raising.
+    """
+    ptn = tmp_path / "x.PTN"
+    ptn.write_text("name id 0 X\n", encoding="shift_jis")
+    with pytest.raises(ValueError, match="token"):
+        read_ptn_mass(ptn)
+
+
+def test_read_ptn_mass_zero_with_no_token3_raises(tmp_path: Path) -> None:
+    """token[2]==0 and only 3 tokens total → ValueError."""
+    ptn = tmp_path / "x.PTN"
+    ptn.write_text("name id 0\n", encoding="shift_jis")
+    with pytest.raises(ValueError, match="token"):
+        read_ptn_mass(ptn)
+
+
+# ---- raw_6digit + dialect end-to-end -------------------------------------
+
+
+def test_raw_6digit_with_no6_spaced_dialect(make_cell_dir: Callable[..., Path]) -> None:
+    """End-to-end: a No6-shaped cell dir (older PTN dialect) must produce
+    the same mass + 電気量 as the newer dialect. This is the regression
+    pin for the v2.01 fallback rule."""
+    d = make_cell_dir("raw_6digit", mass=0.00116, ptn_dialect="spaced")
+    df, mass_g = read_cell_dir(d)
+    assert mass_g == pytest.approx(0.00116)
+    # capacity = elapsed/3600 * I / mass for the 1-hour@1mA charge segment row
+    assert df.loc[1, "電気量"] == pytest.approx(1.0 * 1.0 / 0.00116)
+
+
+def test_raw_6digit_no1_layout_no_option_file(
+    make_cell_dir: Callable[..., Path], tmp_path: Path
+) -> None:
+    """No1 cycler ships only ``main.PTN`` + ``main_Option2.PTN`` (no OPTION.PTN).
+
+    Option2 starts with comma-separated values (``0,1,1,1,...``) — no
+    whitespace, so ``.split()`` yields a single token and the
+    ``len(tokens) < 3`` skip path catches it. The main PTN's mass must
+    still resolve unambiguously.
+    """
+    d = make_cell_dir("raw_6digit", mass=0.000784, ptn_dialect="concat")
+    (d / "pattern_OPTION.PTN").unlink()
+    (d / "pattern_Option2.PTN").write_text(
+        "0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,-,-,-,-,-\n",
+        encoding="shift_jis",
+    )
+    _, mass_g = read_cell_dir(d)
+    assert mass_g == pytest.approx(0.000784)
 
 
 # ---- column_lang translation ---------------------------------------------


### PR DESCRIPTION
## Summary

- TOYO の PTN ファイルにはサイクラーのバージョンで異なる 2 種類の方言がある（共に 9 バイトの `<flag><mass>` 複合フィールド）。`concat`（No5/No1）はフラグと質量を密着させる（`"00.000358"`）一方、`spaced`（No6）はフラグの後に空白を挟む（`"0 0.00116"`）。現状の `read_ptn_mass()` は無条件に `float(tokens[2])` を返すため、`spaced` 方言ではフラグ（`0`）を質量として返してしまい、下流の `_ensure_capacity` が `mass is missing or non-positive` で失敗していた。
- 解決策は `TOYO_Origin_2_01.py` で使われていた既存ヒューリスティックの再導入：`tokens[2]` を試し、ちょうどゼロなら `tokens[3]` にフォールバック。`tokens[3]` も非数値なら `ValueError` を投げ、`_resolve_mass_from_ptn` のスキップパス（`*_OPTION.PTN` / `*_Option2.PTN`）の挙動を維持。
- 実機での確認：No6 → 0.00116 g、No5 → 0.000358 g、No1 → 0.000784 g がそれぞれ正しく抽出される。

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run pytest`（228 pass / 1 GUI ディスプレイなし skip）
- [x] 新規追加の dialect 単体テスト 5 本（concat / spaced / 日本語名 / token[2]==0 のフォールバック失敗 2 種）
- [x] No6 spaced + raw_6digit の end-to-end テスト（電気量計算まで）
- [x] No1 ディレクトリ構成（OPTION.PTN なし、Option2.PTN は CSV 形式）の resolve テスト
- [x] 実 PTN ファイルでの直接読み取り検証（Z:\TOYO\No1, No5, No6）

## Out of scope

`read_cell_dir` を実機ディレクトリで end-to-end 通すと、PTN 質量抽出後に `_finalize` が状態コード `9` を未対応として `ValueError` を投げる別問題が顕在化した。これは `STATE_CODE_TO_JA` の不足で、本 PR とは独立。別 Issue を起票する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)