### PR TITLE
fix(chdis): drop rows below segment running max (V-Q loop-back fix)

### DIFF
--- a/src/echemplot/core/chdis.py
+++ b/src/echemplot/core/chdis.py
@@ -18,10 +18,10 @@ hand-crafted dataset with polarity applied) segments correctly. Rows
 whose ``|電気量|`` falls below the segment's running maximum are dropped.
 This handles both single-row tester glitches (e.g. 500→400→600, the 400
 is dropped) and sustained discontinuities such as the raw-6-digit CC→CV
-sub-step boundary where ``経過時間[Sec]`` resets and a fresh ``t × I``
-series begins below the prior segment's peak. Such CV-hold ``t × I``
+sub-step boundary where ``経過時間[Sec]`` resets and a fresh ``t*I``
+series begins below the prior segment's peak. Such CV-hold ``t*I``
 values are not true cumulative ``∫I dt`` capacity anyway, so dropping
-them is the correct behavior for V–Q plotting.
+them is the correct behavior for V-Q plotting.
 
 First-cycle-is-charge normalization: if cycle 1 begins with 放電 (discharge),
 *all* 状態 labels in the frame are swapped (充電 ↔ 放電). This is the TOYO
@@ -128,7 +128,7 @@ def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.Data
         # Drop rows whose |電気量| falls below the segment's running maximum.
         # Local diff()<0 was insufficient: in raw-6-digit data 経過時間[Sec]
         # resets at CC→CV sub-step boundaries (not just state boundaries),
-        # so capacity drops by ~200 mAh/g and a row whose t×I happens to
+        # so capacity drops by ~200 mAh/g and a row whose t*I happens to
         # inch up vs. its immediate predecessor would leak through and
         # produce a spurious connecting line in plot_chdis.
         cap = g[cap_col].abs().reset_index(drop=True)

--- a/src/echemplot/core/chdis.py
+++ b/src/echemplot/core/chdis.py
@@ -15,7 +15,13 @@ reproduces the same convention because its ``経過時間[Sec]`` resets at
 state transitions and its ``電流[mA]`` is unsigned. The reversal filter
 nonetheless takes ``|電気量|`` so that *any* signed input (e.g. a
 hand-crafted dataset with polarity applied) segments correctly. Rows
-where ``|電気量|.diff() < 0`` are dropped as tester-side glitches.
+whose ``|電気量|`` falls below the segment's running maximum are dropped.
+This handles both single-row tester glitches (e.g. 500→400→600, the 400
+is dropped) and sustained discontinuities such as the raw-6-digit CC→CV
+sub-step boundary where ``経過時間[Sec]`` resets and a fresh ``t × I``
+series begins below the prior segment's peak. Such CV-hold ``t × I``
+values are not true cumulative ``∫I dt`` capacity anyway, so dropping
+them is the correct behavior for V–Q plotting.
 
 First-cycle-is-charge normalization: if cycle 1 begins with 放電 (discharge),
 *all* 状態 labels in the frame are swapped (充電 ↔ 放電). This is the TOYO
@@ -119,10 +125,15 @@ def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.Data
     pieces: dict[tuple[int, str], pd.DataFrame] = {}
     for (cycle_val, state_val), g in working.groupby([cycle_col, state_col], sort=True):
         side = _STATE_TO_SIDE[str(state_val)]
-        # abs() is defensive: real TOYO data (both 連続データ and raw-6-digit
-        # paths) is already monotone non-decreasing per segment; abs() keeps
-        # the filter correct under any hand-crafted signed input.
-        segment = g[[cap_col, v_col]].loc[~(g[cap_col].abs().diff() < 0)].reset_index(drop=True)
+        # Drop rows whose |電気量| falls below the segment's running maximum.
+        # Local diff()<0 was insufficient: in raw-6-digit data 経過時間[Sec]
+        # resets at CC→CV sub-step boundaries (not just state boundaries),
+        # so capacity drops by ~200 mAh/g and a row whose t×I happens to
+        # inch up vs. its immediate predecessor would leak through and
+        # produce a spurious connecting line in plot_chdis.
+        cap = g[cap_col].abs().reset_index(drop=True)
+        keep = (cap == cap.cummax()).to_numpy()
+        segment = g[[cap_col, v_col]].iloc[keep].reset_index(drop=True)
         pieces[(int(cycle_val), side)] = segment
 
     out = pd.concat(pieces, axis=1)

--- a/tests/test_chdis.py
+++ b/tests/test_chdis.py
@@ -82,7 +82,7 @@ def test_capacity_step_boundary_within_charge_state_dropped() -> None:
     CC→CV sub-step boundary in raw-6-digit format, where 経過時間[Sec]
     restarts) must be dropped wholesale — including any row in the new
     sub-step that happens to inch up versus its immediate predecessor.
-    Regression for the V–Q loop-back artifact reported with the negative
+    Regression for the V-Q loop-back artifact reported with the negative
     electrode's first Li-insertion curve."""
     df = _raw(
         [

--- a/tests/test_chdis.py
+++ b/tests/test_chdis.py
@@ -77,6 +77,33 @@ def test_capacity_reversal_rows_dropped() -> None:
     assert out[(1, "ch", "電圧")].dropna().tolist() == [3.50, 3.60, 3.65]
 
 
+def test_capacity_step_boundary_within_charge_state_dropped() -> None:
+    """A sustained capacity reset within the same 充電 group (e.g. the
+    CC→CV sub-step boundary in raw-6-digit format, where 経過時間[Sec]
+    restarts) must be dropped wholesale — including any row in the new
+    sub-step that happens to inch up versus its immediate predecessor.
+    Regression for the V–Q loop-back artifact reported with the negative
+    electrode's first Li-insertion curve."""
+    df = _raw(
+        [
+            (1, "充電", 0.0023, 212.58808),
+            (1, "充電", 0.0020, 213.45448),
+            (1, "充電", 0.0017, 214.26966),
+            (1, "充電", 0.0014, 215.16914),
+            (1, "充電", 0.0015, 19.28384),
+            (1, "充電", 0.0016, 15.97689),
+            (1, "充電", 0.0016, 14.97401),
+            (1, "充電", 0.0016, 14.64183),
+            (1, "充電", 0.0016, 12.49434),
+            (1, "充電", 0.0016, 12.13643),
+            (1, "充電", 0.0016, 12.14260),  # diff>0 vs predecessor, but < running max
+        ]
+    )
+    out = get_chdis_df(df)
+    cap = out[(1, "ch", "電気量")].dropna().tolist()
+    assert cap == [212.58808, 213.45448, 214.26966, 215.16914]
+
+
 def test_discharge_first_triggers_state_swap() -> None:
     """If the first cycle starts with 放電, all state labels are swapped so
     the cell is treated as charge-first."""


### PR DESCRIPTION
## Summary

`Voltage vs Capacity` プロットで Li 挿入曲線の終端から低容量側へ「戻る」線分が描かれる現象を修正。

### 根本原因

[`chdis.py`](src/echemplot/core/chdis.py) の単調性フィルタが**局所差分** (`~(|電気量|.diff() < 0)`) ベースで、直前行との比較しか行わなかった。raw-6-digit フォーマットでは `経過時間[Sec]` が **state 境界だけでなく CC→CV のサブステップ境界でもリセット**されるため、`状態=充電` グループ内で 容量が `~215 → ~19 mAh/g` のように一気に落ちる discontinuity が発生する。`groupby([cycle, state])` ではこれらが同じセグメントに残り、CV hold 内で直前行よりわずかに増えた行（例: `12.13643 → 12.14260`）がフィルタを抜けて生き残り、`(215, 0.0014) → (12.14, 0.0016)` の戻り線として描画されていた。

CV 区間の `t × I` 値はそもそも累積容量 `∫I dt` に一致せず、V–Q プロットの観点でも意味を持たないため drop が正しい挙動。

### 修正

`chdis.py` のフィルタを `cap == cap.cummax()`（区間内 running max ベース）に置換。

- 既存の単一行 reversal（`500→400→600 → {500, 600}`）は同じ結果に保たれる。
- 区間最大値を下回る行は持続的に discontinuity があっても全て drop される。
- API 互換性は不変。

ユーザー実データから抽出した 11 行のシーケンスを再現する回帰テスト `test_capacity_step_boundary_within_charge_state_dropped` を追加。

## Test plan

- [x] `uv run pytest tests/test_chdis.py -v` — 17 passed（新規テスト 1 件含む）
- [x] `uv run pytest tests/test_matplotlib_backend.py -v` — 13 passed
- [x] `uv run pytest` — 209 passed / 3 skipped (typer/plotly/Tk 環境未導入の既存スキップ)
- [ ] 実データで `plot_chdis` を再生成し、V≈0 付近の戻り線が消えていることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)