### PR TITLE
refactor(io): replace whitespace-split PTN parser with fixed-column parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#99])
 
 ### Changed
+- Replaced the whitespace-split PTN parser in `read_ptn_mass` with a
+  fixed-column parser per the TOYO PTN format spec. The two known
+  dialects (concat: `0XX.XXXXXX`, spaced: `0 X.XXXXX`) are auto-detected
+  by the byte at index 1 of the 9-char composite at column 44. The
+  previous V2.01 whitespace-split heuristic remains available behind the
+  `ECHEMPLOT_PTN_LEGACY=1` environment variable as a debug escape hatch
+  for hypothetical third dialects. ([#102])
 - Replaced positional `_CYCLE_COL_*` integer indices in
   `origin/_plots.py` with name-based column lookups, and added an
   `OriginContractError` raised at worksheet-write time if `cap_df`
@@ -354,6 +361,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#99]: https://github.com/tomooki/toyo-battery/issues/99
 [#100]: https://github.com/tomooki/toyo-battery/issues/100
 [#101]: https://github.com/tomooki/toyo-battery/issues/101
+[#102]: https://github.com/tomooki/toyo-battery/issues/102
 [#103]: https://github.com/tomooki/toyo-battery/issues/103
 [#104]: https://github.com/tomooki/toyo-battery/issues/104
 [#107]: https://github.com/tomooki/toyo-battery/pull/107

--- a/src/echemplot/io/reader.py
+++ b/src/echemplot/io/reader.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import re
 from pathlib import Path
 from typing import cast
@@ -186,36 +187,84 @@ _METADATA_MASS_KEY = "重量[mg]"
 # a scan of the first 4 rows is generous.
 _METADATA_SCAN_ROWS = 4
 
+# Fixed-column layout for the PTN mass field on line 0. The TOYO PTN format
+# always places a 9-character ``<flag><mass>`` composite at character offset
+# 44 (after a 42-char operator field + the literal ``"2 "`` electrode-count
+# prefix). The 9-char composite is one of two known dialects:
+#
+# * "concat" (cyclers No5 / No1):  ``flag(1) + mass(%.6f, 8 chars)``
+#                                  e.g. ``"00.000358"`` — flag at index 0,
+#                                  mass at index 1..8.
+# * "spaced" (cycler No6):         ``flag(1) + " "(1) + mass(%.5f, 7 chars)``
+#                                  e.g. ``"0 0.00116"`` — mass at index 2..8.
+#
+# Detection: examine the byte at index 1 of the 9-char composite. ``" "`` →
+# spaced dialect; otherwise concat. ``tests/conftest.py:write_ptn_main`` is
+# the synthetic-fixture truth source; real-data validation against No1 / No5
+# / No6 cyclers is recorded in PR #90 (issue #90). Character indexing is safe
+# even when the operator field contains multi-byte JP names because the file
+# is decoded Shift-JIS first and ``str.ljust`` pads in characters.
+_PTN_MASS_FIELD_START = 44
+_PTN_MASS_FIELD_LEN = 9
+_PTN_MASS_FIELD_END = _PTN_MASS_FIELD_START + _PTN_MASS_FIELD_LEN  # 53
 
-def read_ptn_mass(ptn_path: str | Path) -> float:
-    """Extract active-material mass (grams) from a ``.PTN`` file.
+# Escape hatch: when this env var is set to a truthy value the legacy
+# ``TOYO_Origin_2.01`` heuristic (``str.split()`` + ``token[2] / token[3]``
+# fallback) is used instead of the fixed-column parser. Provided for users
+# who hit a third PTN dialect in the wild — file an issue if you need this.
+_PTN_LEGACY_ENV_VAR = "ECHEMPLOT_PTN_LEGACY"
 
-    TOYO ships at least two PTN dialects that differ in how the mass field
-    is rendered on line 0. Both encode the field as a 9-byte composite of
-    ``<flag><mass>``:
 
-    * Older dialect (e.g. cycler "No6"): ``"0 0.00116"`` — flag, space,
-      ``%.5f`` mass. ``str.split()`` yields the flag at ``tokens[2]`` and
-      the mass at ``tokens[3]``.
-    * Newer dialect (e.g. cyclers "No5"/"No1"): ``"00.000358"`` — flag
-      glued to a ``%.6f`` mass. ``tokens[2]`` parses directly as the mass.
+def _is_legacy_ptn_mode() -> bool:
+    val = os.environ.get(_PTN_LEGACY_ENV_VAR, "").strip().lower()
+    return val in {"1", "true", "yes", "on"}
 
-    Match the legacy ``TOYO_Origin_2.01`` heuristic: take ``tokens[2]``,
-    and if it parses as exactly zero, fall back to ``tokens[3]``.
 
-    Auxiliary ``.PTN`` files that TOYO ships alongside the main one
-    (``*_OPTION.PTN``, ``*_Option2.PTN``, etc.) carry INI- or CSV-style
-    configuration, not a mass; calling this on them will raise
-    ``ValueError``, which :func:`_resolve_mass_from_ptn` relies on to
-    skip them.
+def _parse_ptn_mass_fixed_column(first_line: str, path: Path) -> float:
+    """Parse the 9-char fixed-column mass field on line 0.
+
+    Detects the dialect by inspecting index 1 of the 9-char composite. Raises
+    ``ValueError`` on a short line, a non-numeric mass, or a non-positive
+    parsed value — :func:`_resolve_mass_from_ptn` relies on this to skip
+    auxiliary PTN files (e.g. ``*_OPTION.PTN``).
     """
-    path = Path(ptn_path)
-    encoding = "shift_jis"
+    if len(first_line) < _PTN_MASS_FIELD_END:
+        raise ValueError(
+            f"{path} line 0 is too short for the fixed-column PTN format "
+            f"(need {_PTN_MASS_FIELD_END} chars, got {len(first_line)}); "
+            f"set {_PTN_LEGACY_ENV_VAR}=1 to fall back to the legacy "
+            "whitespace-split parser if your file uses a different layout."
+        )
+    composite = first_line[_PTN_MASS_FIELD_START:_PTN_MASS_FIELD_END]
+    if composite[1] == " ":
+        dialect = "spaced"
+        mass_str = composite[2:].strip()
+    else:
+        dialect = "concat"
+        mass_str = composite[1:].strip()
     try:
-        with path.open(encoding=encoding) as f:
-            first_line = f.readline()
-    except UnicodeDecodeError as e:
-        raise EncodingError(path, expected_encoding=encoding, original=e) from e
+        mass = float(mass_str)
+    except ValueError as e:
+        raise ValueError(
+            f"{path} line 0 fixed-column mass field {composite!r} (dialect={dialect!r}) "
+            f"is not a valid float; "
+            f"set {_PTN_LEGACY_ENV_VAR}=1 to fall back to the legacy parser if needed."
+        ) from e
+    if not math.isfinite(mass) or mass <= 0:
+        raise ValueError(
+            f"{path} line 0 fixed-column mass field {composite!r} (dialect={dialect!r}) "
+            f"parsed as non-positive value {mass!r}"
+        )
+    return mass
+
+
+def _parse_ptn_mass_legacy(first_line: str, path: Path) -> float:
+    """Legacy ``TOYO_Origin_2.01`` whitespace-split heuristic.
+
+    Take ``tokens[2]``; if it parses as exactly zero, fall back to
+    ``tokens[3]``. Preserved for the ``ECHEMPLOT_PTN_LEGACY=1`` escape hatch
+    and for the V2.01 parity tests under ``tests/legacy_v201/``.
+    """
     tokens = first_line.split()
     if len(tokens) < 3:
         raise ValueError(
@@ -236,6 +285,46 @@ def read_ptn_mass(ptn_path: str | Path) -> float:
         f"{path} line 0: token[2]=0 and token[3] absent or non-numeric; "
         "cannot extract active-material mass"
     )
+
+
+def read_ptn_mass(ptn_path: str | Path) -> float:
+    """Extract active-material mass (grams) from a ``.PTN`` file.
+
+    Uses a **fixed-column parser** by default: the TOYO PTN format places a
+    9-char ``<flag><mass>`` composite at character offset 44 of line 0, in
+    one of two known dialects:
+
+    * "concat" (cyclers No5 / No1): flag glued to a ``%.6f`` mass —
+      ``"00.000358"``.
+    * "spaced" (cycler No6): flag, space, then a ``%.5f`` mass —
+      ``"0 0.00116"``.
+
+    Dialect is auto-detected by the byte at index 1 of the composite (a
+    space implies spaced; otherwise concat). Both decode to the same numeric
+    mass.
+
+    The previous :data:`TOYO_Origin_2.01`-derived whitespace-split heuristic
+    (``tokens[2]``, falling back to ``tokens[3]`` when ``tokens[2]==0``) is
+    available behind the ``ECHEMPLOT_PTN_LEGACY=1`` environment variable as
+    an escape hatch for users who hit a third dialect in the wild.
+
+    Auxiliary ``.PTN`` files that TOYO ships alongside the main one
+    (``*_OPTION.PTN``, ``*_Option2.PTN``, etc.) carry INI- or CSV-style
+    configuration whose first line is too short for the fixed-column layout
+    and whose tokens don't form a positive mass; calling this on them will
+    raise ``ValueError``, which :func:`_resolve_mass_from_ptn` relies on to
+    skip them.
+    """
+    path = Path(ptn_path)
+    encoding = "shift_jis"
+    try:
+        with path.open(encoding=encoding) as f:
+            first_line = f.readline()
+    except UnicodeDecodeError as e:
+        raise EncodingError(path, expected_encoding=encoding, original=e) from e
+    if _is_legacy_ptn_mode():
+        return _parse_ptn_mass_legacy(first_line, path)
+    return _parse_ptn_mass_fixed_column(first_line, path)
 
 
 def read_cell_dir(

--- a/tests/legacy_v201/conftest.py
+++ b/tests/legacy_v201/conftest.py
@@ -1,0 +1,18 @@
+"""Autouse fixture: enable the V2.01 PTN parser for the legacy parity suite.
+
+The tests in this directory pin ``TOYO_Origin_2.01.py``-era behavior. The
+0.2.0 cleanup (issue #102) replaced the default ``read_ptn_mass`` with a
+fixed-column parser; the V2.01 ``token[2] / token[3]`` whitespace-split
+heuristic survives behind ``ECHEMPLOT_PTN_LEGACY=1``. This fixture sets
+that env var for every test under ``tests/legacy_v201/`` so the parity
+suite continues to exercise the legacy path it was written against.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _enable_v201_ptn_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ECHEMPLOT_PTN_LEGACY", "1")

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -24,11 +24,17 @@ from echemplot.io.schema import CANONICAL_COLUMNS_EN, CANONICAL_COLUMNS_JA
 
 
 def _write_fixed_column_ptn(path: Path, mass_g: float) -> None:
-    """Write a TOYO-style fixed-column PTN whose first line has the mass at token[2]."""
-    line = (
-        f" 1TestName                                 2 {mass_g:09.6f}       1{mass_g:09.6f}"
-        f"TestCell                                 24 00000"
-    )
+    """Write a TOYO-style fixed-column PTN whose first line has the mass at token[2].
+
+    Layout matches ``conftest.write_ptn_main`` (concat dialect): a 42-char
+    operator/electrode field, the literal ``"2 "`` electrode-count prefix,
+    a 9-char ``<flag><mass>`` composite at columns 44..52, 7 spaces, then a
+    9-char companion electrode block.
+    """
+    operator_field = " 1TestName".ljust(42)
+    field1 = f"0{mass_g:.6f}".rjust(9)
+    field2 = f"1{mass_g:.6f}".rjust(9)
+    line = f"{operator_field}2 {field1}       {field2}TestCell"
     path.write_text(line + "\n", encoding="shift_jis")
 
 
@@ -707,24 +713,46 @@ def test_read_ptn_mass_happy(tmp_path: Path) -> None:
     assert read_ptn_mass(ptn) == pytest.approx(1.234)
 
 
-def test_read_ptn_mass_simple_whitespace_format(tmp_path: Path) -> None:
-    """Legacy tests used to write ``ACTIVE_MATERIAL WEIGHT <float>``; that
-    format also works because ``split()[2]`` still picks the float."""
+def test_read_ptn_mass_simple_whitespace_format_under_legacy_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Under ``ECHEMPLOT_PTN_LEGACY=1``, the V2.01 whitespace-split heuristic
+    accepts hand-crafted formats like ``ACTIVE_MATERIAL WEIGHT <float>`` that
+    the new fixed-column parser rejects. This pins the escape-hatch path."""
+    monkeypatch.setenv("ECHEMPLOT_PTN_LEGACY", "1")
     ptn = tmp_path / "x.PTN"
     ptn.write_text("ACTIVE_MATERIAL WEIGHT 1.234\n", encoding="shift_jis")
     assert read_ptn_mass(ptn) == pytest.approx(1.234)
 
 
-def test_read_ptn_mass_malformed_raises(tmp_path: Path) -> None:
+def test_read_ptn_mass_too_short_raises(tmp_path: Path) -> None:
+    """A PTN whose first line is shorter than the fixed-column mass field
+    raises so ``_resolve_mass_from_ptn`` can skip it (e.g. ``*_OPTION.PTN``)."""
+    ptn = tmp_path / "x.PTN"
+    ptn.write_text("too short\n", encoding="shift_jis")
+    with pytest.raises(ValueError, match="too short for the fixed-column PTN format"):
+        read_ptn_mass(ptn)
+
+
+def test_read_ptn_mass_legacy_short_line_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In legacy mode, a line with fewer than 3 whitespace tokens still raises."""
+    monkeypatch.setenv("ECHEMPLOT_PTN_LEGACY", "1")
     ptn = tmp_path / "x.PTN"
     ptn.write_text("too short\n", encoding="shift_jis")
     with pytest.raises(ValueError, match="fewer than 3 tokens"):
         read_ptn_mass(ptn)
 
 
-def test_read_ptn_mass_non_numeric_raises(tmp_path: Path) -> None:
+def test_read_ptn_mass_non_numeric_field_raises(tmp_path: Path) -> None:
+    """A 53+-char line whose 9-char composite field at columns 44..52 contains
+    non-numeric content raises ``ValueError`` mentioning the dialect."""
     ptn = tmp_path / "x.PTN"
-    ptn.write_text("A B NOT_A_NUMBER\n", encoding="shift_jis")
+    # 44 leading chars (canonical operator+"2 " block) followed by a 9-char
+    # garbage composite at the mass position.
+    junk = "X" * 44 + "0XXNOTANUM" + "extra"
+    ptn.write_text(junk + "\n", encoding="shift_jis")
     with pytest.raises(ValueError, match="not a valid float"):
         read_ptn_mass(ptn)
 
@@ -738,6 +766,62 @@ def test_read_ptn_mass_ini_style_raises(tmp_path: Path) -> None:
     ptn.write_text("[BaseCellCapacity]\nCapacity=0.1\n", encoding="shift_jis")
     with pytest.raises(ValueError):
         read_ptn_mass(ptn)
+
+
+# ---- read_ptn_mass fixed-column parser (#102) ----------------------------
+
+
+def test_read_ptn_mass_concat_dialect(tmp_path: Path) -> None:
+    """Concat dialect (cyclers No5/No1): flag glued to ``%.6f`` mass."""
+    from .conftest import write_ptn_main
+
+    ptn = tmp_path / "x.PTN"
+    write_ptn_main(ptn, mass_g=0.000358, dialect="concat")
+    assert read_ptn_mass(ptn) == pytest.approx(0.000358)
+
+
+def test_read_ptn_mass_spaced_dialect(tmp_path: Path) -> None:
+    """Spaced dialect (cycler No6): flag, space, then ``%.5f`` mass."""
+    from .conftest import write_ptn_main
+
+    ptn = tmp_path / "x.PTN"
+    write_ptn_main(ptn, mass_g=0.00116, dialect="spaced")
+    assert read_ptn_mass(ptn) == pytest.approx(0.00116)
+
+
+def test_read_ptn_mass_japanese_operator_name(tmp_path: Path) -> None:
+    """Multi-byte JP operator names don't shift the fixed-column position
+    because the file is decoded Shift-JIS first and ``ljust`` pads in
+    characters, not bytes."""
+    from .conftest import write_ptn_main
+
+    ptn = tmp_path / "x.PTN"
+    write_ptn_main(ptn, mass_g=0.00116, dialect="spaced", operator="ともい")
+    assert read_ptn_mass(ptn) == pytest.approx(0.00116)
+
+
+def test_read_ptn_mass_negative_mass_field_raises(tmp_path: Path) -> None:
+    """A composite that parses but yields a non-positive mass raises so the
+    file is skipped (defensive against malformed flag bytes)."""
+    ptn = tmp_path / "x.PTN"
+    # 44-char prefix + composite "0-0.00100" (concat-shape, parses to -0.00100).
+    junk = "X" * 44 + "0-0.00100" + "tail"
+    ptn.write_text(junk + "\n", encoding="shift_jis")
+    with pytest.raises(ValueError, match="non-positive"):
+        read_ptn_mass(ptn)
+
+
+def test_read_ptn_mass_legacy_env_falls_back_to_whitespace_split(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``ECHEMPLOT_PTN_LEGACY=1`` enables the V2.01 ``token[2] / token[3]``
+    fallback for hypothetical third dialects."""
+    monkeypatch.setenv("ECHEMPLOT_PTN_LEGACY", "1")
+    ptn = tmp_path / "x.PTN"
+    # Line that is too short for the fixed-column parser but valid for
+    # whitespace-split with token[2] non-zero.
+    ptn.write_text("name id 1.234\n", encoding="shift_jis")
+    assert read_ptn_mass(ptn) == pytest.approx(1.234)
 
 
 # ---- strict-encoding error surface (Issue #96) ----------------------------


### PR DESCRIPTION
## Summary

Final PR of the V2.01 cleanup ([#105](https://github.com/tomooki/toyo-battery/issues/105)). Replaces the V2.01-derived whitespace-split heuristic in `read_ptn_mass` with a fixed-column parser per the TOYO PTN format spec.

- Two known dialects (concat: `0XX.XXXXXX`, spaced: `0 X.XXXXX`) are auto-detected by inspecting index 1 of the 9-char composite at character offset 44.
- Character indexing is safe across multi-byte JP operator names because the file is decoded Shift-JIS first.
- The previous whitespace-split heuristic remains available behind `ECHEMPLOT_PTN_LEGACY=1` as a debug escape hatch.
- V2.01 parity tests under `tests/legacy_v201/` now run with the legacy env var set via an autouse fixture (new `tests/legacy_v201/conftest.py`).

Closes #102.

## Files

- `src/echemplot/io/reader.py` — new `_parse_ptn_mass_fixed_column` + `_parse_ptn_mass_legacy` helpers, `_is_legacy_ptn_mode()` env-var gate, `read_ptn_mass` becomes a thin dispatcher.
- `tests/test_reader.py` — `_write_fixed_column_ptn` realigned to the canonical 44-char prefix layout (matching `conftest.write_ptn_main`); 6 new tests for the fixed-column parser, the legacy env-var fallback, and explicit short-line / non-numeric / non-positive failure modes.
- `tests/legacy_v201/conftest.py` (new) — autouse fixture sets `ECHEMPLOT_PTN_LEGACY=1` so the parity suite continues to exercise the V2.01 path it was written against.
- `CHANGELOG.md` — `[Unreleased] → ### Changed` entry + `[#102]` link reference.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy` — strict, no issues across 23 source files
- [x] `uv run pytest --cov=echemplot --cov-report=term-missing` — 288 passed, coverage 89% → 90%
- [ ] CI green on Linux + Windows × Python 3.9-3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)