### PR TITLE
fix(io): validate row continuity when concatenating 6-digit raw files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   size. ([#103])
 
 ### Added
+- Added per-frame row-continuity validation in `_read_raw_6digit`: each
+  constituent 6-digit file is now checked for monotone-non-decreasing
+  `経過時間[Sec]` within state segments. Truncated or corrupt 6-digit
+  files now raise the new `echemplot.io.RawConcatError` instead of
+  silently joining into a stitched DataFrame. ([#97])
 - `DataIntegrityWarning` (in `echemplot.core`) emitted by `get_chdis_df`
   when the running-max filter drops rows, surfacing previously-silent
   data loss for hand-preprocessed inputs. One aggregated summary warning
@@ -344,6 +349,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#94]: https://github.com/tomooki/toyo-battery/issues/94
 [#95]: https://github.com/tomooki/toyo-battery/issues/95
 [#96]: https://github.com/tomooki/toyo-battery/issues/96
+[#97]: https://github.com/tomooki/toyo-battery/issues/97
 [#98]: https://github.com/tomooki/toyo-battery/issues/98
 [#99]: https://github.com/tomooki/toyo-battery/issues/99
 [#100]: https://github.com/tomooki/toyo-battery/issues/100

--- a/src/echemplot/io/__init__.py
+++ b/src/echemplot/io/__init__.py
@@ -1,5 +1,5 @@
 """I/O layer: TOYO cycler file readers and column schema."""
 
-from echemplot.io.reader import EncodingError
+from echemplot.io.reader import EncodingError, RawConcatError
 
-__all__ = ["EncodingError"]
+__all__ = ["EncodingError", "RawConcatError"]

--- a/src/echemplot/io/reader.py
+++ b/src/echemplot/io/reader.py
@@ -57,6 +57,7 @@ import re
 from pathlib import Path
 from typing import cast
 
+import numpy as np
 import pandas as pd
 
 from echemplot.io.schema import (
@@ -101,6 +102,44 @@ class EncodingError(ValueError):
             f"(default 'shift_jis')."
         )
         super().__init__(msg)
+
+
+class RawConcatError(ValueError):
+    """Raised when a constituent 6-digit raw file fails row-continuity validation.
+
+    A single ``000NNN`` raw file is expected to be internally consistent before
+    being concatenated with its siblings — specifically, ``経過時間[Sec]`` must
+    be monotone-non-decreasing within each run of identical ``状態`` values
+    (state transitions reset elapsed_time). A negative diff inside a single
+    state segment indicates the file was truncated mid-cycle and resumed,
+    silently joining two distinct runs into one DataFrame.
+
+    Attributes
+    ----------
+    file_path : Path
+        The offending 6-digit raw file.
+    segment_index : int | None
+        0-based index of the state-run segment that failed the check, counting
+        from the top of the file. ``None`` for whole-file failures (e.g. an
+        empty file).
+    reason : str
+        Human-readable explanation of the failure mode.
+    """
+
+    def __init__(
+        self,
+        file_path: Path,
+        segment_index: int | None,
+        reason: str,
+    ) -> None:
+        self.file_path = file_path
+        self.segment_index = segment_index
+        self.reason = reason
+        seg_str = "n/a" if segment_index is None else str(segment_index)
+        super().__init__(
+            f"raw file {file_path.name} failed row-continuity validation "
+            f"(segment_index={seg_str}): {reason}"
+        )
 
 
 RAW_FILENAME_RE = re.compile(r"[0-9]{6}")
@@ -355,11 +394,104 @@ def _read_raw_6digit(
                 f"raw file {f.name} has columns differing from {raw_files[0].name}: "
                 f"{list(frame.columns)} vs {base_cols}"
             )
+    # Row-continuity validation: each constituent file must be internally
+    # consistent before concat. A truncated-and-resumed file would otherwise
+    # silently splice two unrelated runs into a single state segment. See
+    # _validate_raw_frame_continuity for the precise rules.
+    for f, frame in zip(raw_files, frames):
+        _validate_raw_frame_continuity(f, frame)
     df = pd.concat(frames, axis=0, ignore_index=True)
     df = _clean_columns(df)
     df = _drop_unnamed(df)
     df = _ensure_capacity(df, mass)
     return _finalize(df, column_lang), mass
+
+
+def _validate_raw_frame_continuity(file_path: Path, frame: pd.DataFrame) -> None:
+    """Validate one raw 6-digit frame's internal row continuity.
+
+    Checks performed:
+
+    * Frame is non-empty. A 6-digit file with zero data rows is suspicious
+      (the on-disk format always carries at least the summary marker plus
+      header, but the data section can be empty if the cycler crashed
+      before any sample landed). Raises :class:`RawConcatError` with
+      ``segment_index=None``.
+    * ``経過時間[Sec]`` is monotone-non-decreasing within each contiguous
+      run of identical ``状態`` values. State transitions reset elapsed
+      time in the TOYO raw format, so we check per-segment, not globally.
+      Run-length segments are computed via a state-change cumsum.
+
+    The elapsed-time column is *optional* in the TOYO 6-digit dialect —
+    some older firmware revisions emit files without it. In that case we
+    skip the continuity check (with a ``logger.debug`` notice) rather
+    than raise; the column-equality check upstream still guarantees that
+    every constituent file in a given concat shares the same schema, so
+    the missing column is consistent across siblings.
+
+    Edge case: if ``状態`` itself is missing we cannot RLE the segments,
+    so we treat the entire frame as one segment for the diff check.
+    """
+    if len(frame) == 0:
+        raise RawConcatError(
+            file_path,
+            None,
+            "frame has 0 data rows after header skip; file is empty or truncated before "
+            "any sample landed",
+        )
+
+    # The reader runs continuity validation pre-_clean_columns, so at this
+    # point ``frame`` carries the source-literal column names. The elapsed
+    # column is the canonical JP form ``経過時間[Sec]``; the state column
+    # is ``状態``.
+    if COL_ELAPSED_S not in frame.columns:
+        logger.debug(
+            "raw file %s: %s column missing; skipping per-segment continuity check",
+            file_path.name,
+            COL_ELAPSED_S,
+        )
+        return
+
+    elapsed = pd.to_numeric(frame[COL_ELAPSED_S], errors="coerce").to_numpy()
+    if "状態" in frame.columns:
+        # Run-length encode: a new segment starts wherever 状態 changes
+        # (using fillna-aware comparison so two consecutive NaN states
+        # are treated as a single segment, matching np.diff semantics on
+        # the elapsed column itself).
+        state_series = frame["状態"]
+        # shift().ne(state_series) marks each row where the state differs
+        # from its predecessor; cumsum turns that into a 0,1,2,... segment id.
+        # We use ne(...) | (both NaN) — pandas' default ne treats NaN!=NaN, so
+        # we compensate by also accepting matching NaNs as same-segment.
+        prev = state_series.shift()
+        changed = state_series.ne(prev) & ~(state_series.isna() & prev.isna())
+        # The very first row's "changed" is True by definition (no
+        # predecessor); cumsum gives segment ids starting at 1.
+        segment_ids = changed.cumsum().to_numpy()
+    else:
+        segment_ids = np.ones(len(frame), dtype=np.int64)
+
+    unique_segments = np.unique(segment_ids)
+    for seg_idx, seg_id in enumerate(unique_segments):
+        mask = segment_ids == seg_id
+        seg_elapsed = elapsed[mask]
+        if seg_elapsed.size < 2:
+            continue
+        diffs = np.diff(seg_elapsed)
+        # NaN diffs are not negative — treat them as inconclusive and skip.
+        # Any strictly-negative diff inside a single state segment is the
+        # truncation/resume signature.
+        bad = diffs < 0
+        if bool(np.any(bad)) and not bool(np.all(np.isnan(diffs[bad]))):
+            first_bad = int(np.argmax(bad))
+            raise RawConcatError(
+                file_path,
+                seg_idx,
+                f"{COL_ELAPSED_S} decreased within state segment "
+                f"(prev={seg_elapsed[first_bad]!r}, "
+                f"next={seg_elapsed[first_bad + 1]!r}); file likely truncated "
+                "and resumed mid-segment",
+            )
 
 
 def _clean_columns(df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,6 +234,47 @@ def write_renzoku_with_states(
     (cell_dir / "連続データ.csv").write_text("\n".join(lines) + "\n", encoding="shift_jis")
 
 
+def write_raw_6digit_file(
+    path: Path,
+    rows: list[tuple[int, str, int, float, float, float]],
+    *,
+    include_elapsed: bool = True,
+    total_cycle: int = 1,
+) -> None:
+    """Write a single TOYO-style 6-digit raw file with explicit row content.
+
+    ``rows`` is a list of ``(cycle, mode, state_int, voltage, elapsed_s,
+    current_mA)`` tuples. When ``include_elapsed=False`` the
+    ``経過時間[Sec]`` column and value are omitted from the header and
+    data rows respectively, mirroring the older firmware revision that
+    predates the elapsed-time column. Used by the row-continuity tests
+    in ``test_reader.py`` to build per-segment-truncated and
+    elapsed-missing fixtures.
+    """
+    empty_sep = ",,,,,,"
+    if include_elapsed:
+        header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    else:
+        header = f"日付,時刻,電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    lines = ["0,0,0,0,0,0,0", "", "", header]
+    date = "2026/01/01"
+    time = "00:00:00"
+    for cycle, mode, state_int, voltage, elapsed, current in rows:
+        if include_elapsed:
+            data = (
+                f"{date},{time},{int(elapsed):08d},+{voltage:.4f},"
+                f"{current:.6f}{empty_sep}"
+                f",{state_int:d}, {mode},  {cycle:d},     {total_cycle:d}"
+            )
+        else:
+            data = (
+                f"{date},{time},+{voltage:.4f},{current:.6f}{empty_sep}"
+                f",{state_int:d}, {mode},  {cycle:d},     {total_cycle:d}"
+            )
+        lines.append(data)
+    path.write_text("\n".join(lines) + "\n", encoding="shift_jis")
+
+
 def write_ptn_main(
     path: Path,
     *,

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -12,8 +12,10 @@ import pytest
 
 from echemplot.core.cell import Cell
 from echemplot.io import EncodingError as EncodingErrorReexport
+from echemplot.io import RawConcatError as RawConcatErrorReexport
 from echemplot.io.reader import (
     EncodingError,
+    RawConcatError,
     _extract_mass_from_renzoku_metadata,
     read_cell_dir,
     read_ptn_mass,
@@ -318,6 +320,155 @@ def test_read_raw_6digit_mismatched_columns_raises(tmp_path: Path) -> None:
     _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
     with pytest.raises(ValueError, match="columns differing"):
         read_cell_dir(cell_dir)
+
+
+# ---- 6-digit raw row-continuity validation (#97) -------------------------
+
+
+def test_raw_concat_error_re_exported_from_io_package() -> None:
+    """`RawConcatError` is part of the public ``echemplot.io`` surface."""
+    assert RawConcatErrorReexport is RawConcatError
+    assert issubclass(RawConcatError, ValueError)
+
+
+def test_read_raw_6digit_concat_normal_two_segment_pass(tmp_path: Path) -> None:
+    """Two consistent 6-digit files concatenate without raising.
+
+    File A: a charge segment with monotone-increasing 経過時間.
+    File B: a discharge segment with monotone-increasing 経過時間.
+    State transitions occur cleanly at file boundaries; no per-segment
+    backwards diff anywhere; row-continuity validation must pass.
+    """
+    from tests.conftest import write_ptn_main, write_raw_6digit_file
+
+    cell_dir = tmp_path / "two_seg"
+    cell_dir.mkdir()
+    write_raw_6digit_file(
+        cell_dir / "000001",
+        [
+            (1, "1", 1, 3.50, 0.0, 1.0),
+            (1, "1", 1, 3.55, 1800.0, 1.0),
+            (1, "1", 1, 3.60, 3600.0, 1.0),
+        ],
+    )
+    write_raw_6digit_file(
+        cell_dir / "000002",
+        [
+            (1, "1", 2, 3.40, 0.0, 1.0),
+            (1, "1", 2, 3.30, 1800.0, 1.0),
+            (1, "1", 2, 3.20, 3600.0, 1.0),
+        ],
+    )
+    write_ptn_main(cell_dir / "pattern.PTN", mass_g=0.001)
+    df, mass_g = read_cell_dir(cell_dir)
+    assert mass_g == pytest.approx(0.001)
+    assert len(df) == 6
+    # Two charge rows from each file's last sample land at indices 2 and 5.
+    assert df["状態"].tolist() == ["充電", "充電", "充電", "放電", "放電", "放電"]
+    # Per-segment monotone capacity (3 rows each, last hits 1000 mAh/g).
+    assert df["電気量"].tolist() == pytest.approx([0.0, 500.0, 1000.0, 0.0, 500.0, 1000.0])
+
+
+def test_read_raw_6digit_raises_on_truncated_segment(tmp_path: Path) -> None:
+    """An elapsed-time backstep within a state segment surfaces as RawConcatError.
+
+    Simulates a tester that crashed mid-charge and resumed: the second
+    "row 1" of the charge segment sees ``経過時間`` go from 1800 back to
+    300 — the truncation/resume signature this validation is designed
+    to catch. The error message must include the segment index.
+    """
+    from tests.conftest import write_ptn_main, write_raw_6digit_file
+
+    cell_dir = tmp_path / "truncated"
+    cell_dir.mkdir()
+    write_raw_6digit_file(
+        cell_dir / "000001",
+        [
+            (1, "1", 1, 3.50, 0.0, 1.0),
+            (1, "1", 1, 3.55, 1800.0, 1.0),
+            # Backstep: tester crashed and resumed mid-charge.
+            (1, "1", 1, 3.52, 300.0, 1.0),
+            (1, "1", 1, 3.60, 3600.0, 1.0),
+        ],
+    )
+    write_ptn_main(cell_dir / "pattern.PTN", mass_g=0.001)
+    with pytest.raises(RawConcatError) as exc_info:
+        read_cell_dir(cell_dir)
+    err = exc_info.value
+    assert err.file_path.name == "000001"
+    assert err.segment_index == 0  # The first (and only) state segment.
+    assert "segment_index=0" in str(err)
+    assert "経過時間[Sec]" in str(err)
+
+
+def test_read_raw_6digit_skips_validation_when_elapsed_missing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Files lacking 経過時間[Sec] read successfully with a debug notice.
+
+    Some older TOYO firmware revisions emit raw files without the
+    elapsed-time column. The continuity check must be skipped (not
+    raise) for that schema, and the skip must be observable at debug
+    level so a user investigating downstream weirdness can find it.
+
+    Also verifies that the absence of the elapsed column does not
+    prevent ``_ensure_capacity`` from raising: the fixture has no
+    pre-computed 電気量 either, so we expect the existing
+    "missing columns" ValueError. The test asserts that we reach that
+    point — i.e. continuity validation did NOT short-circuit with a
+    RawConcatError first.
+    """
+    from tests.conftest import write_ptn_main, write_raw_6digit_file
+
+    cell_dir = tmp_path / "no_elapsed"
+    cell_dir.mkdir()
+    write_raw_6digit_file(
+        cell_dir / "000001",
+        [
+            (1, "1", 1, 3.50, 0.0, 1.0),
+            (1, "1", 1, 3.60, 0.0, 1.0),
+        ],
+        include_elapsed=False,
+    )
+    write_ptn_main(cell_dir / "pattern.PTN", mass_g=0.001)
+    caplog.set_level(logging.DEBUG, logger="echemplot.io.reader")
+    # Without 経過時間 the capacity column cannot be derived, so the
+    # downstream _ensure_capacity raises. We catch that to assert we
+    # got past validation; the validation step is the focus of this test.
+    with pytest.raises(ValueError, match="cannot compute"):
+        read_cell_dir(cell_dir)
+    assert any(
+        "skipping per-segment continuity check" in rec.getMessage() for rec in caplog.records
+    )
+    # Negative assertion: no RawConcatError was raised on the way to that ValueError.
+    assert not any(
+        rec.exc_info and isinstance(rec.exc_info[1], RawConcatError) for rec in caplog.records
+    )
+
+
+def test_read_raw_6digit_raises_on_empty_data_section(tmp_path: Path) -> None:
+    """A 6-digit file with header but zero data rows raises RawConcatError.
+
+    Covers the ``segment_index=None`` branch — the empty-frame check
+    fires before per-segment RLE could even be computed.
+    """
+    from tests.conftest import write_ptn_main
+
+    cell_dir = tmp_path / "empty_data"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    (cell_dir / "000001").write_text(
+        "\n".join(["0,0,0,0,0,0,0", "", "", header]) + "\n",
+        encoding="shift_jis",
+    )
+    write_ptn_main(cell_dir / "pattern.PTN", mass_g=0.001)
+    with pytest.raises(RawConcatError) as exc_info:
+        read_cell_dir(cell_dir)
+    err = exc_info.value
+    assert err.file_path.name == "000001"
+    assert err.segment_index is None
+    assert "segment_index=n/a" in str(err)
 
 
 def test_unknown_state_code_raises(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #97

## Summary

`_read_raw_6digit` previously only checked column equality across sibling `000NNN` files before `pd.concat`; each individual file's internal consistency was unverified. A truncated-and-resumed file would silently splice two unrelated runs into one DataFrame.

This PR adds a per-frame `_validate_raw_frame_continuity` step that runs before the concat:

- Empty data sections (header present, zero rows) raise.
- `経過時間[Sec]` is checked for monotone-non-decreasing diffs within each contiguous run of identical `状態` values (state transitions reset elapsed_time, so the check is per-segment via cumsum-RLE on the state column).
- Files lacking the elapsed-time column emit a `logger.debug` notice and skip the continuity check (older firmware revisions ship without it).

Failures raise the new `RawConcatError(file_path, segment_index, reason)` — a `ValueError` subclass re-exported from `echemplot.io` so callers can distinguish corrupt-file failures from other I/O errors.

## Test plan

- [x] `test_raw_concat_error_re_exported_from_io_package` — public surface check
- [x] `test_read_raw_6digit_concat_normal_two_segment_pass` — two consistent files concatenate cleanly
- [x] `test_read_raw_6digit_raises_on_truncated_segment` — backstep mid-segment surfaces `RawConcatError` with `segment_index=0`
- [x] `test_read_raw_6digit_skips_validation_when_elapsed_missing` — files without `経過時間[Sec]` read past validation, debug notice fires, no `RawConcatError`
- [x] `test_read_raw_6digit_raises_on_empty_data_section` — empty data section hits `segment_index=None` branch
- [x] All 37 prior `test_reader.py` tests still pass; full suite 238 passed / 2 skipped
- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy` all clean
- [x] Coverage non-decreasing (`echemplot.io.reader` 96%)