### PR TITLE
chore(release): v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-04-27
+
+### Fixed
+- `chdis` no longer leaks rows from a later CC→CV sub-step into the
+  preceding sub-step's V-Q segment, eliminating the spurious V≈0
+  "loop-back" line in `plot_chdis` against raw 6-digit data. The
+  reversal filter previously used a local `~(|電気量|.diff() < 0)`
+  comparison, which fails when 経過時間[Sec] resets at sub-step
+  boundaries (not just state boundaries) and 電気量 drops by ~200
+  mAh/g — any row in the new sub-step whose `t * I` happened to inch
+  up vs. its immediate predecessor leaked through. The filter now
+  drops any row whose absolute 電気量 is below the segment's running
+  maximum (`cap == cap.cummax()`); single-row reversals
+  (500→400→600) still resolve to `{500, 600}` as before. ([#108])
+
 ### Changed
 - `STATE_CODE_TO_JA` / `STATE_CODE_TO_EN` / `STATE_JA_TO_EN` now register
   state code `9` as `中断` / `abort`. Empirically observed across TOYO
@@ -19,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preserved as `中断` regardless of position or flow values. Downstream
   `chdis` filters non-charge/discharge rows out of the segmentation
   input, so `capacity`, `dQ/dV`, `stats`, plotting, and Origin output
-  are unaffected. ([#91])
+  are unaffected. ([#107])
 
 ### Backwards-compatibility note
 - Raw 6-digit DataFrames whose source file contains state-9 rows now
@@ -239,7 +254,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pre-alpha.** Public API is unstable and may change without deprecation in
   0.0.x releases.
 
-[Unreleased]: https://github.com/tomooki/toyo-battery/compare/v0.1.7...HEAD
+[Unreleased]: https://github.com/tomooki/toyo-battery/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/tomooki/toyo-battery/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/tomooki/toyo-battery/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/tomooki/toyo-battery/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/tomooki/toyo-battery/compare/v0.1.4...v0.1.5
@@ -259,6 +275,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#80]: https://github.com/tomooki/toyo-battery/pull/80
 [#86]: https://github.com/tomooki/toyo-battery/pull/86
 [#88]: https://github.com/tomooki/toyo-battery/pull/88
+[#107]: https://github.com/tomooki/toyo-battery/pull/107
+[#108]: https://github.com/tomooki/toyo-battery/pull/108
 [0.0.3]: https://github.com/tomooki/toyo-battery/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/tomooki/toyo-battery/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/tomooki/toyo-battery/releases/tag/v0.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "echemplot"
-version = "0.1.7"
+version = "0.1.8"
 description = "OSS Python toolkit for TOYO battery cycler data (charge/discharge, dQ/dV, cycle stats). Installable from PyPI into Origin's embedded Python."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "echemplot"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

Two reader/segmentation fixes against real TOYO cycler outputs since v0.1.7:

- **chdis V-Q loop-back fix** — replace the local `~(|電気量|.diff() < 0)` reversal filter with a segment-wide running-max (`cap == cap.cummax()`). The local check leaked rows from a later CC→CV sub-step into the preceding sub-step's V-Q segment whenever 経過時間[Sec] reset at sub-step boundaries, producing the spurious V≈0 connecting line seen in `plot_chdis` against raw 6-digit data. (#108)
- **state code 9 = `中断` / `abort`** — v0.1.7 only handled the zero-flow variant of the end-of-test sentinel via the trailing-sentinel drop. Non-zero-flow variants (abort mid-cycle, e.g. `Z:\TOYO\No2\DAT\KH-337-P2-NaFeNiMn-NiFe-21-37Vdis\13`) still raised `ValueError: unknown 状態 codes`. Code 9 is now a known state preserved as `中断` / `abort` regardless of position or flow values; `chdis` filters non-charge/discharge rows out of segmentation, so `capacity`, `dQ/dV`, `stats`, plotting, and Origin output are unaffected. (#107)

## Backwards-compatibility note

Raw 6-digit DataFrames whose source contains state-9 rows now contain those rows as `中断` (JA) / `abort` (EN). Code that asserts a state ∈ `{充電, 放電, 休止, 充電休止, 放電休止}` set must extend its set to include `中断`.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run pytest` (236 passed)
- [x] `uv build` produces `echemplot-0.1.8-py3-none-any.whl`
- [ ] CI green on Ubuntu/Windows × 3.9/3.10/3.11/3.12
- [ ] After merge: tag `v0.1.8` on `main` to trigger `Publish` workflow → PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)