### PR TITLE
refactor(io): content-based header detection for 連続データ.csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   columns don't match the expected `[cycle, q_ch, q_dis, ce]` shape.
   Future `cap_df` reorderings now fail loudly instead of silently
   binding wrong columns. ([#100])
+- `_read_renzoku_data` now finds the column-header row by content (first
+  cell == `サイクル`) instead of hardcoded `header=3, skiprows=[4,5,6]`.
+  Falls back to the legacy positional skip with a `logger.warning` if
+  the header isn't found in the first 20 lines, so existing TOYO output
+  is unaffected. ([#101])
 - Consolidated the per-module `_JA_COLS` / `_QUANTITY_KEYS_*` mappings
   duplicated across `core.chdis` / `core.capacity` / `core.dqdv` /
   `core.stats` / `plotting.matplotlib_backend` / `plotting.plotly_backend`
@@ -336,6 +341,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#98]: https://github.com/tomooki/toyo-battery/issues/98
 [#99]: https://github.com/tomooki/toyo-battery/issues/99
 [#100]: https://github.com/tomooki/toyo-battery/issues/100
+[#101]: https://github.com/tomooki/toyo-battery/issues/101
 [#103]: https://github.com/tomooki/toyo-battery/issues/103
 [#104]: https://github.com/tomooki/toyo-battery/issues/104
 [#107]: https://github.com/tomooki/toyo-battery/pull/107

--- a/src/echemplot/io/reader.py
+++ b/src/echemplot/io/reader.py
@@ -2,9 +2,13 @@
 
 Discovery priority for a given cell directory ``path``:
 
-1. ``連続データ.csv``              — native export from the tester
-   (7-line header: 3 metadata rows, then column-name row, channel row,
-   separator row, units row; ``header=3, skiprows=[4,5,6]``)
+1. ``連続データ.csv``              — native export from the tester.
+   Real TOYO firmware emits a 7-line preamble: 3 metadata rows, then
+   column-name row, channel row, separator row, units row (so historically
+   ``header=3, skiprows=[4,5,6]``). The reader now finds the column-name
+   row by content (first cell == ``サイクル``) so an extra/missing
+   metadata row in a future firmware revision does not silently shift the
+   header. See :func:`_detect_renzoku_header`.
 2. ``連続データ_py.csv``           — already-normalized output from a previous run
 3. 6-digit raw file(s) + ``*.PTN`` — factory raw; 電気量 is computed from mass
 
@@ -72,6 +76,33 @@ RAW_FILENAME_RE = re.compile(r"[0-9]{6}")
 PTN_SUFFIX = ".ptn"  # matched case-insensitively (Linux CI is case-sensitive)
 RENZOKU_DATA = "連続データ.csv"
 RENZOKU_DATA_PY = "連続データ_py.csv"
+
+# Number of leading lines to scan when looking for the column-header row in
+# 連続データ.csv. Real TOYO firmware ships with the header at line index 3
+# (3 metadata rows above it); the scan window is sized to absorb a small
+# amount of future drift (extra metadata rows, optional summary lines)
+# while still failing fast on a totally unexpected file.
+_HEADER_SCAN_ROWS = 20
+
+# Legacy positional layout used as a fallback when content-based detection
+# cannot find the header row in the first ``_HEADER_SCAN_ROWS`` lines.
+_LEGACY_HEADER_ROW = 3
+_LEGACY_SKIPROWS = [4, 5, 6]
+
+# First-cell literals identifying the header row of 連続データ.csv. The
+# native export uses the JP literal; the EN form is only present if a user
+# has manually pre-renamed columns, but is cheap to also accept here.
+_HEADER_FIRST_CELL_CANDIDATES: tuple[str, ...] = ("サイクル", "cycle")
+
+# Patterns that mark a row immediately following the header as a unit /
+# channel-id / separator metadata row rather than a data row. We strip the
+# header-following rows greedily until the first row whose first cell parses
+# as a numeric cycle index (a plausible data row).
+_UNIT_ROW_FIRST_CELL_PATTERNS = (
+    re.compile(r"^\[.*\]$"),  # e.g. "[V]", "[mAh/g]"
+    re.compile(r"^-+$"),  # e.g. "-" separator row
+    re.compile(r"^\d+\s*ch$", re.IGNORECASE),  # channel id e.g. "1ch"
+)
 
 # Half-width → full-width canonical rename. The raw 6-digit header row uses
 # half-width katakana for the cycle/mode columns.
@@ -191,10 +222,81 @@ def read_cell_dir(
 def _read_renzoku_data(
     path: Path, mass: float | None, encoding: str, column_lang: ColumnLang
 ) -> pd.DataFrame:
-    df = pd.read_csv(path, header=3, skiprows=[4, 5, 6], encoding=encoding)
+    header_row, skiprows = _detect_renzoku_header(path, encoding)
+    df = pd.read_csv(path, header=header_row, skiprows=skiprows, encoding=encoding)
     df = _clean_columns(df)
     df = _ensure_capacity(df, mass)
     return _finalize(df, column_lang)
+
+
+def _detect_renzoku_header(path: Path, encoding: str) -> tuple[int, list[int]]:
+    """Find the column-header row of 連続データ.csv by content.
+
+    Reads the first :data:`_HEADER_SCAN_ROWS` lines and locates the row
+    whose first non-empty cell matches one of
+    :data:`_HEADER_FIRST_CELL_CANDIDATES` (``サイクル`` for the native JP
+    export; ``cycle`` accepted defensively for hand-renamed sources).
+    Returns ``(header_row, skiprows)`` where ``skiprows`` lists the
+    contiguous unit / channel-id / separator rows that immediately follow
+    the header and should be skipped before the first data row.
+
+    On detection failure (no candidate row in the scan window) emits a
+    ``logger.warning`` and falls back to the historical fixed layout
+    ``(3, [4, 5, 6])``, preserving behaviour on every TOYO file shipped
+    so far while leaving the failure visible in the log stream.
+    """
+    with path.open(encoding=encoding, errors="replace") as f:
+        lines = [f.readline() for _ in range(_HEADER_SCAN_ROWS)]
+    rows: list[list[str]] = [
+        [cell.strip() for cell in line.rstrip("\r\n").split(",")] for line in lines if line
+    ]
+
+    header_row: int | None = None
+    for i, fields in enumerate(rows):
+        first = next((c for c in fields if c), "")
+        # Strip a possible BOM the same way ``_clean_columns`` does, so an
+        # Excel-saved file whose first cell starts with U+FEFF still matches.
+        first = first.replace("﻿", "")
+        if first in _HEADER_FIRST_CELL_CANDIDATES:
+            header_row = i
+            break
+
+    if header_row is None:
+        logger.warning(
+            "could not detect header row in %s, falling back to legacy positional skip",
+            path,
+        )
+        return _LEGACY_HEADER_ROW, list(_LEGACY_SKIPROWS)
+
+    skiprows: list[int] = []
+    for j in range(header_row + 1, len(rows)):
+        first = next((c for c in rows[j] if c), "")
+        if _looks_like_unit_row(first):
+            skiprows.append(j)
+            continue
+        # First plausible data row: stop greedy unit-row consumption.
+        break
+    return header_row, skiprows
+
+
+def _looks_like_unit_row(first_cell: str) -> bool:
+    """Return ``True`` if ``first_cell`` looks like a unit / separator row.
+
+    A row whose first non-empty cell parses as a number is considered a
+    data row and is *not* skipped. Anything matching the unit / channel-id
+    / separator patterns in :data:`_UNIT_ROW_FIRST_CELL_PATTERNS` is.
+    """
+    if not first_cell:
+        # An entirely blank row immediately after the header is treated as
+        # a separator and skipped.
+        return True
+    try:
+        float(first_cell)
+    except ValueError:
+        pass
+    else:
+        return False
+    return any(p.match(first_cell) for p in _UNIT_ROW_FIRST_CELL_PATTERNS)
 
 
 def _read_renzoku_data_py(path: Path, encoding: str, column_lang: ColumnLang) -> pd.DataFrame:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,11 +55,12 @@ def make_cell_dir(tmp_path: Path) -> Callable[..., Path]:
         name: str = "cell_A",
         mass: float = _DEFAULT_MASS_G,
         ptn_dialect: PtnDialect = "concat",
+        n_metadata_rows: int = 3,
     ) -> Path:
         d = tmp_path / name
         d.mkdir()
         if layout == "renzoku":
-            _write_renzoku(d, mass_g=mass)
+            _write_renzoku(d, mass_g=mass, n_metadata_rows=n_metadata_rows)
         elif layout == "renzoku_py":
             _write_renzoku_py(d)
         elif layout == "raw_6digit":
@@ -71,7 +72,33 @@ def make_cell_dir(tmp_path: Path) -> Callable[..., Path]:
     return _make
 
 
-def _write_renzoku(cell_dir: Path, *, mass_g: float) -> None:
+def _build_renzoku_metadata(n_metadata_rows: int, mass_mg: float) -> list[str]:
+    """Build the metadata block for the synthetic 連続データ.csv.
+
+    The mass row is always included (so the reader can resolve mass without
+    needing a .PTN); extra rows are filler ``,メモ<i>,`` lines that look
+    like the genuine product's free-form remarks. ``n_metadata_rows=0``
+    yields an empty block — the header lands at row 0.
+    """
+    if n_metadata_rows < 0:
+        raise ValueError(f"n_metadata_rows must be >= 0, got {n_metadata_rows}")
+    base = [
+        ",試験名,C:¥synthetic¥test¥path,,,,開始日時,2026-01-01 00:00:00",
+        ",測定備考,",
+        f",重量[mg],{mass_mg:.3f}",
+    ]
+    if n_metadata_rows <= len(base):
+        return base[:n_metadata_rows]
+    extras = [f",メモ{i},comment-{i}" for i in range(n_metadata_rows - len(base))]
+    return [*base, *extras]
+
+
+def _write_renzoku(
+    cell_dir: Path,
+    *,
+    mass_g: float,
+    n_metadata_rows: int = 3,
+) -> None:
     """Write a native-format 連続データ.csv.
 
     Real format:
@@ -84,12 +111,17 @@ def _write_renzoku(cell_dir: Path, *, mass_g: float) -> None:
       - Row 6: units (``[],[],[],[V],[mAh/g]``)
       - Row 7+: data rows with state as JP strings including
         ``充電休止``/``放電休止`` substates and pre-computed 電気量.
+
+    The ``n_metadata_rows`` knob lets tests exercise hypothetical TOYO
+    firmware layouts that drift from the historical 3-row preamble. The
+    mass row stays inside the metadata block (so the reader's metadata
+    scan still finds it); extra padding rows are inserted before/after as
+    needed.
     """
     mass_mg = mass_g * 1e3
+    metadata_lines = _build_renzoku_metadata(n_metadata_rows, mass_mg)
     lines = [
-        ",試験名,C:¥synthetic¥test¥path,,,,開始日時,2026-01-01 00:00:00",
-        ",測定備考,",
-        f",重量[mg],{mass_mg:.3f}",
+        *metadata_lines,
         "サイクル,モード,状態,電圧,電気量",
         "1ch,1ch,1ch,1ch,1ch",
         "-,-,-,-,-",

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 from pathlib import Path
 from typing import Callable
@@ -79,6 +80,84 @@ def test_read_renzoku_falls_back_to_ptn_when_metadata_missing(tmp_path: Path) ->
     _write_fixed_column_ptn(d / "pattern.PTN", 0.004)
     _, mass_g = read_cell_dir(d)
     assert mass_g == pytest.approx(0.004)
+
+
+# ---- renzoku header detection (issue #101) -------------------------------
+
+
+def test_read_renzoku_data_detects_header_at_default_position(
+    make_cell_dir: Callable[..., Path],
+) -> None:
+    """Default fixture (3 metadata rows, header at row 3) parses cleanly.
+
+    Sanity-anchors the existing-behaviour-unchanged contract from issue
+    #101: content-based detection must produce the same output as the
+    historical ``header=3, skiprows=[4,5,6]`` positional skip on every
+    file the reader has ever supported.
+    """
+    d = make_cell_dir("renzoku", mass=0.001)
+    df, mass_g = read_cell_dir(d)
+    assert list(df.columns) == list(CANONICAL_COLUMNS_JA)
+    assert len(df) == 5
+    assert df["電気量"].tolist() == pytest.approx([0.0, 1000.0, 0.0, 0.0, 1000.0])
+    assert mass_g == pytest.approx(0.001)
+
+
+def test_read_renzoku_data_detects_header_with_extra_metadata_row(
+    make_cell_dir: Callable[..., Path],
+) -> None:
+    """A future TOYO firmware shipping 4 metadata rows (header at row 4)
+    must still be parsed correctly thanks to content-based detection."""
+    d = make_cell_dir("renzoku", mass=0.001, n_metadata_rows=4)
+    df, mass_g = read_cell_dir(d)
+    assert list(df.columns) == list(CANONICAL_COLUMNS_JA)
+    assert len(df) == 5
+    assert df["電気量"].tolist() == pytest.approx([0.0, 1000.0, 0.0, 0.0, 1000.0])
+    # Mass row is still inside the metadata-scan window (row index 2).
+    assert mass_g == pytest.approx(0.001)
+
+
+def test_read_renzoku_data_detects_header_with_fewer_metadata_rows(
+    make_cell_dir: Callable[..., Path],
+) -> None:
+    """A hypothetical layout with only 2 metadata rows (header at row 2)
+    must also parse. The 重量[mg] row is dropped from this fixture, so
+    mass falls through to NaN — the parse itself is what we assert."""
+    d = make_cell_dir("renzoku", mass=0.001, n_metadata_rows=2)
+    df, _ = read_cell_dir(d)
+    assert list(df.columns) == list(CANONICAL_COLUMNS_JA)
+    assert len(df) == 5
+    assert df["電気量"].tolist() == pytest.approx([0.0, 1000.0, 0.0, 0.0, 1000.0])
+
+
+def test_read_renzoku_data_falls_back_with_warning_on_no_detection(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No row in the first 20 lines starts with サイクル → reader emits
+    a logger.warning and falls back to the legacy positional skip.
+
+    The fallback layout (``header=3, skiprows=[4,5,6]``) is unlikely to
+    parse the synthetic worst-case file into a canonical schema, so we
+    expect a downstream ``ValueError`` from ``_finalize`` after the
+    warning fires. The contract under test is: warning emitted +
+    fallback attempted, not "fallback succeeds" — the latter would
+    require a file whose first 20 lines bury the header but whose
+    line-3 happens to look canonical, which is contrived."""
+    cell_dir = tmp_path / "no_header"
+    cell_dir.mkdir()
+    # 25 lines of random metadata-looking junk, no サイクル anywhere.
+    lines = [f",ﾒﾓ{i},junk-row-{i}" for i in range(25)]
+    (cell_dir / "連続データ.csv").write_text("\n".join(lines) + "\n", encoding="shift_jis")
+    with (
+        caplog.at_level(logging.WARNING, logger="echemplot.io.reader"),
+        pytest.raises(ValueError),
+    ):
+        read_cell_dir(cell_dir)
+    assert any(
+        "could not detect header row" in rec.message and rec.name == "echemplot.io.reader"
+        for rec in caplog.records
+    )
 
 
 # ---- renzoku_py (normalized output) path ----------------------------------


### PR DESCRIPTION
Closes #101

## Summary

`_read_renzoku_data` previously hardcoded `pd.read_csv(path, header=3, skiprows=[4, 5, 6], ...)`. If TOYO firmware ever ships a 連続データ.csv with a different metadata-row count, the reader would silently parse the wrong row as the header.

This PR replaces the positional skip with content-based detection:

- Scan the first 20 lines for a row whose first non-empty cell is `サイクル` (or, defensively, `cycle`); that row becomes the `header`.
- Greedily consume contiguous unit/channel-id/separator rows immediately below it (`[V]`, `[mAh/g]`, `-`, `1ch`, blank lines) as `skiprows` — stop at the first row whose first cell parses as a number (a plausible data row).
- On detection failure, emit `logger.warning("could not detect header row in %s, falling back to legacy positional skip", path)` and use the historical `(3, [4,5,6])` layout, so existing TOYO output is unaffected and the regression mode is visible in the log stream.

The public signature of `_read_renzoku_data` is unchanged; this is an internal robustness fix.

## Test plan

- [x] `test_read_renzoku_data_detects_header_at_default_position` — 3 metadata rows, header at row 3 (existing format), parses correctly.
- [x] `test_read_renzoku_data_detects_header_with_extra_metadata_row` — 4 metadata rows, header at row 4, parses correctly + mass still resolves from the metadata.
- [x] `test_read_renzoku_data_detects_header_with_fewer_metadata_rows` — 2 metadata rows, header at row 2, parses correctly.
- [x] `test_read_renzoku_data_falls_back_with_warning_on_no_detection` — synthetic worst-case file (25 junk lines, no `サイクル`); `caplog` confirms the warning fires; the legacy fallback is attempted and surfaces a downstream `ValueError` from `_finalize` (documented in the docstring).
- [x] All 37 pre-existing reader tests still green (default-layout sanity check is the explicit anchor).
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy` / `uv run pytest --cov=echemplot --cov-report=term-missing` all green; coverage non-decreasing (75% → 76%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)