### PR TITLE
chore(release): v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-04-27
+
 ### Fixed
 - `read_cell_dir` no longer raises `ValueError: unknown 状態 codes in
   source: [9]` on raw 6-digit cell directories whose last data row is
@@ -16,7 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   state-code mapping. Unknown state codes that appear mid-file or with
   non-zero flow still raise, and the error now reports the offending
   row index and a link to file an issue. ([#91])
+- `read_cell_dir` now handles the older TOYO PTN dialect where the
+  active-material mass is rendered as `"<flag> <mass>"` (e.g.
+  `"0 0.00116"`) instead of the newer concatenated form
+  (`"00.000358"`). The reader previously returned `0.0` (the flag)
+  on the spaced dialect and failed downstream with `mass is missing
+  or non-positive`. The v2.01 heuristic is restored: take
+  `tokens[2]`; if it parses as exactly zero, fall back to
+  `tokens[3]`. ([#90])
 
+[#90]: https://github.com/tomooki/toyo-battery/pull/90
 [#91]: https://github.com/tomooki/toyo-battery/issues/91
 
 ## [0.1.6] - 2026-04-23
@@ -205,7 +216,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pre-alpha.** Public API is unstable and may change without deprecation in
   0.0.x releases.
 
-[Unreleased]: https://github.com/tomooki/toyo-battery/compare/v0.1.6...HEAD
+[Unreleased]: https://github.com/tomooki/toyo-battery/compare/v0.1.7...HEAD
+[0.1.7]: https://github.com/tomooki/toyo-battery/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/tomooki/toyo-battery/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/tomooki/toyo-battery/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/tomooki/toyo-battery/compare/v0.1.3...v0.1.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "echemplot"
-version = "0.1.6"
+version = "0.1.7"
 description = "OSS Python toolkit for TOYO battery cycler data (charge/discharge, dQ/dV, cycle stats). Installable from PyPI into Origin's embedded Python."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "echemplot"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- Bump `echemplot` to **0.1.7** (`pyproject.toml` + `uv.lock`).
- Two reader fixes since v0.1.6, both surfaced against real TOYO cycler outputs:
  - **PTN dialect** — handle the older `"<flag> <mass>"` rendering in addition to the newer concatenated `"00.000358"` form, so `read_cell_dir` no longer fails downstream with `mass is missing or non-positive` on No6-style cyclers. (#90)
  - **End-of-test sentinel** — drop a contiguous trailing block of state-code-`9` rows (zero 経過時間, zero 電流) before state-code mapping, so `read_cell_dir` no longer raises `ValueError: unknown 状態 codes in source: [9]` on raw 6-digit cell directories. (#91, #92)
- CHANGELOG: cut `Unreleased` → `[0.1.7] - 2026-04-27` and add the #90 entry that wasn't on `main` yet.

## Test plan
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy` — clean
- [x] `uv run pytest -x` — 233 passed, 1 skipped (Tk display unavailable in CI parity env)
- [x] `uv build` — produces `echemplot-0.1.7-py3-none-any.whl` (pure-Python, satisfies the embedded-Origin install constraint)
- [ ] After merge: tag `v0.1.7` on `main` to trigger the `Publish` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)