### PR TITLE
fix(io): drop errors="replace" silent encoding fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   state literals with EN columns (the legacy mixed shape) must either
   call the reader with `column_lang='en'` or translate state values
   themselves. ([#94])
+- **Breaking**: `read_cell_dir` (and helpers) no longer silently replaces
+  undecodable bytes with `?` (the previous `errors='replace'` behavior).
+  Files containing bytes invalid for the configured encoding now raise
+  the new `echemplot.io.EncodingError` (a `ValueError` subclass). Pass
+  `encoding=` explicitly if the file is not Shift-JIS. ([#96])
 - **Breaking**: `Cell` now deep-copies the input frame on construction and
   returns defensive copies on every read of `raw_df` / `chdis_df` /
   `cap_df` / `dqdv_df`. Code that previously relied on mutating
@@ -333,6 +338,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#93]: https://github.com/tomooki/toyo-battery/issues/93
 [#94]: https://github.com/tomooki/toyo-battery/issues/94
 [#95]: https://github.com/tomooki/toyo-battery/issues/95
+[#96]: https://github.com/tomooki/toyo-battery/issues/96
 [#98]: https://github.com/tomooki/toyo-battery/issues/98
 [#99]: https://github.com/tomooki/toyo-battery/issues/99
 [#100]: https://github.com/tomooki/toyo-battery/issues/100

--- a/src/echemplot/io/__init__.py
+++ b/src/echemplot/io/__init__.py
@@ -1,1 +1,5 @@
 """I/O layer: TOYO cycler file readers and column schema."""
+
+from echemplot.io.reader import EncodingError
+
+__all__ = ["EncodingError"]

--- a/src/echemplot/io/reader.py
+++ b/src/echemplot/io/reader.py
@@ -68,6 +68,37 @@ from echemplot.io.schema import (
 
 logger = logging.getLogger(__name__)
 
+
+class EncodingError(ValueError):
+    """Raised when a TOYO file cannot be decoded with the configured encoding.
+
+    Subclasses :class:`ValueError` so callers that already catch
+    ``ValueError`` keep working. The message includes the file path, the
+    encoding being attempted, the byte position of the first bad sequence
+    (from :class:`UnicodeDecodeError`), and a hint for overriding the
+    encoding via :func:`read_cell_dir`.
+    """
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        expected_encoding: str,
+        original: UnicodeDecodeError,
+    ) -> None:
+        self.path = Path(path)
+        self.expected_encoding = expected_encoding
+        self.original = original
+        msg = (
+            f"failed to decode {self.path} with encoding={expected_encoding!r}: "
+            f"invalid byte(s) at position {original.start}-{original.end} "
+            f"({original.reason}); "
+            f"pass `encoding=<other>` to `read_cell_dir` to override "
+            f"(default 'shift_jis')."
+        )
+        super().__init__(msg)
+
+
 RAW_FILENAME_RE = re.compile(r"[0-9]{6}")
 PTN_SUFFIX = ".ptn"  # matched case-insensitively (Linux CI is case-sensitive)
 RENZOKU_DATA = "連続データ.csv"
@@ -109,8 +140,12 @@ def read_ptn_mass(ptn_path: str | Path) -> float:
     skip them.
     """
     path = Path(ptn_path)
-    with path.open(encoding="shift_jis", errors="replace") as f:
-        first_line = f.readline()
+    encoding = "shift_jis"
+    try:
+        with path.open(encoding=encoding) as f:
+            first_line = f.readline()
+    except UnicodeDecodeError as e:
+        raise EncodingError(path, expected_encoding=encoding, original=e) from e
     tokens = first_line.split()
     if len(tokens) < 3:
         raise ValueError(
@@ -434,19 +469,22 @@ def _extract_mass_from_renzoku_metadata(path: Path, encoding: str) -> float | No
     Native 連続データ.csv has 3 metadata rows before the column-name row;
     the 3rd carries ``,重量[mg],<value>`` where <value> is in milligrams.
     """
-    with path.open(encoding=encoding, errors="replace") as f:
-        for _ in range(_METADATA_SCAN_ROWS):
-            line = f.readline()
-            if not line:
-                return None
-            fields = [c.strip() for c in line.rstrip("\r\n").split(",")]
-            for i, cell in enumerate(fields):
-                if cell == _METADATA_MASS_KEY and i + 1 < len(fields):
-                    try:
-                        mg = float(fields[i + 1])
-                    except ValueError:
-                        return None
-                    return mg * 1e-3
+    try:
+        with path.open(encoding=encoding) as f:
+            for _ in range(_METADATA_SCAN_ROWS):
+                line = f.readline()
+                if not line:
+                    return None
+                fields = [c.strip() for c in line.rstrip("\r\n").split(",")]
+                for i, cell in enumerate(fields):
+                    if cell == _METADATA_MASS_KEY and i + 1 < len(fields):
+                        try:
+                            mg = float(fields[i + 1])
+                        except ValueError:
+                            return None
+                        return mg * 1e-3
+    except UnicodeDecodeError as e:
+        raise EncodingError(path, expected_encoding=encoding, original=e) from e
     return None
 
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -10,7 +10,13 @@ import pandas as pd
 import pytest
 
 from echemplot.core.cell import Cell
-from echemplot.io.reader import read_cell_dir, read_ptn_mass
+from echemplot.io import EncodingError as EncodingErrorReexport
+from echemplot.io.reader import (
+    EncodingError,
+    _extract_mass_from_renzoku_metadata,
+    read_cell_dir,
+    read_ptn_mass,
+)
 from echemplot.io.schema import CANONICAL_COLUMNS_EN, CANONICAL_COLUMNS_JA
 
 
@@ -502,6 +508,82 @@ def test_read_ptn_mass_ini_style_raises(tmp_path: Path) -> None:
     ptn.write_text("[BaseCellCapacity]\nCapacity=0.1\n", encoding="shift_jis")
     with pytest.raises(ValueError):
         read_ptn_mass(ptn)
+
+
+# ---- strict-encoding error surface (Issue #96) ----------------------------
+
+
+def _write_corrupt_shift_jis_ptn(path: Path) -> None:
+    """Write a PTN file with a valid Shift-JIS prefix and an invalid byte mid-stream.
+
+    ``0xFF`` is not a legal Shift-JIS lead byte in any common dialect, so
+    Python's ``shift_jis`` codec rejects it strictly. A trailing valid
+    suffix is included so the failure is genuinely mid-stream rather than
+    at EOF.
+    """
+    valid_prefix = " 1Operator                                 2 ".encode("shift_jis")
+    invalid_bytes = b"\xff\xfe"
+    valid_suffix = b" 0.001000       1 0.001000TestCell\n"
+    path.write_bytes(valid_prefix + invalid_bytes + valid_suffix)
+
+
+def test_encoding_error_is_reexported_from_io_package() -> None:
+    """``echemplot.io.EncodingError`` must be the same class as the reader's."""
+    assert EncodingErrorReexport is EncodingError
+    assert issubclass(EncodingError, ValueError)
+
+
+def test_read_ptn_mass_raises_encoding_error_on_corrupt_bytes(tmp_path: Path) -> None:
+    """A PTN with bytes invalid for Shift-JIS must raise EncodingError, not silently
+    return ``?`` replacements that break downstream float parsing with a misleading
+    error pointing at the replacement character."""
+    ptn = tmp_path / "corrupt_shift_jis_ptn.PTN"
+    _write_corrupt_shift_jis_ptn(ptn)
+    with pytest.raises(EncodingError) as exc_info:
+        read_ptn_mass(ptn)
+    # Path is part of the message so the failure is actionable
+    assert str(ptn) in str(exc_info.value)
+    # Byte position from the underlying UnicodeDecodeError surfaces in the message
+    assert "position" in str(exc_info.value)
+    # The invalid bytes are in the prefix region; assert a numeric byte offset shows
+    assert any(ch.isdigit() for ch in str(exc_info.value))
+
+
+def test_read_ptn_mass_strict_message_includes_hint(tmp_path: Path) -> None:
+    """Users must see how to override the encoding from the error message."""
+    ptn = tmp_path / "corrupt.PTN"
+    _write_corrupt_shift_jis_ptn(ptn)
+    with pytest.raises(EncodingError) as exc_info:
+        read_ptn_mass(ptn)
+    msg = str(exc_info.value)
+    assert "encoding=" in msg
+    # Hint mentions the default so users know what is being overridden
+    assert "shift_jis" in msg
+
+
+def test_read_ptn_mass_encoding_error_is_value_error(tmp_path: Path) -> None:
+    """EncodingError must be a ValueError so existing handlers keep working."""
+    ptn = tmp_path / "corrupt2.PTN"
+    _write_corrupt_shift_jis_ptn(ptn)
+    with pytest.raises(ValueError):
+        read_ptn_mass(ptn)
+
+
+def test_extract_mass_from_renzoku_metadata_raises_encoding_error(tmp_path: Path) -> None:
+    """The renzoku-metadata reader must surface invalid bytes the same way."""
+    csv = tmp_path / "連続データ.csv"
+    valid_prefix = ",試験名,synthetic,,,,開始日時,2026-01-01\n,測定備考,\n,重量[mg],".encode(
+        "shift_jis"
+    )
+    invalid_bytes = b"\xff\xfe"
+    valid_suffix = b"1.0\n"
+    csv.write_bytes(valid_prefix + invalid_bytes + valid_suffix)
+    with pytest.raises(EncodingError) as exc_info:
+        _extract_mass_from_renzoku_metadata(csv, "shift_jis")
+    msg = str(exc_info.value)
+    assert str(csv) in msg
+    assert "encoding=" in msg
+    assert "shift_jis" in msg
 
 
 # ---- column_lang translation ---------------------------------------------


### PR DESCRIPTION
Closes #96.

## Summary
- `io/reader.py`: removed `errors="replace"` from both `open(...)` call sites (`read_ptn_mass` and `_extract_mass_from_renzoku_metadata`). Decoding is now strict; `UnicodeDecodeError` is caught and re-raised as the new `echemplot.io.EncodingError`.
- `EncodingError` is a `ValueError` subclass — existing handlers that catch `ValueError` continue to work — and its message includes the path, the attempted encoding, the byte position from `UnicodeDecodeError.start/end`, and an explicit hint to pass `encoding=` to `read_cell_dir`.
- Re-exported `EncodingError` from `echemplot.io`.

## Breaking change
**Breaking**: `read_cell_dir` (and helpers) no longer silently replaces undecodable bytes with `?` (the previous `errors='replace'` behavior). Files containing bytes invalid for the configured encoding now raise `echemplot.io.EncodingError` (a `ValueError` subclass). Pass `encoding=` explicitly if the file is not Shift-JIS.

Why this is a breaking change: in the previous behavior, undecodable bytes silently became `?`, which masked the real failure — downstream parse failures pointed at the replacement character rather than the real bytes. Code paths that *relied* on this masking (e.g. PTN files containing non-Shift-JIS comment bytes that happened to fall outside the parsed token range) will now raise `EncodingError`. Such callers should pass an explicit `encoding=` matching the file, or open and pre-decode the file themselves.

## Test plan
- [x] `uv run ruff check .` (passed)
- [x] `uv run ruff format --check .` (42 files already formatted)
- [x] `uv run mypy` (Success: no issues found in 23 source files)
- [x] `uv run pytest --cov=echemplot --cov-report=term-missing` (237 passed, 3 skipped — same skips as `main`: typer/plotly extras and Tk display unavailable on this host)
- [x] New tests: `test_read_ptn_mass_raises_encoding_error_on_corrupt_bytes`, `test_read_ptn_mass_strict_message_includes_hint`, `test_read_ptn_mass_encoding_error_is_value_error`, `test_extract_mass_from_renzoku_metadata_raises_encoding_error`, `test_encoding_error_is_reexported_from_io_package`

Refs: tracker issue #105, plan `toyo-origin-v2-01-worktree-warm-snail.md`.