### PR TITLE
fix(core): warn on silent capacity-reversal row drops in chdis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `DataIntegrityWarning` (in `echemplot.core`) emitted by `get_chdis_df`
+  when the running-max filter drops rows, surfacing previously-silent
+  data loss for hand-preprocessed inputs. One aggregated summary warning
+  is emitted per call (e.g. `"chdis: dropped N rows below segment
+  running-max across M segments"`); the dropped-row behavior and
+  resulting DataFrame shape are unchanged. ([#98])
+
 ### Fixed
 - Narrowed `_set_axis_limits` exception handling and added a
   logger.warning so `originpro` failures are observable rather than
@@ -295,6 +303,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#88]: https://github.com/tomooki/toyo-battery/pull/88
 [#93]: https://github.com/tomooki/toyo-battery/issues/93
 [#95]: https://github.com/tomooki/toyo-battery/issues/95
+[#98]: https://github.com/tomooki/toyo-battery/issues/98
 [#99]: https://github.com/tomooki/toyo-battery/issues/99
 [#107]: https://github.com/tomooki/toyo-battery/pull/107
 [#108]: https://github.com/tomooki/toyo-battery/pull/108

--- a/src/echemplot/core/__init__.py
+++ b/src/echemplot/core/__init__.py
@@ -1,1 +1,18 @@
 """Core processing: Cell class and per-step transformations."""
+
+from __future__ import annotations
+
+
+class DataIntegrityWarning(UserWarning):
+    """Emitted when core processing silently drops or alters input rows.
+
+    Currently raised by :func:`echemplot.core.chdis.get_chdis_df` when the
+    running-max filter discards rows whose absolute capacity falls below
+    the segment's running maximum. For real TOYO data this is expected
+    (CC→CV sub-step boundaries) and the warning is informational. For
+    hand-preprocessed inputs it surfaces previously-silent data loss so
+    callers can audit their pipeline.
+    """
+
+
+__all__ = ["DataIntegrityWarning"]

--- a/src/echemplot/core/chdis.py
+++ b/src/echemplot/core/chdis.py
@@ -41,8 +41,11 @@ v2.01 could misread.
 
 from __future__ import annotations
 
+import warnings
+
 import pandas as pd
 
+from echemplot.core import DataIntegrityWarning
 from echemplot.io.schema import JA_COLS, JA_TO_EN, ColumnLang
 
 _CHARGE = "充電"
@@ -118,6 +121,8 @@ def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.Data
         )
 
     pieces: dict[tuple[int, str], pd.DataFrame] = {}
+    total_dropped = 0
+    segments_with_drops = 0
     for (cycle_val, state_val), g in working.groupby([cycle_col, state_col], sort=True):
         side = _STATE_TO_SIDE[str(state_val)]
         # Drop rows whose |電気量| falls below the segment's running maximum.
@@ -128,8 +133,21 @@ def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.Data
         # produce a spurious connecting line in plot_chdis.
         cap = g[cap_col].abs().reset_index(drop=True)
         keep = (cap == cap.cummax()).to_numpy()
+        dropped = int(len(keep) - int(keep.sum()))
+        if dropped > 0:
+            total_dropped += dropped
+            segments_with_drops += 1
         segment = g[[cap_col, v_col]].iloc[keep].reset_index(drop=True)
         pieces[(int(cycle_val), side)] = segment
+
+    if total_dropped > 0:
+        warnings.warn(
+            DataIntegrityWarning(
+                f"chdis: dropped {total_dropped} rows below segment running-max "
+                f"across {segments_with_drops} segments"
+            ),
+            stacklevel=2,
+        )
 
     out = pd.concat(pieces, axis=1)
     out.columns = out.columns.set_names(["cycle", "side", "quantity"])

--- a/tests/test_chdis.py
+++ b/tests/test_chdis.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import Callable
 
 import pandas as pd
 import pytest
 
+from echemplot.core import DataIntegrityWarning
 from echemplot.core.cell import Cell
 from echemplot.core.chdis import get_chdis_df
 
@@ -223,6 +225,47 @@ def test_wrong_column_lang_raises_with_context() -> None:
     df = _raw([(1, "充電", 3.5, 0.0)], lang="ja")
     with pytest.raises(KeyError, match="column_lang='en'"):
         get_chdis_df(df, column_lang="en")
+
+
+def test_chdis_warns_on_capacity_reversal_drops() -> None:
+    """The running-max filter must surface dropped rows via DataIntegrityWarning.
+
+    Real TOYO data legitimately triggers this warning at CC→CV sub-step
+    boundaries; for hand-preprocessed inputs it surfaces previously-silent
+    data loss.
+    """
+    df = _raw(
+        [
+            (1, "充電", 3.50, 0.0),
+            (1, "充電", 3.60, 500.0),
+            (1, "充電", 3.55, 400.0),  # reversal — drop, should warn
+            (1, "充電", 3.65, 600.0),
+        ]
+    )
+    with pytest.warns(DataIntegrityWarning, match=r"dropped \d+ rows"):
+        out = get_chdis_df(df)
+    # Behavior preserved — the warning is informational and does not change shape.
+    assert out[(1, "ch", "電気量")].dropna().tolist() == [0.0, 500.0, 600.0]
+
+
+def test_chdis_silent_on_monotone_data() -> None:
+    """Strictly monotone-non-decreasing capacity must not emit DataIntegrityWarning."""
+    df = _raw(
+        [
+            (1, "充電", 3.50, 0.0),
+            (1, "充電", 3.55, 100.0),
+            (1, "充電", 3.60, 200.0),
+            (1, "充電", 3.65, 300.0),
+            (1, "放電", 3.60, 0.0),
+            (1, "放電", 3.50, 100.0),
+            (1, "放電", 3.40, 200.0),
+        ]
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DataIntegrityWarning)
+        get_chdis_df(df)
+    integrity_warnings = [w for w in caught if issubclass(w.category, DataIntegrityWarning)]
+    assert integrity_warnings == []
 
 
 def test_first_cycle_discharge_swaps_all_cycles_globally() -> None:


### PR DESCRIPTION
## Summary

`get_chdis_df` silently dropped rows whose `|電気量|` fell below the segment's running maximum. The running-max filter is correct for real TOYO data (CC→CV sub-step boundaries, single-row tester glitches) but invisible to users with hand-preprocessed inputs — unintended reversals would vanish without notice.

- Adds `DataIntegrityWarning` (a `UserWarning` subclass) to `echemplot.core`, re-exported from the package.
- `get_chdis_df` now emits one aggregated `DataIntegrityWarning` per call when the running-max filter drops any rows, e.g. `"chdis: dropped 7 rows below segment running-max across 1 segments"`. Row-drop behavior and DataFrame shape are unchanged — the warning is purely informational.
- Two new tests: `test_chdis_warns_on_capacity_reversal_drops` and `test_chdis_silent_on_monotone_data`. Existing tests still pass without modification.
- CHANGELOG entry under `[Unreleased]` → `### Added`.

Closes #98

## Test plan

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 39 files already formatted
- [x] `uv run mypy` — Success: no issues found in 23 source files
- [x] `uv run pytest --cov=echemplot --cov-report=term-missing` — 252 passed; `chdis.py` coverage 100%
- [x] Manual: confirm `pytest.warns(DataIntegrityWarning, match=r"dropped \d+ rows")` fires for hand-crafted reversal frame, and `warnings.catch_warnings` records no `DataIntegrityWarning` for monotone-non-decreasing input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)