### PR TITLE
refactor(core): make Cell properly immutable (defensive copy on raw_df)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+- **Breaking**: `Cell` now deep-copies the input frame on construction and
+  returns defensive copies on every read of `raw_df` / `chdis_df` /
+  `cap_df` / `dqdv_df`. Code that previously relied on mutating
+  `cell.raw_df` to influence cached derivatives must now build a new
+  `Cell`. Memory cost for the constructor copy is ~2× the raw frame
+  size. ([#103])
+
 ### Added
 - `DataIntegrityWarning` (in `echemplot.core`) emitted by `get_chdis_df`
   when the running-max filter drops rows, surfacing previously-silent
@@ -310,6 +318,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#95]: https://github.com/tomooki/toyo-battery/issues/95
 [#98]: https://github.com/tomooki/toyo-battery/issues/98
 [#99]: https://github.com/tomooki/toyo-battery/issues/99
+[#103]: https://github.com/tomooki/toyo-battery/issues/103
 [#104]: https://github.com/tomooki/toyo-battery/issues/104
 [#107]: https://github.com/tomooki/toyo-battery/pull/107
 [#108]: https://github.com/tomooki/toyo-battery/pull/108

--- a/src/echemplot/core/cell.py
+++ b/src/echemplot/core/cell.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
+from typing import cast
 
 import pandas as pd
 
@@ -15,24 +15,47 @@ from echemplot.io.reader import read_cell_dir
 from echemplot.io.schema import ColumnLang
 
 
-@dataclass
 class Cell:
     """Single-cell measurement + derived quantities.
 
-    ``raw_df`` is the normalized source frame. Derived tables (``chdis_df``
-    and, in subsequent branches, capacity / dQ-dV / stats) are exposed as
-    ``cached_property`` so they materialize on first access and are reused.
+    ``raw_df`` is the normalized source frame. Derived tables (``chdis_df``,
+    ``cap_df``, ``dqdv_df``) materialize on first access via
+    ``cached_property`` and are reused thereafter.
 
-    ``raw_df`` is treated as immutable after construction. Mutating it in
-    place (e.g. ``cell.raw_df.drop(...)``) will leave any already-accessed
-    cached properties stale. Build a new ``Cell`` from the modified frame
-    instead.
+    Immutability (イミュータブル志向)
+    --------------------------------
+    The constructor deep-copies its input frame so the caller's DataFrame is
+    fully isolated from the ``Cell``. Each of the four public DataFrame
+    properties (``raw_df``, ``chdis_df``, ``cap_df``, ``dqdv_df``) returns a
+    *defensive copy* of its internal state, so mutating a returned frame
+    cannot corrupt the cached derivatives. The cached value itself is
+    computed exactly once and reused as the source for subsequent copies.
+
+    Tradeoff: the constructor copy roughly doubles peak memory for the raw
+    frame at construction time, and every public read allocates a fresh
+    copy. For typical TOYO-cell sizes (≤10⁶ rows) this is negligible; for
+    very large frames or hot inner loops, hold the returned frame in a
+    local variable rather than re-reading the property.
+
+    Mutating the original frame *after* construction has no effect on the
+    ``Cell``. Mutating a previously-returned copy from a property has no
+    effect on subsequent reads. To produce a ``Cell`` from a transformed
+    frame, build a new ``Cell`` from the new frame.
     """
 
-    name: str
-    mass_g: float
-    raw_df: pd.DataFrame
-    column_lang: ColumnLang = "ja"
+    def __init__(
+        self,
+        name: str,
+        mass_g: float,
+        raw_df: pd.DataFrame,
+        column_lang: ColumnLang = "ja",
+    ) -> None:
+        self.name = name
+        self.mass_g = mass_g
+        # Deep-copy on ingest so the caller can keep using their frame
+        # without affecting (or being affected by) this Cell.
+        self._raw_df: pd.DataFrame = cast("pd.DataFrame", raw_df.copy(deep=True))
+        self.column_lang: ColumnLang = column_lang
 
     @classmethod
     def from_dir(
@@ -47,19 +70,49 @@ class Cell:
         df, mass_g = read_cell_dir(p, mass=mass, encoding=encoding, column_lang=column_lang)
         return cls(name=p.name, mass_g=mass_g, raw_df=df, column_lang=column_lang)
 
+    @property
+    def raw_df(self) -> pd.DataFrame:
+        """Return a defensive copy of the normalized raw frame.
+
+        Each call yields a fresh ``DataFrame``; mutations on the returned
+        object do not propagate back into the ``Cell``.
+        """
+        return cast("pd.DataFrame", self._raw_df.copy())
+
+    # ------------------------------------------------------------------
+    # Derived frames. ``_<name>_cached`` holds the materialized result;
+    # the public ``<name>`` property returns a defensive copy on every
+    # read. The compute call runs exactly once per ``Cell`` instance.
+    # ------------------------------------------------------------------
+
     @cached_property
+    def _chdis_cached(self) -> pd.DataFrame:
+        return get_chdis_df(self._raw_df, column_lang=self.column_lang)
+
+    @property
     def chdis_df(self) -> pd.DataFrame:
-        return get_chdis_df(self.raw_df, column_lang=self.column_lang)
+        """Charge/discharge V-Q segments per cycle (defensive copy)."""
+        return cast("pd.DataFrame", self._chdis_cached.copy())
 
     @cached_property
+    def _cap_cached(self) -> pd.DataFrame:
+        return get_cap_df(self._chdis_cached, column_lang=self.column_lang)
+
+    @property
     def cap_df(self) -> pd.DataFrame:
-        return get_cap_df(self.chdis_df, column_lang=self.column_lang)
+        """Per-cycle capacity + Coulombic efficiency (defensive copy)."""
+        return cast("pd.DataFrame", self._cap_cached.copy())
 
     @cached_property
+    def _dqdv_cached(self) -> pd.DataFrame:
+        return get_dqdv_df(self._chdis_cached, column_lang=self.column_lang)
+
+    @property
     def dqdv_df(self) -> pd.DataFrame:
-        """dQ/dV with default parameters. For non-default ``inter_num`` /
-        ``window_length`` / ``polyorder``, call
-        :func:`echemplot.core.dqdv.get_dqdv_df` directly on
+        """dQ/dV with default parameters (defensive copy).
+
+        For non-default ``inter_num`` / ``window_length`` / ``polyorder``,
+        call :func:`echemplot.core.dqdv.get_dqdv_df` directly on
         ``cell.chdis_df``.
         """
-        return get_dqdv_df(self.chdis_df, column_lang=self.column_lang)
+        return cast("pd.DataFrame", self._dqdv_cached.copy())

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -211,11 +211,17 @@ def test_cycle_with_all_nan_ch_side_preserves_row_as_nan() -> None:
 
 
 def test_cell_cap_df_cached_and_columns(make_cell_dir: Callable[..., Path]) -> None:
-    """Cell.cap_df integrates the capacity function and is cached."""
+    """Cell.cap_df integrates the capacity function and is cached.
+
+    Defensive-copy contract: each access returns a fresh frame (not the
+    same object), but the underlying computation is cached so contents
+    match exactly.
+    """
     cell = Cell.from_dir(make_cell_dir("renzoku"))
     first = cell.cap_df
     second = cell.cap_df
-    assert first is second
+    assert first is not second
+    pd.testing.assert_frame_equal(first, second)
     assert (cell.cap_df.columns == ["q_ch", "q_dis", "ce"]).all()
     assert cell.cap_df.index.name == "cycle"
 

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -1,0 +1,110 @@
+"""Tests for :class:`echemplot.core.cell.Cell` immutability semantics.
+
+The ``Cell`` contract:
+
+- The constructor deep-copies its input ``raw_df`` so the caller can keep
+  using their original frame without affecting the ``Cell`` (and vice
+  versa).
+- Every public DataFrame property (``raw_df``, ``chdis_df``, ``cap_df``,
+  ``dqdv_df``) returns a fresh defensive copy on each access; mutating the
+  returned frame must not corrupt the ``Cell``'s internal state.
+- The underlying computation backing each derived property
+  (``cached_property``) runs exactly once per ``Cell`` instance — the
+  per-read copy is cheap, the compute is not.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pandas as pd
+
+from echemplot.core.cell import Cell
+
+
+def _minimal_raw() -> pd.DataFrame:
+    """Single-cycle charge → discharge frame in the canonical JA layout.
+
+    Sized minimally — these tests only care about the immutability
+    contract, not segmentation correctness.
+    """
+    return pd.DataFrame(
+        [
+            (1, "充電", 3.50, 0.0),
+            (1, "充電", 3.60, 1000.0),
+            (1, "放電", 3.40, 0.0),
+            (1, "放電", 3.20, 1000.0),
+        ],
+        columns=["サイクル", "状態", "電圧", "電気量"],
+    )
+
+
+def test_cell_constructor_does_not_share_input_frame() -> None:
+    """Mutating the original frame after ``Cell(...)`` must not affect the cell."""
+    raw = _minimal_raw()
+    original_voltage = raw.loc[0, "電圧"]
+    cell = Cell(name="c1", mass_g=0.001, raw_df=raw)
+
+    # Mutate the caller's frame — the Cell must be isolated.
+    raw.loc[0, "電圧"] = 99.99
+    raw.iloc[1, raw.columns.get_loc("電気量")] = -12345.0
+
+    cell_raw = cell.raw_df
+    assert cell_raw.loc[0, "電圧"] == original_voltage
+    assert cell_raw.loc[1, "電気量"] == 1000.0
+
+
+def test_cell_raw_df_returns_a_copy() -> None:
+    """Mutating a returned ``raw_df`` must not affect subsequent reads."""
+    cell = Cell(name="c1", mass_g=0.001, raw_df=_minimal_raw())
+
+    first = cell.raw_df
+    first.loc[0, "電圧"] = 42.0
+    first.iloc[2, first.columns.get_loc("電気量")] = -1.0
+
+    second = cell.raw_df
+    assert second.loc[0, "電圧"] == 3.50
+    assert second.loc[2, "電気量"] == 0.0
+    # Defensive-copy contract: each access yields a distinct object.
+    assert first is not second
+
+
+def test_cell_chdis_df_returns_a_copy() -> None:
+    """Mutating a returned ``chdis_df`` must not affect subsequent reads."""
+    cell = Cell(name="c1", mass_g=0.001, raw_df=_minimal_raw())
+
+    first = cell.chdis_df
+    assert not first.empty, "fixture must produce a non-empty chdis_df"
+    # Stomp every value in the returned copy.
+    first.iloc[:, :] = 0.0
+
+    second = cell.chdis_df
+    assert first is not second
+    # The fresh copy must reflect the original cached computation, not
+    # the caller's mutation.
+    pd.testing.assert_frame_equal(second, cell.chdis_df)
+    # And it must not be all zeros (the original fixture has non-zero
+    # capacity + voltage entries).
+    assert (second.fillna(0.0).abs().to_numpy() > 0).any()
+
+
+def test_cell_cached_property_only_computed_once() -> None:
+    """Multiple ``cell.chdis_df`` reads must invoke ``get_chdis_df`` exactly once.
+
+    The defensive copy on each public read is fine; the expensive
+    computation behind it must still be cached.
+    """
+    cell = Cell(name="c1", mass_g=0.001, raw_df=_minimal_raw())
+
+    with patch(
+        "echemplot.core.cell.get_chdis_df",
+        wraps=__import__("echemplot.core.chdis", fromlist=["get_chdis_df"]).get_chdis_df,
+    ) as spy:
+        _ = cell.chdis_df
+        _ = cell.chdis_df
+        _ = cell.chdis_df
+
+    assert spy.call_count == 1, (
+        f"get_chdis_df was invoked {spy.call_count} times - cached_property "
+        "must memoize the computation across reads."
+    )

--- a/tests/test_chdis.py
+++ b/tests/test_chdis.py
@@ -180,13 +180,16 @@ def test_only_rest_rows_returns_empty() -> None:
 
 
 def test_cell_chdis_df_is_cached(make_cell_dir: Callable[..., Path]) -> None:
-    """Cell.chdis_df is a cached_property — second access returns the same object."""
+    """Cell.chdis_df returns equal-but-distinct frames; computation is cached."""
     cell_dir = make_cell_dir("renzoku")
     cell = Cell.from_dir(cell_dir)
 
     first = cell.chdis_df
     second = cell.chdis_df
-    assert first is second
+    # Defensive-copy contract: each access returns a fresh frame, but the
+    # underlying cached computation is reused so the contents are identical.
+    assert first is not second
+    pd.testing.assert_frame_equal(first, second)
     assert (1, "ch", "電気量") in first.columns
     assert (1, "dis", "電気量") in first.columns
 

--- a/tests/test_dqdv.py
+++ b/tests/test_dqdv.py
@@ -265,13 +265,16 @@ def test_cc_cv_plateau_preserves_tail_capacity() -> None:
 
 
 def test_cell_dqdv_df_is_cached(make_cell_dir: Callable[..., Path]) -> None:
-    """Cell.dqdv_df is cached_property — second access returns the same object."""
+    """Cell.dqdv_df returns equal-but-distinct frames; computation is cached."""
     cell_dir = make_cell_dir("renzoku")
     cell = Cell.from_dir(cell_dir)
 
     first = cell.dqdv_df
     second = cell.dqdv_df
-    assert first is second
+    # Defensive-copy contract: each access returns a fresh frame, but the
+    # cached computation is reused so contents are identical.
+    assert first is not second
+    pd.testing.assert_frame_equal(first, second)
     # The synthetic renzoku fixture has a very small voltage span (0.1 V for
     # ch, 0.2 V for dis) so ipnum=int(100*0.1)=10 < window_length=11 → both
     # segments produce NaN columns by design. The shape + column layout must


### PR DESCRIPTION
## Breaking change

**This PR changes the public mutability contract of `Cell`.** Code that previously relied on mutating `cell.raw_df` (or any of the derived properties) to influence cached state must now construct a new `Cell` from the transformed frame. See the new `Immutability` section in the `Cell` docstring.

Closes #103

## Summary

`Cell` was advertised as "イミュータブル志向" (immutability-oriented) but only via docstring warnings. A caller could do `cell.raw_df.iloc[0, 0] = ...` and silently desync the `cached_property`-backed `chdis_df` / `cap_df` / `dqdv_df`. This PR makes the contract real:

- **`Cell.__init__`** now deep-copies its input: `self._raw_df = raw_df.copy(deep=True)`. The caller's frame and the `Cell`'s internal frame are fully isolated.
- **`raw_df`** is now a `@property` returning `self._raw_df.copy()` — a defensive copy on every read.
- **`chdis_df` / `cap_df` / `dqdv_df`** moved from `cached_property` to a `_<name>_cached` `cached_property` (private, holds the materialized result) plus a public `@property` that returns `.copy()`. The expensive computation still runs **exactly once** per `Cell`; only the cheap copy runs per read.
- The `Cell` docstring now spells out the tradeoff (constructor ~2x raw frame memory, one allocation per public read).

The class is no longer a `@dataclass` since the immutable-input contract is incompatible with auto-generated `__init__`. The constructor signature (`name`, `mass_g`, `raw_df`, `column_lang`) is preserved.

## Files modified

- `src/echemplot/core/cell.py` — restructure properties, deep-copy on init.
- `tests/test_cell.py` — new file, four tests (constructor isolation, `raw_df` defensive copy, `chdis_df` defensive copy, cached_property only computed once).
- `tests/test_chdis.py`, `tests/test_capacity.py`, `tests/test_dqdv.py` — three existing tests asserted `first is second` on `cell.chdis_df` / `cell.cap_df` / `cell.dqdv_df`. The new contract returns equal-but-distinct frames; updated to `assert first is not second` plus `pd.testing.assert_frame_equal`.
- `CHANGELOG.md` — `[Unreleased]` → new `### Breaking` subsection.

No source files outside `core/cell.py` were touched. Plotting / origin / GUI / CLI / stats keep working unchanged because they always read the property, copy or not.

## Test plan

- [x] `uv run ruff check .` - clean
- [x] `uv run ruff format --check .` - clean
- [x] `uv run mypy` - clean (strict mode, all 23 source files)
- [x] `uv run pytest --cov=echemplot --cov-report=term-missing` - 227 passed, `core/cell.py` at 100% coverage
- [x] New tests/test_cell.py exercises all four DoD assertions
- [ ] CI lint/type/test/build matrix on PR

## Memory tradeoff (per #103 ask)

Constructor: peak memory ~2x the raw frame for one tick (the deep-copy + the caller's still-live original). After construction the caller's frame can be dropped; the `Cell` retains only its private copy.

Per public read: one frame allocation. For TOYO cell sizes (≤10⁶ rows) this is sub-millisecond. For large frames or hot inner loops, the docstring directs callers to bind once (`chdis = cell.chdis_df`) and reuse the local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)