### PR TITLE
fix(io): register state code 9 as 中断/abort (Issue #91 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `STATE_CODE_TO_JA` / `STATE_CODE_TO_EN` / `STATE_JA_TO_EN` now register
+  state code `9` as `中断` / `abort`. Empirically observed across TOYO
+  cyclers No1, No2, and No6 as the end-of-test / abort sentinel —
+  usually a single trailing row, sometimes with non-zero 経過時間/電流
+  values left from the moment of interruption. v0.1.7 only handled the
+  zero-flow variant via the trailing-sentinel drop; the non-zero-flow
+  variant (e.g. `Z:\TOYO\No2\DAT\KH-337-P2-NaFeNiMn-NiFe-21-37Vdis\13`)
+  still raised. With code 9 promoted to a known state, the row is now
+  preserved as `中断` regardless of position or flow values. Downstream
+  `chdis` filters non-charge/discharge rows out of the segmentation
+  input, so `capacity`, `dQ/dV`, `stats`, plotting, and Origin output
+  are unaffected. ([#91])
+
+### Backwards-compatibility note
+- Raw 6-digit DataFrames whose source file contains state-9 rows now
+  contain those rows as `中断` (JA) / `abort` (EN). Earlier versions
+  silently dropped them when zero-flow (v0.1.7) or raised on them
+  (v0.1.6 and earlier with non-zero flow, v0.1.7 with non-zero flow).
+  Code that iterates over all rows and asserts a state ∈
+  `{充電, 放電, 休止, 充電休止, 放電休止}` set must extend its set to
+  include `中断`.
+
 ## [0.1.7] - 2026-04-27
 
 ### Fixed

--- a/src/echemplot/io/reader.py
+++ b/src/echemplot/io/reader.py
@@ -15,7 +15,10 @@ any extra source columns such as 経過時間[Sec] / 電流[mA] / 日付 / 時�
     Canonical columns: サイクル, モード, 状態, 電圧, 電気量
     状態 values:
       - Native 連続データ.csv:  {"充電", "放電", "充電休止", "放電休止"}
-      - Raw 6-digit (int→JA):   {"充電", "放電", "休止"}
+      - Raw 6-digit (int→JA):   {"充電", "放電", "休止", "中断"}
+                                ("中断" = state code 9, the TOYO end-of-test
+                                 / abort sentinel; usually a single trailing
+                                 row, sometimes with non-zero 経過時間/電流.)
       - 連続データ_py.csv:       whatever was persisted (usually the 3-value set)
 
 When ``column_lang="en"`` is requested, only column *names* are translated.
@@ -265,19 +268,20 @@ def _ensure_capacity(df: pd.DataFrame, mass: float | None) -> pd.DataFrame:
 
 
 def _drop_trailing_sentinel_rows(df: pd.DataFrame) -> tuple[pd.DataFrame, list[int]]:
-    """Drop a contiguous tail block of TOYO end-of-test sentinel rows.
+    """Drop a contiguous tail block of *unknown-code* sentinel rows.
 
-    A row is treated as a sentinel iff its 状態 is numeric and unknown
-    (not in :data:`STATE_CODE_TO_JA`) AND ``経過時間[Sec] == 0`` AND
-    ``電流[mA] == 0``. Real TOYO raw 6-digit files emit at least one
-    such row (state code ``9``) per file as the end-of-test marker; the
-    row is not a real measurement and would otherwise blow up state-code
-    mapping in :func:`_finalize`.
+    Defensive backstop for any future TOYO firmware that emits an
+    end-of-test sentinel with a state code we have not yet catalogued
+    in :data:`STATE_CODE_TO_JA`. A row is treated as a sentinel iff its
+    状態 is numeric and unknown AND ``経過時間[Sec] == 0`` AND
+    ``電流[mA] == 0``. State code ``9`` (``中断``) is *not* a sentinel
+    here — it is now a known state and is mapped to its JA label like
+    any other.
 
-    The scan is strictly trailing/contiguous, so a state-9 row in the
-    middle of the file (or with non-zero flow) is *not* dropped — those
-    cases still surface as the ``unknown 状態 codes`` error so genuinely
-    surprising data is not silently swallowed.
+    The scan is strictly trailing/contiguous; an unknown-code row in
+    the middle of the file (or with non-zero flow) is *not* dropped —
+    those still surface as the ``unknown 状態 codes`` error so
+    genuinely surprising data is not silently swallowed.
     """
     if not pd.api.types.is_numeric_dtype(df["状態"]):
         return df, []

--- a/src/echemplot/io/schema.py
+++ b/src/echemplot/io/schema.py
@@ -48,12 +48,25 @@ JA_TO_EN: dict[str, str] = {
 
 EN_TO_JA: dict[str, str] = {v: k for k, v in JA_TO_EN.items()}
 
-STATE_CODE_TO_JA: dict[int, str] = {0: "休止", 1: "充電", 2: "放電"}
-STATE_CODE_TO_EN: dict[int, str] = {0: "rest", 1: "charge", 2: "discharge"}
+# State-code mapping for the raw 6-digit format. Codes {0, 1, 2} are
+# documented; code 9 is empirically observed across multiple TOYO cyclers
+# (No1 / No2 / No6) as an end-of-test "abort" signal — typically a single
+# trailing row, sometimes with non-zero 経過時間/電流 values left from the
+# moment of interruption. We do not have official TOYO documentation for
+# code 9, but it has been validated against real cell directories. Do not
+# strip the 9-entry without re-checking against current data.
+STATE_CODE_TO_JA: dict[int, str] = {0: "休止", 1: "充電", 2: "放電", 9: "中断"}
+STATE_CODE_TO_EN: dict[int, str] = {
+    0: "rest",
+    1: "charge",
+    2: "discharge",
+    9: "abort",
+}
 STATE_JA_TO_EN: dict[str, str] = {
     "休止": "rest",
     "充電": "charge",
     "放電": "discharge",
+    "中断": "abort",
 }
 
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -240,9 +240,11 @@ def test_read_raw_6digit_mismatched_columns_raises(tmp_path: Path) -> None:
 def test_unknown_state_code_raises(tmp_path: Path) -> None:
     """An unrecognized integer 状態 code with non-zero flow must raise.
 
-    The sentinel-drop guard in :func:`_finalize` only swallows trailing
-    rows whose 経過時間 *and* 電流 are both zero; this fixture has
-    non-zero values, so it must still surface the unknown code.
+    Code ``9`` is now a known state (``中断``); use ``8`` to exercise
+    the unknown-code branch. The sentinel-drop guard in
+    :func:`_finalize` only swallows trailing rows whose 経過時間 *and*
+    電流 are both zero; this fixture has non-zero values, so it must
+    still surface the unknown code.
     """
     cell_dir = tmp_path / "bad_state"
     cell_dir.mkdir()
@@ -253,7 +255,7 @@ def test_unknown_state_code_raises(tmp_path: Path) -> None:
         "",
         header,
         f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
-        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},9, 1,  1,     1",
+        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},8, 1,  1,     1",
     ]
     (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
     _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
@@ -272,7 +274,7 @@ def test_unknown_state_code_error_message_includes_row_index(tmp_path: Path) -> 
         "",
         header,
         f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
-        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},9, 1,  1,     1",
+        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},8, 1,  1,     1",
     ]
     (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
     _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
@@ -280,9 +282,12 @@ def test_unknown_state_code_error_message_includes_row_index(tmp_path: Path) -> 
         read_cell_dir(cell_dir)
 
 
-def test_raw_6digit_trailing_state_9_sentinel_is_dropped(tmp_path: Path) -> None:
-    """A trailing state-9 row with zero elapsed and zero current is the
-    documented TOYO end-of-test sentinel and must be silently dropped."""
+def test_raw_6digit_trailing_state_9_preserved_as_中断(tmp_path: Path) -> None:
+    """State code 9 maps to ``中断`` and is preserved as a real row.
+
+    Mirrors the No1/No6-style end-of-test marker: state=9 with zero
+    elapsed and zero current at the file tail.
+    """
     cell_dir = tmp_path / "sentinel"
     cell_dir.mkdir()
     empty_sep = ",,,,,,"
@@ -293,65 +298,22 @@ def test_raw_6digit_trailing_state_9_sentinel_is_dropped(tmp_path: Path) -> None
         header,
         f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
         f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},1, 1,  1,     1",
-        # Trailing TOYO sentinel: state=9, elapsed=0, current=0
+        # Trailing TOYO end-of-test row: state=9, elapsed=0, current=0
         f"2025/01/01,00:30:00,00000000,+3.6000,0.000000{empty_sep},9, 1,  1,     1",
     ]
     (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
     _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
     df, _ = read_cell_dir(cell_dir)
-    assert len(df) == 2
-    assert df["状態"].tolist() == ["充電", "充電"]
+    assert len(df) == 3
+    assert df["状態"].tolist() == ["充電", "充電", "中断"]
 
 
-def test_raw_6digit_multiple_trailing_sentinels_dropped(tmp_path: Path) -> None:
-    """Two contiguous trailing sentinel rows must both be dropped."""
-    cell_dir = tmp_path / "sentinel_multi"
-    cell_dir.mkdir()
-    empty_sep = ",,,,,,"
-    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
-    raw = [
-        "0,0,0,0,0,0,0",
-        "",
-        header,
-        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
-        f"2025/01/01,00:30:00,00000000,+3.6000,0.000000{empty_sep},9, 1,  1,     1",
-        f"2025/01/01,00:30:00,00000000,+3.6000,0.000000{empty_sep},9, 1,  1,     1",
-    ]
-    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
-    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
-    df, _ = read_cell_dir(cell_dir)
-    assert len(df) == 1
-    assert df["状態"].tolist() == ["充電"]
-
-
-def test_raw_6digit_state_9_midfile_still_raises(tmp_path: Path) -> None:
-    """A state-9 row in the *middle* of the file (followed by a known
-    state) is not the trailing sentinel pattern and must still raise."""
-    cell_dir = tmp_path / "midfile_9"
-    cell_dir.mkdir()
-    empty_sep = ",,,,,,"
-    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
-    raw = [
-        "0,0,0,0,0,0,0",
-        "",
-        header,
-        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
-        # Mid-file state-9 with zero flow: still raises because it is
-        # followed by a valid row, so it isn't a trailing sentinel.
-        f"2025/01/01,00:15:00,00000000,+3.5500,0.000000{empty_sep},9, 1,  1,     1",
-        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},1, 1,  1,     1",
-    ]
-    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
-    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
-    with pytest.raises(ValueError, match="unknown 状態 codes"):
-        read_cell_dir(cell_dir)
-
-
-def test_raw_6digit_trailing_state_9_with_nonzero_flow_still_raises(
+def test_raw_6digit_trailing_state_9_with_nonzero_flow_preserved(
     tmp_path: Path,
 ) -> None:
-    """The sentinel guard requires zero elapsed AND zero current; a
-    trailing state-9 row with non-zero current is not a sentinel."""
+    """Reproduces the No2 case (Issue #91 follow-up): trailing state=9
+    with **non-zero** elapsed/current. v0.1.7 raised here; v0.1.8 must
+    map the row to ``中断`` and preserve it."""
     cell_dir = tmp_path / "trailing_nonzero"
     cell_dir.mkdir()
     empty_sep = ",,,,,,"
@@ -361,13 +323,62 @@ def test_raw_6digit_trailing_state_9_with_nonzero_flow_still_raises(
         "",
         header,
         f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
-        # Trailing state=9 but current is non-zero → not a sentinel.
-        f"2025/01/01,00:30:00,00000000,+3.6000,0.500000{empty_sep},9, 1,  1,     1",
+        # Trailing state=9 with non-zero current — exactly the No2 No.13
+        # cell pattern that triggered the v0.1.7 regression.
+        f"2025/01/01,00:30:00,00000900,+3.6000,0.500000{empty_sep},9, 1,  1,     1",
     ]
     (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
     _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
-    with pytest.raises(ValueError, match="unknown 状態 codes"):
-        read_cell_dir(cell_dir)
+    df, _ = read_cell_dir(cell_dir)
+    assert len(df) == 2
+    assert df["状態"].tolist() == ["充電", "中断"]
+
+
+def test_raw_6digit_state_9_midfile_preserved_as_中断(tmp_path: Path) -> None:
+    """A state-9 row in the *middle* of the file is also valid and
+    maps to ``中断``. Downstream ``chdis`` filters it out cleanly
+    because it is neither 充電 nor 放電."""
+    cell_dir = tmp_path / "midfile_9"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    raw = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        f"2025/01/01,00:15:00,00000000,+3.5500,0.000000{empty_sep},9, 1,  1,     1",
+        f"2025/01/01,00:30:00,00001800,+3.6000,1.000000{empty_sep},1, 1,  1,     1",
+    ]
+    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    df, _ = read_cell_dir(cell_dir)
+    assert df["状態"].tolist() == ["充電", "中断", "充電"]
+
+
+def test_raw_6digit_trailing_unknown_code_with_zero_flow_still_dropped(
+    tmp_path: Path,
+) -> None:
+    """The defensive backstop in :func:`_drop_trailing_sentinel_rows`
+    still drops a *trailing* row with an unknown code AND zero flow,
+    e.g. a hypothetical future TOYO sentinel code ``8``."""
+    cell_dir = tmp_path / "future_sentinel"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    raw = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        # Trailing unknown code 8, zero elapsed, zero current → backstop drops it.
+        f"2025/01/01,00:30:00,00000000,+3.6000,0.000000{empty_sep},8, 1,  1,     1",
+    ]
+    (cell_dir / "000001").write_text("\n".join(raw) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    df, _ = read_cell_dir(cell_dir)
+    assert len(df) == 1
+    assert df["状態"].tolist() == ["充電"]
 
 
 def test_nan_state_is_preserved(tmp_path: Path) -> None:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -32,6 +32,20 @@ def test_schema_roundtrip() -> None:
     assert rename(en, "ja") == ja
 
 
+def test_state_code_9_maps_to_中断() -> None:
+    """State code 9 is the empirical TOYO end-of-test/abort sentinel
+    and must round-trip through all three state mappings."""
+    from echemplot.io.schema import (
+        STATE_CODE_TO_EN,
+        STATE_CODE_TO_JA,
+        STATE_JA_TO_EN,
+    )
+
+    assert STATE_CODE_TO_JA[9] == "中断"
+    assert STATE_CODE_TO_EN[9] == "abort"
+    assert STATE_JA_TO_EN["中断"] == "abort"
+
+
 def test_origin_submodule_imports_without_originpro() -> None:
     """origin submodule must be importable even when originpro is missing."""
     from echemplot import origin


### PR DESCRIPTION
## Summary
- Promote TOYO state code `9` from "unknown sentinel" to a first-class state value: `9 → 中断` (JA) / `9 → abort` (EN). v0.1.7 only handled the trailing state-9 row when both 経過時間 and 電流 were zero; a No2 cell directory (`Z:\TOYO\No2\DAT\KH-337-P2-NaFeNiMn-NiFe-21-37Vdis\13`) produces a trailing state-9 row with **non-zero** flow and still raised `ValueError: unknown 状態 codes in source: [9] ... first seen at row 244 ...`.
- Empirical basis (now documented in [schema.py](src/echemplot/io/schema.py)): code 9 has been observed across cyclers No1, No2, and No6; always abort/end-of-test, never a real measurement.
- The trailing-sentinel helper [`_drop_trailing_sentinel_rows`](src/echemplot/io/reader.py) stays as a defensive backstop for any *future* unknown trailing code with zero flow. Its docstring is refreshed to reflect that code 9 is no longer in its scope.
- Downstream is already safe: [`chdis.py:108`](src/echemplot/core/chdis.py#L108) filters `state ∈ {充電, 放電}` before segmentation, so `capacity`, `dQ/dV`, `stats`, plotting, and Origin output are unaffected by the `中断` rows that now appear in raw 6-digit DataFrames.

Issue [#91](https://github.com/tomooki/toyo-battery/issues/91) follow-up to PR [#92](https://github.com/tomooki/toyo-battery/pull/92).

### Backwards-compat note (in CHANGELOG)
Raw 6-digit DataFrames whose source file contains state-9 rows now contain those rows as `中断` / `abort`. Earlier versions silently dropped them (zero-flow on v0.1.7) or raised on them (non-zero-flow on v0.1.7; either flow on v0.1.6 and earlier). Code that asserts `state ∈ {充電, 放電, 休止, 充電休止, 放電休止}` must add `中断`.

## Test plan
- [x] `python -m pytest tests/test_reader.py tests/test_chdis.py tests/test_smoke.py -v` — 66/66 pass
  - Updated: `test_unknown_state_code_raises`, `test_unknown_state_code_error_message_includes_row_index` use code `8` (still unknown)
  - Inverted: `test_raw_6digit_trailing_state_9_preserved_as_中断`, `test_raw_6digit_trailing_state_9_with_nonzero_flow_preserved` (covers the No2 regression), `test_raw_6digit_state_9_midfile_preserved_as_中断`, `test_raw_6digit_trailing_unknown_code_with_zero_flow_still_dropped` (backstop behavior on a hypothetical future code 8)
  - New: `test_state_code_9_maps_to_中断` — schema round-trip
- [x] `python -m pytest -q` — 208 passed, 3 skipped
- [x] `ruff check` / `ruff format --check` / `mypy src` — all clean
- [ ] Manual smoke (workstation with `Z:` mounted): `read_cell_dir(r'Z:\TOYO\No2\DAT\KH-337-P2-NaFeNiMn-NiFe-21-37Vdis\13')` returns without raising and the trailing row's `状態` is `中断`.
- [ ] Smoke `Cell.from_dir(...).chdis_df` on the same cell to confirm the cycle count matches expectations (中断 row excluded from segmentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)