### PR TITLE
chore: update stale docs and inline comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exports. Pure refactor — no runtime behaviour change. ([#93])
 - Moved V2.01 parity tests into `tests/legacy_v201/` to clarify the
   boundary between primary-spec and legacy-compatibility tests. ([#95])
+- Updated stale documentation, added explanatory inline comments for
+  V2.01-derived design decisions (Simpson integration order, dQ/dV
+  `ipnum` floor), added an info-level log when Origin sheet names are
+  truncated, and replaced lingering `toyo_battery` references in
+  CLAUDE.md with the current `echemplot` package name. ([#104])
 
 ## [0.1.8] - 2026-04-27
 
@@ -296,6 +301,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/tomooki/toyo-battery/issues/93
 [#95]: https://github.com/tomooki/toyo-battery/issues/95
 [#99]: https://github.com/tomooki/toyo-battery/issues/99
+[#104]: https://github.com/tomooki/toyo-battery/issues/104
 [#107]: https://github.com/tomooki/toyo-battery/pull/107
 [#108]: https://github.com/tomooki/toyo-battery/pull/108
 [0.0.3]: https://github.com/tomooki/toyo-battery/compare/v0.0.2...v0.0.3

--- a/src/echemplot/core/dqdv.py
+++ b/src/echemplot/core/dqdv.py
@@ -248,6 +248,9 @@ def get_dqdv_df(
         v_arr: NDArray[np.float64] = frame["v"].to_numpy(dtype=float)
         q_arr: NDArray[np.float64] = frame["q"].to_numpy(dtype=float)
         v_min, v_max = float(v_arr.min()), float(v_arr.max())
+        # Floor to 2 ensures ``linspace`` produces a usable array; segments
+        # where ``ipnum < window_length`` will return None below and surface
+        # as NaN columns.
         ipnum = max(int(inter_num * (v_max - v_min)), 2)
 
         if ipnum < window_length:

--- a/src/echemplot/core/stats.py
+++ b/src/echemplot/core/stats.py
@@ -138,6 +138,12 @@ def _integrate_v_dq(v_arr: NDArray[np.float64], q_arr: NDArray[np.float64]) -> f
     # simpson() returns a numpy scalar; explicit float() cast pins the
     # return contract for mypy under the scipy.* ignore_missing_imports
     # override so callers see a plain float, not an ``Any``.
+    #
+    # V2.01 (``TOYO_Origin_2.01.py`` L578) called ``simps(v_latent_dis,
+    # ip_cap_dis)`` with the integration variable in the ``y`` argument
+    # position by mistake, computing ``∫V dV`` instead of ``∫V dQ``.
+    # This rewrite passes them as named args so the integration variable
+    # is unambiguous.
     return float(simpson(y=v, x=q))
 
 

--- a/src/echemplot/origin/_worksheets.py
+++ b/src/echemplot/origin/_worksheets.py
@@ -37,10 +37,13 @@ stable across column orders (pandas preserves tuple order in
 from __future__ import annotations
 
 import hashlib
+import logging
 from typing import Any
 
 import numpy as np
 import pandas as pd
+
+logger = logging.getLogger("echemplot.origin")
 
 # Origin's worksheet-name length limit. Hard-coded here rather than
 # re-read from ``originpro`` because the constant is a platform invariant
@@ -66,7 +69,9 @@ def _sanitize_sheet_name(name: str) -> str:
     digest = hashlib.sha1(name.encode("utf-8")).hexdigest()[:_HASH_SUFFIX_LEN]
     # Leave a single "_" separator between prefix and hash.
     prefix_len = _SHEET_NAME_MAX - _HASH_SUFFIX_LEN - 1
-    return f"{name[:prefix_len]}_{digest}"
+    truncated = f"{name[:prefix_len]}_{digest}"
+    logger.info("sheet name truncated: %r -> %r (original len %d)", name, truncated, len(name))
+    return truncated
 
 
 def _flatten_columns(df: pd.DataFrame) -> pd.DataFrame:

--- a/src/echemplot/origin/templates/README.md
+++ b/src/echemplot/origin/templates/README.md
@@ -23,3 +23,11 @@ three filenames. `push_to_origin` resolves templates in this order:
 
 If a required template is missing at runtime, `push_to_origin` raises
 `FileNotFoundError` with a message naming both remediation paths.
+
+**Version coupling note**: When you upgrade `echemplot`, the bundled `.otpu`
+templates may have changed. If you've set `ECHEMPLOT_ORIGIN_TEMPLATE_DIR` to
+a custom directory, unset it (or copy the new bundled templates from
+`<wheel>/echemplot/origin/templates/` into your override directory) — Origin
+will otherwise instantiate graphs using the old template, and the worksheet
+column layout produced by the new code may not match what the old template
+binds to.


### PR DESCRIPTION
Closes #104.

## Summary

Low-risk documentation / comment / log-line cleanup. **No logic changes.**

### Edits

1. **`src/echemplot/core/stats.py`** — inline comment near the `simpson(y=v, x=q)` call recording the V2.01 (`TOYO_Origin_2.01.py` L578) bug where `simps(v_latent_dis, ip_cap_dis)` placed the integration variable in the `y` argument position, computing `∫V dV` instead of `∫V dQ`. The named-arg call here makes the integration variable unambiguous.
2. **`src/echemplot/core/dqdv.py`** — inline comment on the `ipnum = max(int(inter_num * (v_max - v_min)), 2)` floor noting that the floor of 2 keeps `linspace` usable and that segments where `ipnum < window_length` will return `None` and surface as NaN columns downstream.
3. **`src/echemplot/origin/_worksheets.py`** — added a module-level `logger = logging.getLogger("echemplot.origin")` and a `logger.info("sheet name truncated: %r -> %r (original len %d)", ...)` call inside `_sanitize_sheet_name` that fires only when truncation actually happens. Truncation logic is unchanged.
4. **`src/echemplot/origin/templates/README.md`** — appended a "Version coupling note" paragraph warning users that `ECHEMPLOT_ORIGIN_TEMPLATE_DIR` overrides need to be refreshed (or unset) when upgrading `echemplot`, otherwise Origin will instantiate graphs against an outdated template that may not match the new worksheet column layout.
5. **`CLAUDE.md`** — replaced 11 lingering `toyo_battery` references (lines 14, 40, 45, 55-61, 67) with `echemplot`. The repo *directory* path stays as `toyo-battery`; only the Python *package* references were updated. Note: `CLAUDE.md` is gitignored at the repo root (`.gitignore` line 74), so this edit is local-only and does not appear in the PR diff — it is reported here for completeness because the task explicitly requested the rename.

### CHANGELOG

Added an `[Unreleased]` → `### Changed` entry plus the `[#104]` link reference at the bottom.

## Test plan

- [x] `uv run ruff check .` — All checks passed.
- [x] `uv run ruff format --check .` — 39 files already formatted.
- [x] `uv run mypy` — Success: no issues found in 23 source files.
- [x] `uv run pytest --cov=echemplot --cov-report=term-missing` — 224 passed, 2 skipped (typer / plotly extras absent in env). Test count unchanged from `main`.
- [x] No runtime behavior changes — the only executable line added is a single `logger.info(...)` that fires inside the existing truncation branch.