### PR TITLE
fix(io): drop trailing TOYO end-of-test sentinel rows (state code 9) (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `read_cell_dir` no longer raises `ValueError: unknown 状態 codes in
+  source: [9]` on raw 6-digit cell directories whose last data row is
+  the TOYO end-of-test sentinel (state code `9` with zero 経過時間 and
+  zero 電流). The `_finalize` step now drops a contiguous trailing
+  block of such sentinel rows (with a `logger.debug` notice) before
+  state-code mapping. Unknown state codes that appear mid-file or with
+  non-zero flow still raise, and the error now reports the offending
+  row index and a link to file an issue. ([#91])
+
+[#91]: https://github.com/tomooki/toyo-battery/issues/91
+
 ## [0.1.6] - 2026-04-23
 
 ### Changed

--- a/src/echemplot/io/reader.py
+++ b/src/echemplot/io/reader.py
@@ -42,6 +42,7 @@ per-segment monotone-non-decreasing 電気量 (matching the convention that
 
 from __future__ import annotations
 
+import logging
 import math
 import re
 from pathlib import Path
@@ -58,6 +59,8 @@ from echemplot.io.schema import (
     STATE_CODE_TO_JA,
     ColumnLang,
 )
+
+logger = logging.getLogger(__name__)
 
 RAW_FILENAME_RE = re.compile(r"[0-9]{6}")
 PTN_SUFFIX = ".ptn"  # matched case-insensitively (Linux CI is case-sensitive)
@@ -261,19 +264,65 @@ def _ensure_capacity(df: pd.DataFrame, mass: float | None) -> pd.DataFrame:
     return cast("pd.DataFrame", out)
 
 
+def _drop_trailing_sentinel_rows(df: pd.DataFrame) -> tuple[pd.DataFrame, list[int]]:
+    """Drop a contiguous tail block of TOYO end-of-test sentinel rows.
+
+    A row is treated as a sentinel iff its 状態 is numeric and unknown
+    (not in :data:`STATE_CODE_TO_JA`) AND ``経過時間[Sec] == 0`` AND
+    ``電流[mA] == 0``. Real TOYO raw 6-digit files emit at least one
+    such row (state code ``9``) per file as the end-of-test marker; the
+    row is not a real measurement and would otherwise blow up state-code
+    mapping in :func:`_finalize`.
+
+    The scan is strictly trailing/contiguous, so a state-9 row in the
+    middle of the file (or with non-zero flow) is *not* dropped — those
+    cases still surface as the ``unknown 状態 codes`` error so genuinely
+    surprising data is not silently swallowed.
+    """
+    if not pd.api.types.is_numeric_dtype(df["状態"]):
+        return df, []
+    if COL_ELAPSED_S not in df.columns or COL_CURRENT_MA not in df.columns:
+        return df, []
+    drop_idx: list[int] = []
+    for i in range(len(df) - 1, -1, -1):
+        state = df["状態"].iat[i]
+        if pd.isna(state) or int(state) in STATE_CODE_TO_JA:
+            break
+        if df[COL_ELAPSED_S].iat[i] == 0 and df[COL_CURRENT_MA].iat[i] == 0:
+            drop_idx.append(int(df.index[i]))
+        else:
+            break
+    if not drop_idx:
+        return df, []
+    return cast("pd.DataFrame", df.drop(index=drop_idx).reset_index(drop=True)), drop_idx
+
+
 def _finalize(df: pd.DataFrame, column_lang: ColumnLang) -> pd.DataFrame:
     missing = [c for c in CANONICAL_COLUMNS_JA if c not in df.columns]
     if missing:
         raise ValueError(f"missing canonical columns after read: {missing}")
     extras = [c for c in df.columns if c not in CANONICAL_COLUMNS_JA]
     out = df.loc[:, [*CANONICAL_COLUMNS_JA, *extras]].copy()
+    out, dropped = _drop_trailing_sentinel_rows(out)
+    if dropped:
+        logger.debug(
+            "Dropped %d trailing TOYO sentinel row(s) at indices %s",
+            len(dropped),
+            dropped,
+        )
     if pd.api.types.is_numeric_dtype(out["状態"]):
         mapped = out["状態"].map(STATE_CODE_TO_JA)
         unmapped_mask = mapped.isna() & out["状態"].notna()
         if unmapped_mask.any():
             bad = sorted(out.loc[unmapped_mask, "状態"].unique().tolist())
+            first_bad_idx = int(out.index[unmapped_mask][0])
             raise ValueError(
-                f"unknown 状態 codes in source: {bad} (known codes: {sorted(STATE_CODE_TO_JA)})"
+                f"unknown 状態 codes in source: {bad} "
+                f"(known codes: {sorted(STATE_CODE_TO_JA)}); "
+                f"first seen at row {first_bad_idx}. If this is a TOYO "
+                "sentinel code, please file an issue at "
+                "https://github.com/tomooki/toyo-battery/issues "
+                "with a sample file."
             )
         out["状態"] = mapped
     out = out.reset_index(drop=True)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -238,7 +238,12 @@ def test_read_raw_6digit_mismatched_columns_raises(tmp_path: Path) -> None:
 
 
 def test_unknown_state_code_raises(tmp_path: Path) -> None:
-    """An unrecognized integer 状態 code must not silently pass through."""
+    """An unrecognized integer 状態 code with non-zero flow must raise.
+
+    The sentinel-drop guard in :func:`_finalize` only swallows trailing
+    rows whose 経過時間 *and* 電流 are both zero; this fixture has
+    non-zero values, so it must still surface the unknown code.
+    """
     cell_dir = tmp_path / "bad_state"
     cell_dir.mkdir()
     empty_sep = ",,,,,,"
@@ -249,6 +254,115 @@ def test_unknown_state_code_raises(tmp_path: Path) -> None:
         header,
         f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
         f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},9, 1,  1,     1",
+    ]
+    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    with pytest.raises(ValueError, match="unknown 状態 codes"):
+        read_cell_dir(cell_dir)
+
+
+def test_unknown_state_code_error_message_includes_row_index(tmp_path: Path) -> None:
+    """The unknown-code ValueError must include the offending row index."""
+    cell_dir = tmp_path / "bad_state_msg"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    raw = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},9, 1,  1,     1",
+    ]
+    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    with pytest.raises(ValueError, match=r"first seen at row \d+"):
+        read_cell_dir(cell_dir)
+
+
+def test_raw_6digit_trailing_state_9_sentinel_is_dropped(tmp_path: Path) -> None:
+    """A trailing state-9 row with zero elapsed and zero current is the
+    documented TOYO end-of-test sentinel and must be silently dropped."""
+    cell_dir = tmp_path / "sentinel"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    raw = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},1, 1,  1,     1",
+        # Trailing TOYO sentinel: state=9, elapsed=0, current=0
+        f"2025/01/01,00:30:00,00000000,+3.6000,0.000000{empty_sep},9, 1,  1,     1",
+    ]
+    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    df, _ = read_cell_dir(cell_dir)
+    assert len(df) == 2
+    assert df["状態"].tolist() == ["充電", "充電"]
+
+
+def test_raw_6digit_multiple_trailing_sentinels_dropped(tmp_path: Path) -> None:
+    """Two contiguous trailing sentinel rows must both be dropped."""
+    cell_dir = tmp_path / "sentinel_multi"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    raw = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        f"2025/01/01,00:30:00,00000000,+3.6000,0.000000{empty_sep},9, 1,  1,     1",
+        f"2025/01/01,00:30:00,00000000,+3.6000,0.000000{empty_sep},9, 1,  1,     1",
+    ]
+    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    df, _ = read_cell_dir(cell_dir)
+    assert len(df) == 1
+    assert df["状態"].tolist() == ["充電"]
+
+
+def test_raw_6digit_state_9_midfile_still_raises(tmp_path: Path) -> None:
+    """A state-9 row in the *middle* of the file (followed by a known
+    state) is not the trailing sentinel pattern and must still raise."""
+    cell_dir = tmp_path / "midfile_9"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    raw = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        # Mid-file state-9 with zero flow: still raises because it is
+        # followed by a valid row, so it isn't a trailing sentinel.
+        f"2025/01/01,00:15:00,00000000,+3.5500,0.000000{empty_sep},9, 1,  1,     1",
+        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},1, 1,  1,     1",
+    ]
+    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    with pytest.raises(ValueError, match="unknown 状態 codes"):
+        read_cell_dir(cell_dir)
+
+
+def test_raw_6digit_trailing_state_9_with_nonzero_flow_still_raises(
+    tmp_path: Path,
+) -> None:
+    """The sentinel guard requires zero elapsed AND zero current; a
+    trailing state-9 row with non-zero current is not a sentinel."""
+    cell_dir = tmp_path / "trailing_nonzero"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    raw = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        # Trailing state=9 but current is non-zero → not a sentinel.
+        f"2025/01/01,00:30:00,00000000,+3.6000,0.500000{empty_sep},9, 1,  1,     1",
     ]
     (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
     _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)


### PR DESCRIPTION
## Summary
- Drop trailing TOYO end-of-test sentinel rows (state code `9` with zero 経過時間 and zero 電流) before state-code mapping in `_finalize`, so `read_cell_dir` returns a clean DataFrame for real raw 6-digit cell directories instead of raising `ValueError: unknown 状態 codes in source: [9]`. Surfaced after [#90](https://github.com/tomooki/toyo-battery/pull/90) fixed mass extraction for these dirs.
- Drop is strictly contiguous-from-the-tail, gated on `経過時間[Sec]==0 AND 電流[mA]==0`. Mid-file state-9 rows and trailing rows with non-zero flow still raise — genuinely surprising data is not silently swallowed.
- Improve the unknown-code error: now reports the offending row index and links to the issue tracker.
- Add module-level `logger` in `echemplot.io.reader`; the drop emits a `logger.debug` notice (silent unless callers configure handlers).

Fixes [#91](https://github.com/tomooki/toyo-battery/issues/91).

Out of scope: adding `9` to `STATE_CODE_TO_JA` (deferred until we have TOYO documentation or a confirmed dataset sweep).

## Test plan
- [x] `python -m pytest tests/test_reader.py -v` — 44/44 pass (5 new + 39 existing)
  - `test_raw_6digit_trailing_state_9_sentinel_is_dropped`
  - `test_raw_6digit_multiple_trailing_sentinels_dropped`
  - `test_raw_6digit_state_9_midfile_still_raises`
  - `test_raw_6digit_trailing_state_9_with_nonzero_flow_still_raises`
  - `test_unknown_state_code_error_message_includes_row_index`
- [x] `python -m pytest -q` — 207 passed, 3 skipped (unrelated optional deps)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src` — clean
- [ ] Manual smoke on a workstation with `Z:` access: `read_cell_dir(r'Z:\TOYO\No1\DAT\00006-tomoi\22')` returns without raising and the last row is a known state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)