### PR TITLE
refactor(origin): replace _CYCLE_COL_* positional indices with name-based contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#99])
 
 ### Changed
+- Replaced positional `_CYCLE_COL_*` integer indices in
+  `origin/_plots.py` with name-based column lookups, and added an
+  `OriginContractError` raised at worksheet-write time if `cap_df`
+  columns don't match the expected `[cycle, q_ch, q_dis, ce]` shape.
+  Future `cap_df` reorderings now fail loudly instead of silently
+  binding wrong columns. ([#100])
 - Consolidated the per-module `_JA_COLS` / `_QUANTITY_KEYS_*` mappings
   duplicated across `core.chdis` / `core.capacity` / `core.dqdv` /
   `core.stats` / `plotting.matplotlib_backend` / `plotting.plotly_backend`
@@ -318,6 +324,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#95]: https://github.com/tomooki/toyo-battery/issues/95
 [#98]: https://github.com/tomooki/toyo-battery/issues/98
 [#99]: https://github.com/tomooki/toyo-battery/issues/99
+[#100]: https://github.com/tomooki/toyo-battery/issues/100
 [#103]: https://github.com/tomooki/toyo-battery/issues/103
 [#104]: https://github.com/tomooki/toyo-battery/issues/104
 [#107]: https://github.com/tomooki/toyo-battery/pull/107

--- a/src/echemplot/origin/_plots.py
+++ b/src/echemplot/origin/_plots.py
@@ -69,6 +69,8 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from echemplot.origin._worksheets import _CYCLE_SHEET_COLUMNS
+
 _logger = logging.getLogger("echemplot.origin")
 
 # Exception types that the originpro attribute-API path is observed to raise
@@ -91,14 +93,6 @@ _AXIS_API_EXCEPTIONS: tuple[type[BaseException], ...] = (
 _TEMPLATE_CHDIS = "charge_discharge.otpu"
 _TEMPLATE_CYCLE = "cycle_efficiency.otpu"
 _TEMPLATE_DQDV = "dqdv.otpu"
-
-# Column indices for cap_df after reset_index(): [cycle, q_ch, q_dis, ce].
-# Pinned here so the cycle_efficiency bind is resilient to cap_df column
-# reorderings — a future refactor that changes the order must also touch
-# these constants (and would fail a focused test).
-_CYCLE_COL_CYCLE = 0
-_CYCLE_COL_QDIS = 2
-_CYCLE_COL_CE = 3
 
 _TEMPLATE_ENV_VAR = "ECHEMPLOT_ORIGIN_TEMPLATE_DIR"
 
@@ -162,8 +156,9 @@ def compute_global_ranges(cells: Sequence[Any]) -> _GraphRanges:
 
     The function walks every cell once and collects per-axis values from
     ``cell.chdis_df`` (even columns = capacity X, odd = voltage Y),
-    ``cell.cap_df`` (``[cycle, q_ch, q_dis, ce]`` with indices pinned by
-    ``_CYCLE_COL_*`` constants), and ``cell.dqdv_df`` (even columns =
+    ``cell.cap_df`` (resolved to ``[cycle, q_ch, q_dis, ce]`` after
+    ``reset_index()`` and looked up by name — see
+    :data:`_CYCLE_SHEET_COLUMNS`), and ``cell.dqdv_df`` (even columns =
     voltage X, odd = dQ/dV Y). Concatenated arrays are reduced by
     :func:`_safe_range` so empty / all-NaN inputs surface as ``None`` on
     the returned :class:`_GraphRanges` rather than raising.
@@ -171,6 +166,17 @@ def compute_global_ranges(cells: Sequence[Any]) -> _GraphRanges:
     When the input is a single cell, "global" and "that cell's range"
     coincide — the autoscale for a one-cell push is simply the cell's
     own data range.
+
+    Cells whose ``cap_df.reset_index()`` does not satisfy the
+    :data:`_CYCLE_SHEET_COLUMNS` contract are silently skipped for the
+    cycle_x / cycle_left_y / cycle_right_y aggregation here — the hard
+    failure is deferred to
+    :func:`echemplot.origin._worksheets.write_cell_sheets`, which raises
+    :class:`echemplot.origin._worksheets.OriginContractError` at
+    worksheet-write time. Surfacing the contract violation from the
+    range-aggregation path would tie compute_global_ranges to the same
+    error semantics for no benefit; the write path is the single
+    enforcement point.
     """
     chdis_x_vals: list[np.ndarray] = []
     chdis_y_vals: list[np.ndarray] = []
@@ -193,10 +199,16 @@ def compute_global_ranges(cells: Sequence[Any]) -> _GraphRanges:
         # column to match the post-``reset_index`` layout used when
         # writing the sheet. See :func:`._worksheets.write_cell_sheets`.
         cap = cell.cap_df.reset_index()
-        if cap.shape[1] > _CYCLE_COL_CE:
-            cycle_x_vals.append(cap.iloc[:, _CYCLE_COL_CYCLE].to_numpy(dtype=float))
-            cycle_left_vals.append(cap.iloc[:, _CYCLE_COL_QDIS].to_numpy(dtype=float))
-            cycle_right_vals.append(cap.iloc[:, _CYCLE_COL_CE].to_numpy(dtype=float))
+        cap_cols = list(cap.columns)
+        # Only contribute to the aggregation when every contracted
+        # column is present. The write path is the contract gate; here
+        # we just need the lookups to be safe so a malformed cell does
+        # not raise mid-aggregation before write_cell_sheets can produce
+        # the proper OriginContractError.
+        if all(name in cap_cols for name in _CYCLE_SHEET_COLUMNS):
+            cycle_x_vals.append(cap["cycle"].to_numpy(dtype=float))
+            cycle_left_vals.append(cap["q_dis"].to_numpy(dtype=float))
+            cycle_right_vals.append(cap["ce"].to_numpy(dtype=float))
     return _GraphRanges(
         chdis_x=_safe_range(np.concatenate(chdis_x_vals)) if chdis_x_vals else None,
         chdis_y=_safe_range(np.concatenate(chdis_y_vals)) if chdis_y_vals else None,
@@ -364,9 +376,23 @@ def _bind_cycle(graph: Any, sheet: Any) -> None:
     capacity), ``graph[1]`` is the right Y (Coulombic efficiency). Both
     share ``cycle`` as X. Each layer is rescaled after binding so the
     autoscale survives the template's default axis range.
+
+    Column indices are resolved by **name** against
+    :data:`_CYCLE_SHEET_COLUMNS` rather than baked-in positionals, so a
+    future ``get_cap_df`` schema change cannot silently shift which
+    column gets bound to which axis. The contract is enforced at
+    worksheet-write time by
+    :func:`echemplot.origin._worksheets.write_cell_sheets`, so by the
+    time we reach this helper the sheet is guaranteed to expose the
+    four contracted columns in their canonical order — the ``index()``
+    lookups below are therefore O(1) on a fixed-size tuple and cannot
+    miss.
     """
-    graph[0].add_plot(sheet, colx=_CYCLE_COL_CYCLE, coly=_CYCLE_COL_QDIS)
-    graph[1].add_plot(sheet, colx=_CYCLE_COL_CYCLE, coly=_CYCLE_COL_CE)
+    cycle_idx = _CYCLE_SHEET_COLUMNS.index("cycle")
+    qdis_idx = _CYCLE_SHEET_COLUMNS.index("q_dis")
+    ce_idx = _CYCLE_SHEET_COLUMNS.index("ce")
+    graph[0].add_plot(sheet, colx=cycle_idx, coly=qdis_idx)
+    graph[1].add_plot(sheet, colx=cycle_idx, coly=ce_idx)
     graph[0].rescale()
     graph[1].rescale()
 

--- a/src/echemplot/origin/_worksheets.py
+++ b/src/echemplot/origin/_worksheets.py
@@ -51,6 +51,52 @@ logger = logging.getLogger("echemplot.origin")
 # without an ``op`` handle in tests.
 _SHEET_NAME_MAX = 32
 
+# Contracted column shape for ``cap_df.reset_index()``: the cycle index
+# surfaced as the first column followed by the three derived metrics. The
+# metric columns are always English (``q_ch`` / ``q_dis`` / ``ce``) per
+# :func:`echemplot.core.capacity.get_cap_df`'s "fixed English" contract,
+# regardless of the cell's ``column_lang`` (which only selects the *input*
+# quantity label read out of ``chdis_df``). The cycle index is always
+# named ``cycle`` (set in ``get_cap_df``'s ``out.index.name = "cycle"``).
+#
+# This tuple is the single source of truth for both:
+# * the cycle_efficiency template's add_plot column indices
+#   (:func:`echemplot.origin._plots._bind_cycle`), and
+# * the worksheet-write-time contract assertion enforced in
+#   :func:`write_cell_sheets`.
+#
+# A future refactor that changes ``get_cap_df`` 's column names or order
+# must update this tuple, otherwise :class:`OriginContractError` fires
+# loudly during the next push instead of letting Origin silently bind the
+# wrong column to the cycle_efficiency plot.
+_CYCLE_SHEET_COLUMNS: tuple[str, ...] = ("cycle", "q_ch", "q_dis", "ce")
+
+
+class OriginContractError(ValueError):
+    """Raised when a DataFrame handed to the Origin push path violates a contract.
+
+    The Origin adapter binds plots to worksheet columns by *index*
+    (``add_plot(sheet, colx=..., coly=...)``) since ``originpro``'s
+    template-backed graph API takes 0-based positionals, not column
+    names. Inside the package we look up those positionals by name
+    against a contracted shape (e.g. :data:`_CYCLE_SHEET_COLUMNS` for
+    ``cap_df.reset_index()``); when the shape doesn't match, binding
+    silently to the wrong columns would produce a graph with the right
+    template but wrong-axis data — the worst kind of failure mode for a
+    visual diagnostic tool.
+
+    Subclasses :class:`ValueError` so callers that already catch
+    ``ValueError`` (e.g. ``push_to_origin``'s ``sg_window`` validation)
+    keep working without an extra ``except`` clause.
+
+    The package-internal nature of this exception is intentional: callers
+    of :func:`echemplot.origin.push_to_origin` should treat it as a
+    "your input frame is malformed" :class:`ValueError`, not a special
+    type to catch by name. Re-export from
+    :mod:`echemplot.origin` is therefore deliberately omitted.
+    """
+
+
 # Length of the hash suffix appended when a name must be truncated.
 # 8 hex chars from a SHA-1 gives ~4e9 uniqueness — ample for per-project
 # disambiguation and short enough to leave room for a recognizable prefix.
@@ -237,6 +283,28 @@ def write_cell_sheets(
     # regular column so Origin has an X source for the cycle_efficiency
     # plot. Matches the pattern :func:`write_stat_table` already uses.
     cap = cell.cap_df.reset_index()
+    # Contract gate: the cycle_efficiency plot binds columns by 0-based
+    # positional index, and those indices are derived in :mod:`._plots`
+    # from the canonical name order in :data:`_CYCLE_SHEET_COLUMNS`. If
+    # ``get_cap_df``'s output shape ever drifts (column rename, new
+    # column inserted in the middle, etc.) we want the push to fail
+    # loudly here — a wrong-axis cycle plot is a silent-correctness bug
+    # that would slip past every existing test. Verifying both names AND
+    # order guards against partial drift (e.g. q_ch and q_dis swapping
+    # places: the column set is still correct, but the bind would now
+    # plot charge capacity on the discharge-capacity axis).
+    actual_cap_cols = tuple(str(c) for c in cap.columns)
+    if actual_cap_cols != _CYCLE_SHEET_COLUMNS:
+        raise OriginContractError(
+            "cap_df.reset_index() column shape violates the cycle_efficiency "
+            "plot contract. Expected columns "
+            f"{list(_CYCLE_SHEET_COLUMNS)} (in this order); "
+            f"got {list(actual_cap_cols)}. "
+            "If echemplot.core.capacity.get_cap_df's output schema "
+            "changed intentionally, update _CYCLE_SHEET_COLUMNS in "
+            "echemplot.origin._worksheets and the corresponding bind "
+            "logic in echemplot.origin._plots."
+        )
     dqdv = cell.dqdv_df if dqdv_df is None else dqdv_df
 
     sheets: dict[str, Any] = {}
@@ -248,7 +316,8 @@ def write_cell_sheets(
     )
     # cap_df after reset_index: [cycle, q_ch, q_dis, ce] → "XYYY".
     # q_ch is kept as Y rather than dropped so the user can easily
-    # re-plot it without re-running the pipeline.
+    # re-plot it without re-running the pipeline. Column order is
+    # contract-checked above.
     sheets["cycle"] = _write_sheet(
         op,
         f"{cell.name}_cycle",

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -637,7 +637,9 @@ def test_cap_df_written_with_cycle_as_column(
     assert "cycle" in written.columns, (
         f"cycle column missing from cap_df write: {list(written.columns)}"
     )
-    # Order must match the _CYCLE_COL_* constants in _plots.py.
+    # Order must match the _CYCLE_SHEET_COLUMNS contract in
+    # echemplot.origin._worksheets — the cycle_efficiency template's
+    # add_plot indices are derived from that tuple.
     assert next(iter(written.columns)) == "cycle", list(written.columns)
 
 
@@ -1196,3 +1198,154 @@ def test_ranges_not_applied_when_dataframes_yield_no_finite_values(
 
     layer.axis.assert_not_called()
     layer.lt_exec.assert_not_called()
+
+
+# ----------------------------------------------------------------------
+# cap_df cycle-sheet column contract (issue #100)
+# ----------------------------------------------------------------------
+
+
+def _linear_cell_en(name: str, *, q_ch: float = 1000.0, q_dis: float = 990.0) -> Cell:
+    """Same shape as :func:`_linear_cell` but with EN raw columns + ``column_lang="en"``.
+
+    Used to confirm that the cycle-sheet contract holds across the
+    ``column_lang`` axis: ``get_cap_df`` always emits English derived
+    column names regardless of input language, so the same
+    :data:`_CYCLE_SHEET_COLUMNS` shape applies to both modes.
+    ``状態`` cell values stay JA — that's the documented per-row state
+    convention; only the *column headers* switch.
+    """
+    n_points = 30
+    rows: list[tuple[int, str, str, float, float]] = []
+    v_ch = np.linspace(3.0, 4.2, n_points)
+    q_ch_arr = np.linspace(0.0, q_ch, n_points)
+    rows.extend((1, "1", "充電", float(v), float(q)) for v, q in zip(v_ch, q_ch_arr))
+    v_dis = np.linspace(4.2, 3.0, n_points)
+    q_dis_arr = np.linspace(0.0, q_dis, n_points)
+    rows.extend((1, "1", "放電", float(v), float(q)) for v, q in zip(v_dis, q_dis_arr))
+    raw = pd.DataFrame(rows, columns=["cycle", "mode", "state", "voltage", "capacity"])
+    return Cell(name=name, mass_g=0.001, raw_df=raw, column_lang="en")
+
+
+def test_origin_cycle_sheet_contract_holds_for_default_capdf(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A normally-built ``Cell`` must satisfy the cycle-sheet column contract.
+
+    The Origin cycle_efficiency plot binds columns by 0-based positional
+    index; those indices are derived from
+    :data:`_CYCLE_SHEET_COLUMNS`. As long as
+    :func:`echemplot.core.capacity.get_cap_df` keeps emitting
+    ``[cycle, q_ch, q_dis, ce]`` in that order, ``push_to_origin`` must
+    complete without raising :class:`OriginContractError`.
+    """
+    _stub_templates(monkeypatch, tmp_path)
+    _install_mock_originpro(monkeypatch)
+    cell = _linear_cell("A")
+
+    from echemplot.origin import push_to_origin
+
+    # Must complete without raising the contract error. We don't assert
+    # on call counts here (separate tests already do); the goal is to
+    # exercise the contract gate on the happy path.
+    push_to_origin([cell], stat_cycles=(1,))
+
+
+def test_origin_cycle_sheet_contract_raises_on_reordered_capdf(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Reordering ``cap_df`` columns must raise :class:`OriginContractError`.
+
+    Patches :func:`echemplot.core.capacity.get_cap_df` (looked up where
+    :class:`Cell` imports it from, in :mod:`echemplot.core.cell`) to
+    return a frame whose columns swap ``q_ch`` and ``q_dis`` —
+    exercises the partial-drift case where the column *set* still matches
+    but the *order* is wrong, which would silently bind charge capacity
+    to the discharge-capacity axis if the contract weren't enforced.
+
+    The raised error must name both the expected and actual column
+    lists so a future maintainer can read the contract violation
+    straight from the traceback.
+    """
+    _stub_templates(monkeypatch, tmp_path)
+    _install_mock_originpro(monkeypatch)
+
+    from echemplot.core import cell as cell_mod
+    from echemplot.origin._worksheets import OriginContractError
+
+    real_get_cap_df = cell_mod.get_cap_df
+
+    def _reordered_get_cap_df(*args: Any, **kwargs: Any) -> pd.DataFrame:
+        df = real_get_cap_df(*args, **kwargs)
+        # Swap q_ch and q_dis: column set is unchanged, order is wrong.
+        return df[["q_dis", "q_ch", "ce"]]
+
+    monkeypatch.setattr(cell_mod, "get_cap_df", _reordered_get_cap_df)
+
+    cell = _linear_cell("A")
+
+    from echemplot.origin import push_to_origin
+
+    with pytest.raises(OriginContractError) as excinfo:
+        push_to_origin([cell], stat_cycles=(1,))
+
+    msg = str(excinfo.value)
+    # Both the expected and actual column lists must surface in the
+    # message so a future maintainer can diagnose the violation
+    # without grepping the source.
+    assert "cycle" in msg and "q_ch" in msg and "q_dis" in msg and "ce" in msg, msg
+    # The "got" list is the swapped order produced above
+    # (``cycle`` comes first via ``reset_index`` then the swapped pair).
+    assert "['cycle', 'q_dis', 'q_ch', 'ce']" in msg, msg
+    # And the expected list with the canonical order.
+    assert "['cycle', 'q_ch', 'q_dis', 'ce']" in msg, msg
+
+
+def test_origin_contract_error_subclasses_value_error() -> None:
+    """``OriginContractError`` must subclass ``ValueError``.
+
+    Callers of :func:`push_to_origin` already handle ``ValueError`` (the
+    ``sg_window`` validation raises plain ``ValueError``). Subclassing
+    keeps the broad ``except ValueError`` clauses in their code working
+    without an extra ``except OriginContractError`` arm.
+    """
+    from echemplot.origin._worksheets import OriginContractError
+
+    assert issubclass(OriginContractError, ValueError)
+
+
+@pytest.mark.parametrize("column_lang", ["ja", "en"])
+def test_origin_cycle_sheet_contract_works_for_both_langs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, column_lang: str
+) -> None:
+    """The cycle-sheet contract is the same in JA and EN ``column_lang`` modes.
+
+    :func:`echemplot.core.capacity.get_cap_df` documents its derived
+    column names as "fixed English" — ``column_lang`` only selects the
+    *input* quantity label read out of ``chdis_df``, not the output
+    schema. This test makes that invariant explicit at the Origin push
+    boundary so a future change to ``get_cap_df`` that started honoring
+    ``column_lang`` for output names would fail loudly here AND the
+    underlying ``OriginContractError`` raised from ``write_cell_sheets``.
+    """
+    _stub_templates(monkeypatch, tmp_path)
+    _, sheet_objs, _ = _install_tracking_originpro(monkeypatch)
+
+    cell = _linear_cell("A") if column_lang == "ja" else _linear_cell_en("A")
+
+    from echemplot.origin import push_to_origin
+
+    push_to_origin([cell], stat_cycles=(1,))
+
+    # Sheet creation order: chdis → cycle → dqdv → stat_table.
+    cycle_sheet = sheet_objs[1]
+    from_df_call = cycle_sheet.from_df.call_args
+    assert from_df_call is not None, "from_df not called on cycle sheet"
+    written = from_df_call.args[0]
+    # The contract holds in both modes: same English column names in
+    # the same order, regardless of which language the cell was built
+    # with. If this ever flips the test catches it before Origin
+    # silently mis-binds.
+    assert list(written.columns) == ["cycle", "q_ch", "q_dis", "ce"], (
+        f"column_lang={column_lang!r} produced {list(written.columns)}"
+    )


### PR DESCRIPTION
Closes #100

## Summary

- Replace the positional ``_CYCLE_COL_CYCLE`` / ``_CYCLE_COL_QDIS`` / ``_CYCLE_COL_CE`` integer constants in ``echemplot.origin._plots`` with a named-tuple contract ``_CYCLE_SHEET_COLUMNS = ("cycle", "q_ch", "q_dis", "ce")`` defined in ``echemplot.origin._worksheets`` and imported by ``_plots``. The cycle_efficiency bind helper resolves its ``add_plot`` column indices via ``.index()`` lookups on that tuple; ``compute_global_ranges`` reads ``cap_df`` columns by name instead of positional ``iloc``.
- Add a new ``OriginContractError`` (subclass of ``ValueError``) raised by ``write_cell_sheets`` when ``cap_df.reset_index().columns`` do not match the contracted shape, both in names AND order — partial drift (e.g. ``q_ch`` and ``q_dis`` swapping places) would otherwise silently bind charge capacity to the discharge-capacity axis. Kept package-internal: not re-exported from ``echemplot.origin``.
- Note on ``column_lang``: ``echemplot.core.capacity.get_cap_df`` documents its derived column names as "fixed English" regardless of ``column_lang`` (which only selects the *input* quantity label read out of ``chdis_df``). The contract is therefore the same in both JA and EN modes; the parametrised test asserts that invariant.

## Files changed

- ``src/echemplot/origin/_worksheets.py`` — add ``_CYCLE_SHEET_COLUMNS``, ``OriginContractError``, contract assertion at cycle-sheet write site
- ``src/echemplot/origin/_plots.py`` — replace ``_CYCLE_COL_*`` with name-based lookups in ``compute_global_ranges`` and ``_bind_cycle``
- ``tests/test_origin.py`` — 4 new focused contract tests (1 parametrised over ``column_lang``)
- ``CHANGELOG.md`` — Unreleased ``Changed`` entry + ``[#100]`` link reference

## Test plan

- [x] ``uv run ruff check .``
- [x] ``uv run ruff format --check .``
- [x] ``uv run mypy``
- [x] ``uv run pytest --cov=echemplot --cov-report=term-missing`` — 264 passed, ``_worksheets.py`` 96%, ``_plots.py`` 97%, total 89% (non-decreasing vs main)
- [x] ``uv build`` — wheel still ``echemplot-0.1.8-py3-none-any.whl``

🤖 Generated with [Claude Code](https://claude.com/claude-code)