### PR TITLE
fix(origin): flatten arrays before concat in compute_global_ranges

### DIFF
--- a/src/echemplot/origin/_plots.py
+++ b/src/echemplot/origin/_plots.py
@@ -185,16 +185,25 @@ def compute_global_ranges(cells: Sequence[Any]) -> _GraphRanges:
     cycle_x_vals: list[np.ndarray] = []
     cycle_left_vals: list[np.ndarray] = []
     cycle_right_vals: list[np.ndarray] = []
+    # Each cell's chdis_df / dqdv_df can have a different number of
+    # (cycle, side) column pairs and a different row count, so the 2D
+    # arrays from different cells do not share a common axis-1 size.
+    # ``np.concatenate`` (default axis=0) requires every non-concat axis
+    # to match exactly, which would raise "along dimension 1, size N vs.
+    # size M" when cells have differing pair counts. ``_safe_range``
+    # ravels its input before computing min/max anyway, so we ravel here
+    # at append time and concatenate flat 1D arrays — equivalent result,
+    # no shape constraint.
     for cell in cells:
         chdis = cell.chdis_df
         if chdis.shape[1] >= 2:
             # even = capacity (x), odd = voltage (y)
-            chdis_x_vals.append(chdis.iloc[:, 0::2].to_numpy(dtype=float))
-            chdis_y_vals.append(chdis.iloc[:, 1::2].to_numpy(dtype=float))
+            chdis_x_vals.append(chdis.iloc[:, 0::2].to_numpy(dtype=float).ravel())
+            chdis_y_vals.append(chdis.iloc[:, 1::2].to_numpy(dtype=float).ravel())
         dqdv = cell.dqdv_df
         if dqdv.shape[1] >= 2:
-            dqdv_x_vals.append(dqdv.iloc[:, 0::2].to_numpy(dtype=float))
-            dqdv_y_vals.append(dqdv.iloc[:, 1::2].to_numpy(dtype=float))
+            dqdv_x_vals.append(dqdv.iloc[:, 0::2].to_numpy(dtype=float).ravel())
+            dqdv_y_vals.append(dqdv.iloc[:, 1::2].to_numpy(dtype=float).ravel())
         # cap_df carries the cycle number in its index; surface it as a
         # column to match the post-``reset_index`` layout used when
         # writing the sheet. See :func:`._worksheets.write_cell_sheets`.

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -823,6 +823,59 @@ def test_compute_global_ranges_extracts_per_axis_min_max() -> None:
     assert ranges.dqdv_y == (-8.0, 22.0)
 
 
+def test_compute_global_ranges_handles_cells_with_different_column_counts() -> None:
+    """Cells with mismatched (cycle, side) pair counts must not raise.
+
+    Regression for the np.concatenate "along dimension 1" failure that
+    surfaced when Run-ing multiple cells whose chdis_df / dqdv_df had
+    different numbers of column pairs (e.g. 50 cycles x 2 sides vs.
+    1 cycle x 1 side).
+    """
+    from echemplot.origin._plots import compute_global_ranges
+
+    chdis_a = pd.DataFrame(
+        {
+            "q_ch": [0.0, 500.0],
+            "v_ch": [3.0, 4.0],
+            "q_dis": [0.0, 480.0],
+            "v_dis": [4.0, 3.0],
+        }
+    )
+    chdis_b = pd.DataFrame({"q_ch": [0.0, 800.0], "v_ch": [3.1, 4.2]})
+
+    cap_a = pd.DataFrame(
+        {
+            "cycle": [1, 2],
+            "q_ch": [1000.0, 990.0],
+            "q_dis": [990.0, 980.0],
+            "ce": [99.0, 98.9],
+        }
+    ).set_index("cycle")
+    cap_b = pd.DataFrame(
+        {"cycle": [1], "q_ch": [800.0], "q_dis": [760.0], "ce": [95.0]}
+    ).set_index("cycle")
+
+    dqdv_a = pd.DataFrame(
+        {
+            "v_ch": [3.0, 3.5, 4.0],
+            "dqdv_ch": [10.0, 20.0, -5.0],
+            "v_dis": [4.0, 3.5, 3.0],
+            "dqdv_dis": [-3.0, -8.0, -1.0],
+        }
+    )
+    dqdv_b = pd.DataFrame({"v": [3.1, 4.1], "dqdv": [12.0, -8.0]})
+
+    a = _fake_cell(chdis=chdis_a, cap=cap_a, dqdv=dqdv_a, name="A")
+    b = _fake_cell(chdis=chdis_b, cap=cap_b, dqdv=dqdv_b, name="B")
+
+    ranges = compute_global_ranges([a, b])
+
+    assert ranges.chdis_x == (0.0, 800.0)
+    assert ranges.chdis_y == (3.0, 4.2)
+    assert ranges.dqdv_x == (3.0, 4.1)
+    assert ranges.dqdv_y == (-8.0, 20.0)
+
+
 def test_compute_global_ranges_single_cell_equals_cell_range() -> None:
     """With a single cell, global == that cell's own data range."""
     from echemplot.origin._plots import compute_global_ranges

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -872,6 +872,9 @@ def test_compute_global_ranges_handles_cells_with_different_column_counts() -> N
 
     assert ranges.chdis_x == (0.0, 800.0)
     assert ranges.chdis_y == (3.0, 4.2)
+    assert ranges.cycle_x == (1.0, 2.0)
+    assert ranges.cycle_left_y == (760.0, 990.0)
+    assert ranges.cycle_right_y == (95.0, 99.0)
     assert ranges.dqdv_x == (3.0, 4.1)
     assert ranges.dqdv_y == (-8.0, 20.0)
 

--- a/tests/test_origin.py
+++ b/tests/test_origin.py
@@ -851,9 +851,9 @@ def test_compute_global_ranges_handles_cells_with_different_column_counts() -> N
             "ce": [99.0, 98.9],
         }
     ).set_index("cycle")
-    cap_b = pd.DataFrame(
-        {"cycle": [1], "q_ch": [800.0], "q_dis": [760.0], "ce": [95.0]}
-    ).set_index("cycle")
+    cap_b = pd.DataFrame({"cycle": [1], "q_ch": [800.0], "q_dis": [760.0], "ce": [95.0]}).set_index(
+        "cycle"
+    )
 
     dqdv_a = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary

- 複数 Cell を origin_mode で Run すると completion hook 内で `np.concatenate` が `"along dimension 1, the array at index 0 has size N and the array at index 1 has size M"` で失敗する問題を修正
- `compute_global_ranges()` の `chdis_df` / `dqdv_df` 列抽出で 2D 配列のまま append → concat していたが、Cell ごとに `(cycle, side)` ペア数が異なると axis-1 のサイズが揃わず concat が通らなかった
- `_safe_range()` は入力を `.ravel()` してから min/max を取るので、append 時点で 1D 化すれば等価かつ shape 制約なしで concat できる

## What changed

- `src/echemplot/origin/_plots.py`: `chdis_x_vals` / `chdis_y_vals` / `dqdv_x_vals` / `dqdv_y_vals` への append を `.ravel()` 付きに変更し、なぜ 1D 化するかを explain するコメントを追加
- `tests/test_origin.py`: 列数の異なる 2 つの Cell（A: 4 列・2 ペア / B: 2 列・1 ペア）で `compute_global_ranges()` が raise せず正しい min/max を返すことを確認する regression テストを追加

## Test plan

- [x] `pytest tests/test_origin.py -k "compute_global_ranges or safe_range"` が pass（6/6）
- [x] `pytest tests/test_origin.py` が pass（51/51）
- [x] 実際に列数（サイクル数 × side 数）が大きく異なる 2 つの Cell ディレクトリを GUI に投入し Origin で Run、エラーが出ずプロットが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)