### PR TITLE
fix(gui): release Origin Console on Run errors in origin_mode

### DIFF
--- a/src/echemplot/gui/tk_app.py
+++ b/src/echemplot/gui/tk_app.py
@@ -387,17 +387,17 @@ class _App:
                     dqdv_range=_parse_range(self._entry_drange.get(), "dQ/dV range"),
                 )
         except ValueError as exc:
-            self._fail(f"Invalid input: {exc}")
+            self._fail_and_maybe_close(f"Invalid input: {exc}")
             return
 
         # Controller-level validation (empty dirs / no kinds) raises too.
         try:
             result = run(request)
         except ValueError as exc:
-            self._fail(f"Invalid request: {exc}")
+            self._fail_and_maybe_close(f"Invalid request: {exc}")
             return
         except Exception as exc:
-            self._fail(f"Error running pipeline: {exc}")
+            self._fail_and_maybe_close(f"Error running pipeline: {exc}")
             return
 
         if self._on_complete is not None:
@@ -410,7 +410,17 @@ class _App:
                 # effect on the pushed output. See issue #60.
                 self._on_complete(result.cells, result.figures, request.sg_window)
             except Exception as exc:
-                self._fail(f"Error in completion hook: {exc}")
+                # Drop the traceback chain BEFORE the modal blocks: in
+                # origin_mode the chain transitively pins partial Origin
+                # COM proxies created by ``push_to_origin`` before it
+                # raised, and Origin's "is a Python script running?"
+                # probe can fire while ``messagebox.showerror`` is up.
+                # Implicit ``del exc`` at end-of-except runs too late
+                # (after ``root.destroy``). See issue history for the
+                # "stop external script execution" dialog bug.
+                msg = f"Error in completion hook: {exc}"
+                exc = None  # type: ignore[assignment]
+                self._fail_and_maybe_close(msg)
                 return
             self._status.set(f"Ran {len(result.figures)} figure(s); pushed via hook.")
             if self._origin_mode:
@@ -458,6 +468,27 @@ class _App:
         """Surface ``message`` via a modal error and the status bar."""
         messagebox.showerror("echemplot", message, parent=self.root)
         self._status.set(message)
+
+    def _fail_and_maybe_close(self, message: str) -> None:
+        """Surface error, then auto-close the root in ``origin_mode``.
+
+        In origin_mode the Tk mainloop blocks the Origin Python Console
+        (``launch_gui()`` is a one-shot batch). If we leave the window
+        open after a failed Run, Origin's "is a Python script running?"
+        check trips when the user later clicks the Origin close button
+        and shows a confusing "stop external script execution" warning.
+        ``messagebox.showerror`` is modal, so by the time we get here the
+        user has already dismissed the dialog; auto-closing the window
+        afterwards lets them re-invoke ``launch_gui()`` from the Console.
+        ``gc.collect()`` releases any Origin COM proxies that participate
+        in reference cycles before mainloop exits.
+        """
+        self._fail(message)
+        if self._origin_mode:
+            import gc
+
+            gc.collect()
+            self.root.destroy()
 
 
 def launch_gui(

--- a/src/echemplot/origin/__init__.py
+++ b/src/echemplot/origin/__init__.py
@@ -228,22 +228,28 @@ def launch_gui(
         # defaults and can't surface per-run overrides on its own (see
         # issue #60), so ``push_to_origin`` recomputes the frame when the
         # caller supplies a non-default window.
-        push_to_origin(
-            cells,
-            project_path=project_path,
-            stat_cycles=stat_cycles,
-            sg_window=sg_window,
-        )
-        # Close the figures the controller built. The Origin path
-        # bypasses ``_show_figure`` (which would otherwise own the close
-        # via ``WM_DELETE_WINDOW``), so a single Run still leaves several
-        # figures pinned in pyplot's global registry — the Tk root is
-        # destroyed right after this callback returns, but pyplot doesn't
-        # know about that and would keep the figures alive indefinitely.
         import matplotlib.pyplot as plt
 
-        for fig in figures:
-            plt.close(fig)
+        try:
+            push_to_origin(
+                cells,
+                project_path=project_path,
+                stat_cycles=stat_cycles,
+                sg_window=sg_window,
+            )
+        finally:
+            # Close the figures the controller built. The Origin path
+            # bypasses ``_show_figure`` (which would otherwise own the
+            # close via ``WM_DELETE_WINDOW``), so a single Run still
+            # leaves several figures pinned in pyplot's global registry
+            # — the Tk root is destroyed right after this callback
+            # returns, but pyplot doesn't know about that and would keep
+            # the figures alive indefinitely. ``finally`` so the cleanup
+            # also runs when ``push_to_origin`` raises (otherwise figures
+            # accumulate across repeated ``launch_gui()`` calls within
+            # the same Origin session).
+            for fig in figures:
+                plt.close(fig)
 
     _launch_tk_gui(on_complete=_push, origin_mode=True)
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -449,12 +449,17 @@ def test_app_origin_mode_destroys_root_after_successful_run(
         real_destroy()
 
 
-def test_app_origin_mode_keeps_root_when_on_complete_raises(
+def test_app_origin_mode_destroys_root_when_on_complete_raises(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """If the on_complete hook raises, ``_fail`` surfaces the error and
-    the root stays alive — the user needs the window to see the dialog
-    and retry.
+    """In origin_mode the Tk mainloop blocks the Origin Python Console;
+    if a Run fails inside ``on_complete`` (e.g. ``push_to_origin``
+    raises) we still need to free the Console after the user dismisses
+    the modal error. Otherwise Origin's "is a Python script running?"
+    probe trips when the user clicks the Origin close button and shows
+    the "stop external script execution" warning. ``messagebox.showerror``
+    is modal so the user sees the error before destroy fires; re-running
+    is one more ``launch_gui()`` call from the Console.
     """
     import tkinter as tk
     from tkinter import messagebox
@@ -487,7 +492,134 @@ def test_app_origin_mode_keeps_root_when_on_complete_raises(
 
         app._on_run()
 
-        assert not destroy_calls, "root must stay alive when on_complete raises"
+        assert destroy_calls, "root must be destroyed when on_complete raises in origin_mode"
+    finally:
+        real_destroy()
+
+
+def test_app_origin_mode_destroys_root_when_controller_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same Console-block rationale as the on_complete test, but for the
+    earlier controller-error branch: a directory that cannot be loaded
+    or a plotting failure inside ``run()`` must also auto-close the Tk
+    root in origin_mode so the Origin Python Console is freed.
+    """
+    import tkinter as tk
+    from tkinter import messagebox
+
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no display available for Tk: {exc}")
+
+    import echemplot.gui.tk_app as tk_app
+
+    real_destroy = root.destroy
+    destroy_calls: list[None] = []
+
+    def spy_destroy() -> None:
+        destroy_calls.append(None)
+
+    def raising_run(_req: object) -> None:
+        raise RuntimeError("simulated controller failure")
+
+    try:
+        monkeypatch.setattr(tk_app, "run", raising_run)
+        monkeypatch.setattr(messagebox, "showerror", lambda *_a, **_kw: None)
+
+        app = tk_app._App(root, origin_mode=True, on_complete=lambda *_a: None)
+        app._dirs = [tmp_path]
+        root.destroy = spy_destroy  # type: ignore[assignment,method-assign]
+
+        app._on_run()
+
+        assert destroy_calls, "root must be destroyed when controller raises in origin_mode"
+    finally:
+        real_destroy()
+
+
+def test_app_origin_mode_destroys_root_on_input_validation_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Input parsing in origin_mode is narrow (only ``SG window_length``
+    flows through) but still raises ``ValueError`` for non-positive or
+    even integers. That early-exit branch must also destroy the root in
+    origin_mode for the same Console-block reason.
+    """
+    import tkinter as tk
+    from tkinter import messagebox
+
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no display available for Tk: {exc}")
+
+    import echemplot.gui.tk_app as tk_app
+
+    real_destroy = root.destroy
+    destroy_calls: list[None] = []
+
+    def spy_destroy() -> None:
+        destroy_calls.append(None)
+
+    try:
+        monkeypatch.setattr(messagebox, "showerror", lambda *_a, **_kw: None)
+
+        app = tk_app._App(root, origin_mode=True, on_complete=lambda *_a: None)
+        app._dirs = [tmp_path]
+        # Even integers fail ``_parse_sg_window`` (positive odd required).
+        app._entry_sg.delete(0, "end")
+        app._entry_sg.insert(0, "10")
+        root.destroy = spy_destroy  # type: ignore[assignment,method-assign]
+
+        app._on_run()
+
+        assert destroy_calls, "root must be destroyed on input validation error in origin_mode"
+    finally:
+        real_destroy()
+
+
+def test_app_standalone_mode_keeps_root_when_on_complete_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression guard for the standalone GUI: when ``origin_mode=False``
+    the auto-close behavior is gated off and the window must stay alive
+    after a failed Run so the user can fix inputs and retry without
+    losing the matplotlib Toplevels.
+    """
+    import tkinter as tk
+    from tkinter import messagebox
+
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no display available for Tk: {exc}")
+
+    import echemplot.gui.tk_app as tk_app
+    from echemplot.gui._controller import RunResult
+
+    real_destroy = root.destroy
+    destroy_calls: list[None] = []
+
+    def spy_destroy() -> None:
+        destroy_calls.append(None)
+
+    try:
+        monkeypatch.setattr(tk_app, "run", lambda _req: RunResult(cells=[], figures=[]))
+        monkeypatch.setattr(messagebox, "showerror", lambda *_a, **_kw: None)
+
+        def raising_hook(_cells: object, _figs: object, _sg: int) -> None:
+            raise RuntimeError("simulated push failure")
+
+        # No origin_mode flag — defaults to False.
+        app = tk_app._App(root, on_complete=raising_hook)
+        app._dirs = [tmp_path]
+        root.destroy = spy_destroy  # type: ignore[assignment,method-assign]
+
+        app._on_run()
+
+        assert not destroy_calls, "standalone mode must not destroy root on error"
     finally:
         real_destroy()
 

--- a/tests/test_origin_launcher.py
+++ b/tests/test_origin_launcher.py
@@ -105,6 +105,56 @@ def test_launch_gui_passes_callback_that_calls_push_to_origin(
     assert call["sg_window"] == 11
 
 
+def test_push_callback_closes_figures_when_push_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The injected ``on_complete`` callback must close every figure even
+    when ``push_to_origin`` raises. Otherwise the figures leak in
+    pyplot's global registry across repeated ``launch_gui()`` calls
+    within a single Origin session, and Origin's "is a Python script
+    running?" probe sees the residual matplotlib state on the way out.
+    """
+    _install_mock_originpro(monkeypatch)
+
+    captured: dict[str, object] = {}
+
+    def fake_tk_launch(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    import echemplot.gui as gui_pkg
+
+    monkeypatch.setattr(gui_pkg, "launch_gui", fake_tk_launch)
+
+    def raising_push(_cells: object, **_kw: object) -> None:
+        raise RuntimeError("simulated push_to_origin failure")
+
+    import echemplot.origin as origin_mod
+
+    monkeypatch.setattr(origin_mod, "push_to_origin", raising_push)
+
+    origin_mod.launch_gui()
+
+    on_complete = captured.get("on_complete")
+    assert callable(on_complete)
+
+    import matplotlib
+
+    matplotlib.use("Agg")  # headless backend
+    import matplotlib.pyplot as plt
+
+    fig_a = plt.figure()
+    fig_b = plt.figure()
+    fig_nums = [fig_a.number, fig_b.number]
+    assert all(n in plt.get_fignums() for n in fig_nums)
+
+    with pytest.raises(RuntimeError, match="simulated push_to_origin failure"):
+        on_complete(["c"], [fig_a, fig_b], 11)  # type: ignore[operator]
+
+    assert all(n not in plt.get_fignums() for n in fig_nums), (
+        "figures must be closed even when push_to_origin raises"
+    )
+
+
 def test_launch_gui_defaults_match_push_to_origin_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- When `launch_gui()` is called from OriginPro's embedded Python Console and a Run fails, Origin later showed *「Originを閉じる前に外部スクリプトの実行を停止して下さい。pythonスクリプトが実行されているかもしれません。」* on close because the Tk mainloop kept running and partial Origin COM proxies stayed pinned in the exception traceback.
- Mirror the success-path auto-destroy on every error branch in `origin_mode` via a new `_fail_and_maybe_close` helper (`tk_app.py`); drop the traceback chain before the modal blocks so Origin's "is a script running?" probe doesn't see lingering COM refs while the dialog is up.
- Wrap `push_to_origin` in `try/finally` inside `launch_gui`'s `_push` callback (`origin/__init__.py`) so matplotlib figures are closed even when the push raises — prevents a leak across repeated `launch_gui()` calls in a single Origin session.

## Why

`op.exit()` is not an option (the embedded Python is *Origin itself* — calling `exit` would terminate Origin). The fix instead ensures the Tk mainloop exits and any partial Origin COM proxies are released before Origin's close-time probe runs.

The previous behavior of *keeping* the window open on error (so the user could retry) was wrong specifically for `origin_mode`: the Console blocks on `mainloop()`, so the user can't retry until destroy anyway. `messagebox.showerror` is modal, so the user always sees the error before destroy fires; re-running is one `launch_gui()` call from the Console. Standalone Tk (`origin_mode=False`) keeps the previous "window stays open on error" behavior — regression-tested.

## Reviewer notes

- The existing `test_app_origin_mode_keeps_root_when_on_complete_raises` (test_gui.py:452) explicitly asserted the old behavior. I inverted it to `..._destroys_root_...` with an updated docstring explaining the Console-block rationale.
- The `exc = None` line inside the `except Exception` block is load-bearing: implicit `del exc` at end-of-except runs *after* `root.destroy()`, which is too late — Origin's probe can fire while `messagebox.showerror` is up and `exc` (transitively holding push_to_origin's frame locals = partial worksheets/graphs) is still in scope.
- `gc.collect()` in `_fail_and_maybe_close` covers Origin COM proxies that participate in reference cycles (refcounting alone wouldn't release those).

## Test plan

- [x] `pytest tests/test_gui.py tests/test_origin_launcher.py -v` — 26 passed
- [x] `pytest` (full suite) — 265 passed, 3 skipped (pre-existing display-related skips), 0 failed
- [ ] **Manual verification in real OriginPro 2025** (the bug only manifests there):
  - Reproduce: trigger an error during Run (e.g. malformed cell directory). Confirm `Originを閉じる前に外部スクリプトの実行を停止して下さい` warning appeared on close before the fix.
  - After fix: error dialog → OK → Tk auto-closes → Console prompt returns → Origin closes cleanly with no warning.
  - Regression: success path still auto-closes; standalone `python -m echemplot.gui` still keeps window open on error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)