### PR TITLE
fix(io): symmetric state-value handling in _finalize and column_lang routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking
+- **Breaking**: `read_cell_dir` (and `_finalize`) now raises `ValueError`
+  on unknown JA-string state values, matching the existing strictness
+  for unknown numeric state codes. State values are also translated to
+  EN when `column_lang='en'` (e.g. `充電休止` → `charge_rest`); previous
+  releases left state values JA regardless of `column_lang`. Downstream
+  `get_chdis_df` is now language-aware: in EN mode it filters on
+  `charge`/`discharge` instead of `充電`/`放電`, so callers passing JA
+  state literals with EN columns (the legacy mixed shape) must either
+  call the reader with `column_lang='en'` or translate state values
+  themselves. ([#94])
 - **Breaking**: `Cell` now deep-copies the input frame on construction and
   returns defensive copies on every read of `raw_df` / `chdis_df` /
   `cap_df` / `dqdv_df`. Code that previously relied on mutating
@@ -315,6 +325,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#86]: https://github.com/tomooki/toyo-battery/pull/86
 [#88]: https://github.com/tomooki/toyo-battery/pull/88
 [#93]: https://github.com/tomooki/toyo-battery/issues/93
+[#94]: https://github.com/tomooki/toyo-battery/issues/94
 [#95]: https://github.com/tomooki/toyo-battery/issues/95
 [#98]: https://github.com/tomooki/toyo-battery/issues/98
 [#99]: https://github.com/tomooki/toyo-battery/issues/99

--- a/src/echemplot/core/chdis.py
+++ b/src/echemplot/core/chdis.py
@@ -46,11 +46,12 @@ import warnings
 import pandas as pd
 
 from echemplot.core import DataIntegrityWarning
-from echemplot.io.schema import JA_COLS, JA_TO_EN, ColumnLang
+from echemplot.io.schema import JA_COLS, JA_TO_EN, STATE_JA_TO_EN, ColumnLang
 
-_CHARGE = "充電"
-_DISCHARGE = "放電"
-_STATE_TO_SIDE = {_CHARGE: "ch", _DISCHARGE: "dis"}
+_CHARGE_JA = "充電"
+_DISCHARGE_JA = "放電"
+_CHARGE_EN = STATE_JA_TO_EN[_CHARGE_JA]
+_DISCHARGE_EN = STATE_JA_TO_EN[_DISCHARGE_JA]
 
 _NEEDED_KEYS = ("cycle", "state", "voltage", "capacity")
 
@@ -59,6 +60,19 @@ def _resolve_cols(column_lang: ColumnLang) -> dict[str, str]:
     if column_lang == "ja":
         return {k: JA_COLS[k] for k in _NEEDED_KEYS}
     return {k: JA_TO_EN[JA_COLS[k]] for k in _NEEDED_KEYS}
+
+
+def _resolve_states(column_lang: ColumnLang) -> tuple[str, str, dict[str, str]]:
+    """Return (charge, discharge, side_map) labels for the active language.
+
+    The reader translates state values when ``column_lang='en'``, so
+    chdis must filter on EN literals in EN mode. ``side_map`` keys are the
+    state literals; values are the canonical "ch"/"dis" side codes used in
+    the output MultiIndex.
+    """
+    if column_lang == "ja":
+        return _CHARGE_JA, _DISCHARGE_JA, {_CHARGE_JA: "ch", _DISCHARGE_JA: "dis"}
+    return _CHARGE_EN, _DISCHARGE_EN, {_CHARGE_EN: "ch", _DISCHARGE_EN: "dis"}
 
 
 def _empty_result() -> pd.DataFrame:
@@ -74,8 +88,11 @@ def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.Data
     df
         Output of :func:`echemplot.io.reader.read_cell_dir`. Must contain
         サイクル/状態/電圧/電気量 columns (or their EN equivalents when
-        ``column_lang="en"``). ``状態`` cell values are always JA
-        (``充電``/``放電``/``休止``) regardless of ``column_lang``.
+        ``column_lang="en"``). ``状態`` cell values follow ``column_lang``:
+        JA literals (``充電``/``放電``/``休止``/``充電休止``/``放電休止``/
+        ``中断``) when ``column_lang='ja'``, EN equivalents (``charge``/
+        ``discharge``/``rest``/``charge_rest``/``discharge_rest``/``abort``)
+        when ``column_lang='en'``.
     column_lang
         Language of the input column names and the ``quantity`` level of
         the returned MultiIndex.
@@ -108,23 +125,28 @@ def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.Data
         cols["cycle"],
         cols["state"],
     )
+    charge_lbl, discharge_lbl, state_to_side = _resolve_states(column_lang)
 
-    working = df.loc[df[state_col].isin([_CHARGE, _DISCHARGE])].reset_index(drop=True)
+    working = df.loc[df[state_col].isin([charge_lbl, discharge_lbl])].reset_index(drop=True)
     if working.empty:
         return _empty_result()
 
     first_cycle = working[cycle_col].min()
     first_state = working.loc[working[cycle_col] == first_cycle, state_col].iloc[0]
-    if first_state == _DISCHARGE:
+    if first_state == discharge_lbl:
         working = working.assign(
-            **{state_col: working[state_col].map({_CHARGE: _DISCHARGE, _DISCHARGE: _CHARGE})}
+            **{
+                state_col: working[state_col].map(
+                    {charge_lbl: discharge_lbl, discharge_lbl: charge_lbl}
+                )
+            }
         )
 
     pieces: dict[tuple[int, str], pd.DataFrame] = {}
     total_dropped = 0
     segments_with_drops = 0
     for (cycle_val, state_val), g in working.groupby([cycle_col, state_col], sort=True):
-        side = _STATE_TO_SIDE[str(state_val)]
+        side = state_to_side[str(state_val)]
         # Drop rows whose |電気量| falls below the segment's running maximum.
         # Local diff()<0 was insufficient: in raw-6-digit data 経過時間[Sec]
         # resets at CC→CV sub-step boundaries (not just state boundaries),

--- a/src/echemplot/io/reader.py
+++ b/src/echemplot/io/reader.py
@@ -21,9 +21,11 @@ any extra source columns such as 経過時間[Sec] / 電流[mA] / 日付 / 時�
                                  row, sometimes with non-zero 経過時間/電流.)
       - 連続データ_py.csv:       whatever was persisted (usually the 3-value set)
 
-When ``column_lang="en"`` is requested, only column *names* are translated.
-状態 cell values stay JP — translate via ``schema.STATE_JA_TO_EN`` downstream
-if needed.
+When ``column_lang="en"`` is requested, both column *names* and 状態 cell
+values are translated. State values are mapped via ``schema.STATE_JA_TO_EN``
+(e.g. ``充電休止`` → ``charge_rest``) so EN-mode consumers receive a fully
+EN frame. Unknown JA-string state literals raise ``ValueError`` regardless
+of ``column_lang`` — same strictness as the unknown-numeric-state branch.
 
 The active-material mass (grams) is resolved in this priority order:
 
@@ -60,6 +62,7 @@ from echemplot.io.schema import (
     COL_ELAPSED_S,
     JA_TO_EN,
     STATE_CODE_TO_JA,
+    STATE_JA_TO_EN,
     ColumnLang,
 )
 
@@ -314,6 +317,8 @@ def _finalize(df: pd.DataFrame, column_lang: ColumnLang) -> pd.DataFrame:
             len(dropped),
             dropped,
         )
+    # Step 1: numeric → JA. Both branches (numeric source and already-JA
+    # string source) converge on a JA-string 状態 column before validation.
     if pd.api.types.is_numeric_dtype(out["状態"]):
         mapped = out["状態"].map(STATE_CODE_TO_JA)
         unmapped_mask = mapped.isna() & out["状態"].notna()
@@ -329,8 +334,33 @@ def _finalize(df: pd.DataFrame, column_lang: ColumnLang) -> pd.DataFrame:
                 "with a sample file."
             )
         out["状態"] = mapped
+    # Step 2: validate JA-string 状態 strictly. The numeric branch is
+    # already exhaustive (mapped values are by definition in
+    # STATE_CODE_TO_JA's value set, all of which are STATE_JA_TO_EN keys);
+    # this guard primarily catches unknown literals from native
+    # 連続データ.csv / 連続データ_py.csv sources that were never mapped
+    # through STATE_CODE_TO_JA.
+    state_notna = out["状態"].notna()
+    unknown_mask = state_notna & ~out["状態"].isin(STATE_JA_TO_EN)
+    if unknown_mask.any():
+        bad_labels = sorted(out.loc[unknown_mask, "状態"].unique().tolist())
+        first_bad_idx = int(out.index[unknown_mask][0])
+        raise ValueError(
+            f"unknown 状態 labels in source: {bad_labels} "
+            f"(known labels: {sorted(STATE_JA_TO_EN)}); "
+            f"first seen at row {first_bad_idx}. If this is a TOYO "
+            "label we have not yet catalogued, please file an issue at "
+            "https://github.com/tomooki/toyo-battery/issues "
+            "with a sample file."
+        )
     out = out.reset_index(drop=True)
+    # Step 3: JA → EN translation when requested. Column names always
+    # translate; state values translate so EN-mode callers receive a fully
+    # EN frame. NaN rows are preserved by ``Series.map`` (na_action='ignore'
+    # default in modern pandas, but we pass it explicitly via the dict
+    # which leaves missing values untouched).
     if column_lang == "en":
+        out["状態"] = out["状態"].map(lambda v: STATE_JA_TO_EN[v] if pd.notna(v) else v)
         out = out.rename(columns={c: JA_TO_EN.get(c, c) for c in out.columns})
     return cast("pd.DataFrame", out)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,39 @@ def _write_raw_6digit(
     )
 
 
+def write_renzoku_with_states(
+    cell_dir: Path,
+    *,
+    rows: list[tuple[int, str, str, float, float]],
+    mass_g: float = _DEFAULT_MASS_G,
+) -> None:
+    """Write a native ``連続データ.csv`` with caller-supplied state literals.
+
+    Mirrors :func:`_write_renzoku`'s 7-row header but lets each test pin
+    the exact 状態 string per row — useful for exercising substate
+    coverage (``充電休止``/``放電休止``) and unknown-label rejection in
+    :func:`echemplot.io.reader._finalize`.
+
+    Parameters
+    ----------
+    rows
+        ``[(cycle, mode, state_ja, voltage, capacity), ...]``.
+    """
+    mass_mg = mass_g * 1e3
+    lines = [
+        ",試験名,C:¥synthetic¥test¥path,,,,開始日時,2026-01-01 00:00:00",
+        ",測定備考,",
+        f",重量[mg],{mass_mg:.3f}",
+        "サイクル,モード,状態,電圧,電気量",
+        "1ch,1ch,1ch,1ch,1ch",
+        "-,-,-,-,-",
+        "[],[],[],[V],[mAh/g]",
+    ]
+    for cycle, mode, state_ja, voltage, capacity in rows:
+        lines.append(f"{cycle},{mode},{state_ja},{voltage:.4f},{capacity:.6f}")
+    (cell_dir / "連続データ.csv").write_text("\n".join(lines) + "\n", encoding="shift_jis")
+
+
 def write_ptn_main(
     path: Path,
     *,

--- a/tests/test_chdis.py
+++ b/tests/test_chdis.py
@@ -147,12 +147,20 @@ def test_multi_cycle_multiindex_shape() -> None:
 
 
 def test_column_lang_en() -> None:
+    """EN-mode input carries EN state values (``charge``/``discharge``).
+
+    The reader translates state values when ``column_lang='en'`` is
+    requested (issue #94), so chdis must filter on EN literals in EN
+    mode. Passing JA state values with EN columns (the legacy behavior)
+    is no longer supported — see ``test_en_mode_filters_on_en_state_labels``
+    below for the active EN contract.
+    """
     df = _raw(
         [
-            (1, "充電", 3.50, 0.0),
-            (1, "充電", 3.60, 500.0),
-            (1, "放電", 3.60, 0.0),
-            (1, "放電", 3.40, 500.0),
+            (1, "charge", 3.50, 0.0),
+            (1, "charge", 3.60, 500.0),
+            (1, "discharge", 3.60, 0.0),
+            (1, "discharge", 3.40, 500.0),
         ],
         lang="en",
     )
@@ -160,6 +168,27 @@ def test_column_lang_en() -> None:
     assert set(out.columns.get_level_values("quantity")) == {"capacity", "voltage"}
     assert (1, "ch", "capacity") in out.columns
     assert out[(1, "dis", "voltage")].dropna().tolist() == [3.60, 3.40]
+
+
+def test_en_mode_filters_on_en_state_labels() -> None:
+    """In EN mode, chdis filters on ``charge``/``discharge`` and ignores
+    ``rest``/``charge_rest``/``discharge_rest``/``abort`` rows, mirroring
+    the JA-mode 充電/放電 filter."""
+    df = _raw(
+        [
+            (1, "charge", 3.50, 0.0),
+            (1, "charge", 3.60, 500.0),
+            (1, "charge_rest", 3.61, 500.0),
+            (1, "discharge", 3.60, 0.0),
+            (1, "discharge", 3.40, 500.0),
+            (1, "discharge_rest", 3.40, 500.0),
+            (1, "abort", 3.40, 500.0),
+        ],
+        lang="en",
+    )
+    out = get_chdis_df(df, column_lang="en")
+    assert out[(1, "ch", "capacity")].notna().sum() == 2
+    assert out[(1, "dis", "capacity")].notna().sum() == 2
 
 
 def test_empty_frame_returns_empty_multiindex() -> None:

--- a/tests/test_dqdv.py
+++ b/tests/test_dqdv.py
@@ -29,12 +29,14 @@ def _linear_chdis_ch_only(
     """
     v = np.linspace(v_lo, v_hi, n_points)
     q = slope * (v - v_lo)
-    rows = [(1, "充電", float(vi), float(qi)) for vi, qi in zip(v, q)]
     if lang == "ja":
+        state = "充電"
         columns = ["サイクル", "状態", "電圧", "電気量"]
     else:
+        # EN-mode chdis filters on EN state literals (issue #94).
+        state = "charge"
         columns = ["cycle", "state", "voltage", "capacity"]
-        # Even with EN column frame, chdis expects JA state strings.
+    rows = [(1, state, float(vi), float(qi)) for vi, qi in zip(v, q)]
     return pd.DataFrame(rows, columns=columns)
 
 

--- a/tests/test_matplotlib_backend.py
+++ b/tests/test_matplotlib_backend.py
@@ -85,13 +85,16 @@ def _linear_cell(
     q_ch = 400.0 * (v_ch - v_lo)
     v_dis = np.linspace(v_hi, v_lo, n_points)
     q_dis = 400.0 * (v_hi - v_dis)
-    for cycle in range(1, n_cycles + 1):
-        rows += [(cycle, "1", "充電", float(vi), float(qi)) for vi, qi in zip(v_ch, q_ch)]
-        rows += [(cycle, "1", "放電", float(vi), float(qi)) for vi, qi in zip(v_dis, q_dis)]
     if column_lang == "ja":
+        charge_lbl, discharge_lbl = "充電", "放電"
         columns = ["サイクル", "モード", "状態", "電圧", "電気量"]
     else:
+        # EN-mode chdis filters on EN state literals (issue #94).
+        charge_lbl, discharge_lbl = "charge", "discharge"
         columns = ["cycle", "mode", "state", "voltage", "capacity"]
+    for cycle in range(1, n_cycles + 1):
+        rows += [(cycle, "1", charge_lbl, float(vi), float(qi)) for vi, qi in zip(v_ch, q_ch)]
+        rows += [(cycle, "1", discharge_lbl, float(vi), float(qi)) for vi, qi in zip(v_dis, q_dis)]
     raw = pd.DataFrame(rows, columns=columns)
     return Cell(name=name, mass_g=0.001, raw_df=raw, column_lang=column_lang)
 

--- a/tests/test_plotly_backend.py
+++ b/tests/test_plotly_backend.py
@@ -49,13 +49,16 @@ def _linear_cell(
     q_ch = 400.0 * (v_ch - v_lo)
     v_dis = np.linspace(v_hi, v_lo, n_points)
     q_dis = 400.0 * (v_hi - v_dis)
-    for cycle in range(1, n_cycles + 1):
-        rows += [(cycle, "1", "充電", float(vi), float(qi)) for vi, qi in zip(v_ch, q_ch)]
-        rows += [(cycle, "1", "放電", float(vi), float(qi)) for vi, qi in zip(v_dis, q_dis)]
     if column_lang == "ja":
+        charge_lbl, discharge_lbl = "充電", "放電"
         columns = ["サイクル", "モード", "状態", "電圧", "電気量"]
     else:
+        # EN-mode chdis filters on EN state literals (issue #94).
+        charge_lbl, discharge_lbl = "charge", "discharge"
         columns = ["cycle", "mode", "state", "voltage", "capacity"]
+    for cycle in range(1, n_cycles + 1):
+        rows += [(cycle, "1", charge_lbl, float(vi), float(qi)) for vi, qi in zip(v_ch, q_ch)]
+        rows += [(cycle, "1", discharge_lbl, float(vi), float(qi)) for vi, qi in zip(v_dis, q_dis)]
     raw = pd.DataFrame(rows, columns=columns)
     return Cell(name=name, mass_g=0.001, raw_df=raw, column_lang=column_lang)
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -514,9 +514,82 @@ def test_column_lang_en(make_cell_dir: Callable[..., Path]) -> None:
     # extras translated via schema.JA_TO_EN
     assert "elapsed_time_s" in df.columns
     assert "current_ma" in df.columns
-    # state values are NOT translated here — that is schema.STATE_JA_TO_EN's job
-    # when needed by downstream consumers
-    assert set(df["state"].unique()) <= {"休止", "充電", "放電"}
+    # State values are translated to EN (issue #94) so EN-mode consumers
+    # receive a fully EN frame.
+    assert set(df["state"].unique()) <= {"rest", "charge", "discharge"}
+
+
+def test_finalize_translates_state_values_when_lang_en(tmp_path: Path) -> None:
+    """Native 連続データ.csv state literals translate to EN when requested.
+
+    Pins the issue #94 contract: the reader maps every JA literal in the
+    extended STATE_JA_TO_EN set (including 充電休止/放電休止 substates) to
+    its EN equivalent.
+    """
+    from tests.conftest import write_renzoku_with_states
+
+    d = tmp_path / "cell"
+    d.mkdir()
+    write_renzoku_with_states(
+        d,
+        rows=[
+            (1, "1", "充電", 3.50, 0.0),
+            (1, "1", "充電休止", 3.60, 100.0),
+            (1, "1", "放電", 3.55, 0.0),
+            (1, "1", "放電休止", 3.40, 50.0),
+            (1, "1", "中断", 3.40, 50.0),
+        ],
+    )
+    df, _ = read_cell_dir(d, column_lang="en")
+    assert df["state"].tolist() == [
+        "charge",
+        "charge_rest",
+        "discharge",
+        "discharge_rest",
+        "abort",
+    ]
+
+
+def test_finalize_raises_on_unknown_ja_state_string(tmp_path: Path) -> None:
+    """An unrecognized JA state literal (e.g. ``予期しない``) must raise.
+
+    Mirrors the strictness already enforced for unknown numeric state
+    codes — closing the asymmetry called out in issue #94.
+    """
+    from tests.conftest import write_renzoku_with_states
+
+    d = tmp_path / "cell"
+    d.mkdir()
+    write_renzoku_with_states(
+        d,
+        rows=[
+            (1, "1", "充電", 3.50, 0.0),
+            (1, "1", "予期しない", 3.55, 50.0),
+        ],
+    )
+    with pytest.raises(ValueError, match=r"unknown 状態 labels.*予期しない"):
+        read_cell_dir(d)
+
+
+def test_finalize_passes_charge_rest_through_unchanged_when_lang_ja(tmp_path: Path) -> None:
+    """In JA mode, native 充電休止/放電休止 substate labels must round-trip
+    untranslated. Belt-and-suspenders against the new validation step
+    accidentally normalizing JA literals."""
+    from tests.conftest import write_renzoku_with_states
+
+    d = tmp_path / "cell"
+    d.mkdir()
+    write_renzoku_with_states(
+        d,
+        rows=[
+            (1, "1", "充電", 3.50, 0.0),
+            (1, "1", "充電休止", 3.60, 100.0),
+            (1, "1", "放電", 3.55, 0.0),
+            (1, "1", "放電休止", 3.40, 50.0),
+        ],
+    )
+    df, _ = read_cell_dir(d, column_lang="ja")
+    assert df["状態"].tolist() == ["充電", "充電休止", "放電", "放電休止"]
 
 
 # ---- Cell.from_dir wiring -----------------------------------------------

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -437,11 +437,13 @@ def test_column_lang_en_input_produces_english_output() -> None:
     schema is EN-fixed regardless, so the column list is identical to the
     JA-input case.
     """
+    # EN-mode chdis filters on EN state literals (issue #94), so this
+    # frame uses ``charge``/``discharge`` to match its EN column names.
     rows = [
-        (1, "1", "充電", 3.0, 0.0),
-        (1, "1", "充電", 4.2, 1000.0),
-        (1, "1", "放電", 4.2, 0.0),
-        (1, "1", "放電", 3.0, 990.0),
+        (1, "1", "charge", 3.0, 0.0),
+        (1, "1", "charge", 4.2, 1000.0),
+        (1, "1", "discharge", 4.2, 0.0),
+        (1, "1", "discharge", 3.0, 990.0),
     ]
     raw = pd.DataFrame(rows, columns=["cycle", "mode", "state", "voltage", "capacity"])
     cell = Cell(name="en_cell", mass_g=0.001, raw_df=raw, column_lang="en")


### PR DESCRIPTION
Closes #94

## Summary

`io/reader.py:_finalize` was asymmetric — it raised on unknown numeric state codes but let unknown JA-string state literals pass through. When `column_lang='en'` was requested, column names were translated but state values stayed JA, leaving EN-mode consumers with a hybrid frame.

This PR:
- Adds strict JA-string validation against the 6-entry `STATE_JA_TO_EN` set (`休止`/`充電`/`放電`/`中断`/`充電休止`/`放電休止`); unknown labels raise `ValueError` listing the offending values and the first-seen row index.
- Translates state values to EN when `column_lang='en'` (e.g. `充電休止` → `charge_rest`), preserving `NaN` rows.
- Pipeline order: numeric → JA, JA validation, JA → EN (if requested).
- Makes `get_chdis_df` language-aware: in EN mode it filters on `charge`/`discharge` to match the new EN-mode reader contract.

## Breaking change

This is a behavior change for two scenarios:

1. **Unknown JA-string states now raise.** Sources that previously silently passed unrecognized 状態 literals (e.g. typos, future TOYO labels not yet catalogued) now raise `ValueError`. Same strictness as the existing numeric-code branch.
2. **EN-mode state values are now translated.** `read_cell_dir(..., column_lang='en')` now returns a frame whose `state` column contains `charge`/`discharge`/`rest`/`charge_rest`/`discharge_rest`/`abort` instead of the JA literals. Callers passing JA states with EN columns to `get_chdis_df(column_lang='en')` (the legacy mixed shape) must either route through the reader (which translates), pass EN states, or call with `column_lang='ja'`.

The `Cell` flow is unaffected — it constructs from a frame produced by the reader so the language is consistent end-to-end.

## Files modified

- `src/echemplot/io/reader.py` — `_finalize` validation + EN translation; module docstring updated.
- `src/echemplot/core/chdis.py` — language-aware state filter; docstring updated to reflect the new state-value contract.
- `tests/conftest.py` — new `write_renzoku_with_states` helper for synthesizing native CSVs with arbitrary state literals.
- `tests/test_reader.py` — three new tests: EN translation, unknown JA-state rejection, JA-mode 充電休止/放電休止 pass-through.
- `tests/test_chdis.py` — new EN-mode filter test; updated `test_column_lang_en` to use EN states.
- `tests/test_dqdv.py`, `tests/test_matplotlib_backend.py`, `tests/test_stats.py` — updated EN-mode synthetic fixtures to use EN state literals (legacy mixed shape no longer supported).
- `CHANGELOG.md` — Breaking-change entry under `[Unreleased]`.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy` — clean
- [x] `uv run pytest --cov=echemplot --cov-report=term-missing` — 237 passed, 2 skipped (CLI/Plotly extras unavailable in worktree). Coverage 75% (chdis.py 100%, reader.py 95%); non-decreasing vs. main.
- [x] New tests cover the three new code paths (EN translation, unknown-JA rejection, JA pass-through) and EN-mode chdis filter.
- [ ] CI (lint + types on 3.12, tests on 3.9-3.12 × ubuntu/windows, pure-Python wheel build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)