### PR TITLE
fix(chdis): prefer 総サイクル over サイクル as the chdis_df group key

### DIFF
--- a/src/echemplot/core/chdis.py
+++ b/src/echemplot/core/chdis.py
@@ -4,7 +4,15 @@ Splits a raw DataFrame (from :func:`echemplot.io.reader.read_cell_dir`)
 into per-cycle charge/discharge segments. The output is a wide DataFrame
 with a 3-level column MultiIndex:
 
-    level 0  cycle    — int cycle number (1, 2, 3, ...)
+    level 0  cycle    — int cycle number (1, 2, 3, ...). Sourced from
+                        ``総サイクル`` (the global cycle counter) when the
+                        column is present, otherwise from ``サイクル`` (per-
+                        mode counter). Multi-mode TOYO programs reset
+                        ``サイクル`` at every mode boundary so two physically
+                        distinct cycles can share ``サイクル=1`` — preferring
+                        ``総サイクル`` keeps them as separate groups so the
+                        running-max filter below does not have to disentangle
+                        sub-runs across mode boundaries.
     level 1  side     — "ch" or "dis"
     level 2  quantity — "電気量"/"電圧" (or EN equivalents) as in the input
 
@@ -46,7 +54,13 @@ import warnings
 import pandas as pd
 
 from echemplot.core import DataIntegrityWarning
-from echemplot.io.schema import JA_COLS, JA_TO_EN, STATE_JA_TO_EN, ColumnLang
+from echemplot.io.schema import (
+    COL_TOTAL_CYCLE_JA,
+    JA_COLS,
+    JA_TO_EN,
+    STATE_JA_TO_EN,
+    ColumnLang,
+)
 
 _CHARGE_JA = "充電"
 _DISCHARGE_JA = "放電"
@@ -55,11 +69,28 @@ _DISCHARGE_EN = STATE_JA_TO_EN[_DISCHARGE_JA]
 
 _NEEDED_KEYS = ("cycle", "state", "voltage", "capacity")
 
+_TOTAL_CYCLE_EN = JA_TO_EN[COL_TOTAL_CYCLE_JA]
+
 
 def _resolve_cols(column_lang: ColumnLang) -> dict[str, str]:
     if column_lang == "ja":
         return {k: JA_COLS[k] for k in _NEEDED_KEYS}
     return {k: JA_TO_EN[JA_COLS[k]] for k in _NEEDED_KEYS}
+
+
+def _resolve_cycle_col(df: pd.DataFrame, column_lang: ColumnLang, fallback: str) -> str:
+    """Return the column name used as the cycle key for groupby.
+
+    Prefers the global counter (``総サイクル`` / ``total_cycle``) when present
+    in ``df.columns``, otherwise returns ``fallback`` (the per-mode
+    ``サイクル`` / ``cycle`` column resolved by :func:`_resolve_cols`). The
+    global counter is the right key for multi-mode TOYO programs where the
+    per-mode counter resets at mode boundaries — see the module docstring.
+    """
+    total_col = COL_TOTAL_CYCLE_JA if column_lang == "ja" else _TOTAL_CYCLE_EN
+    if total_col in df.columns:
+        return total_col
+    return fallback
 
 
 def _resolve_states(column_lang: ColumnLang) -> tuple[str, str, dict[str, str]]:
@@ -119,12 +150,12 @@ def get_chdis_df(df: pd.DataFrame, *, column_lang: ColumnLang = "ja") -> pd.Data
             f"for column_lang={column_lang!r}; got columns={list(df.columns)}"
         )
 
-    cap_col, v_col, cycle_col, state_col = (
+    cap_col, v_col, state_col = (
         cols["capacity"],
         cols["voltage"],
-        cols["cycle"],
         cols["state"],
     )
+    cycle_col = _resolve_cycle_col(df, column_lang, fallback=cols["cycle"])
     charge_lbl, discharge_lbl, state_to_side = _resolve_states(column_lang)
 
     working = df.loc[df[state_col].isin([charge_lbl, discharge_lbl])].reset_index(drop=True)

--- a/src/echemplot/io/reader.py
+++ b/src/echemplot/io/reader.py
@@ -14,7 +14,10 @@ Discovery priority for a given cell directory ``path``:
 
 All three paths converge on the same canonical schema (canonical columns first;
 any extra source columns such as 経過時間[Sec] / 電流[mA] / 日付 / 時刻 /
-総ｻｲｸﾙ are preserved after them so downstream P1 phases can use them):
+総サイクル are preserved after them so downstream P1 phases can use them.
+The half-width source spelling ``総ｻｲｸﾙ`` is canonicalized to the full-width
+``総サイクル`` here so :mod:`echemplot.core.chdis` can prefer it over
+``サイクル`` as the cycle key without re-asking which form the reader emitted):
 
     Canonical columns: サイクル, モード, 状態, 電圧, 電気量
     状態 values:
@@ -176,8 +179,17 @@ _UNIT_ROW_FIRST_CELL_PATTERNS = (
 )
 
 # Half-width → full-width canonical rename. The raw 6-digit header row uses
-# half-width katakana for the cycle/mode columns.
-_RAW_TO_CANONICAL = {"ｻｲｸﾙ": "サイクル", "ﾓｰﾄﾞ": "モード", "電圧[V]": "電圧"}
+# half-width katakana for the cycle/mode columns. ``総ｻｲｸﾙ`` is the global
+# cycle counter (does not reset across mode boundaries); chdis prefers it as
+# the cycle key when present so multi-mode programs (e.g. formation in mode 1
+# followed by regular cycling in mode 2) do not collapse two physically
+# distinct cycles into a single chdis_df group.
+_RAW_TO_CANONICAL = {
+    "ｻｲｸﾙ": "サイクル",
+    "総ｻｲｸﾙ": "総サイクル",
+    "ﾓｰﾄﾞ": "モード",
+    "電圧[V]": "電圧",
+}
 
 # Metadata key used by the native 連続データ.csv to carry active-material mass.
 _METADATA_MASS_KEY = "重量[mg]"
@@ -342,7 +354,8 @@ def read_cell_dir(
         Canonical columns first (see :data:`schema.CANONICAL_COLUMNS_JA` or
         the EN equivalent when ``column_lang="en"``), followed by any extra
         columns present in the source file (e.g. 経過時間[Sec], 電流[mA],
-        日付, 時刻, 総ｻｲｸﾙ).
+        日付, 時刻, 総サイクル — half-width ``総ｻｲｸﾙ`` from the raw 6-digit
+        header is canonicalized to the full-width spelling).
     mass_g : float
         Active-material mass used for the capacity calculation, in grams.
         ``math.nan`` if the source already had 電気量 precomputed and no
@@ -595,7 +608,8 @@ def _drop_unnamed(df: pd.DataFrame) -> pd.DataFrame:
 
     Raw TOYO 6-digit files have 6-7 empty separator columns between the
     sensor block (``経過時間[Sec]/電圧[V]/電流[mA]``) and the per-row
-    metadata block (``状態/ﾓｰﾄﾞ/ｻｲｸﾙ/総ｻｲｸﾙ``). pandas names them
+    metadata block (``状態/ﾓｰﾄﾞ/ｻｲｸﾙ/総ｻｲｸﾙ``, which ``_clean_columns``
+    later canonicalizes to ``状態/モード/サイクル/総サイクル``). pandas names them
     ``Unnamed: 5``, ``Unnamed: 6``, ... — noise, never useful downstream.
     """
     keep = [c for c in df.columns if not str(c).startswith("Unnamed:")]

--- a/src/echemplot/io/schema.py
+++ b/src/echemplot/io/schema.py
@@ -25,6 +25,15 @@ COL_ELAPSED_S: str = "経過時間[Sec]"
 COL_CURRENT_MA: str = "電流[mA]"
 COL_CAPACITY: str = "電気量"
 
+# Optional global cycle counter that the TOYO firmware emits alongside the
+# per-mode ``サイクル`` column. Cyclers running multi-mode test programs
+# (e.g. mode 1 = formation, mode 2 = regular cycling) reset ``サイクル`` at
+# every mode boundary while ``総サイクル`` keeps counting monotonically; chdis
+# prefers ``総サイクル`` as the cycle key when present so cycles from
+# different modes do not get conflated. Half-width ``総ｻｲｸﾙ`` is the source
+# spelling and is canonicalized to this full-width form by the reader.
+COL_TOTAL_CYCLE_JA: str = "総サイクル"
+
 CANONICAL_COLUMNS_EN: tuple[str, ...] = (
     "cycle",
     "mode",
@@ -35,6 +44,7 @@ CANONICAL_COLUMNS_EN: tuple[str, ...] = (
 
 JA_TO_EN: dict[str, str] = {
     "サイクル": "cycle",
+    "総サイクル": "total_cycle",
     "モード": "mode",
     "状態": "state",
     "電圧": "voltage",

--- a/tests/test_chdis.py
+++ b/tests/test_chdis.py
@@ -325,3 +325,121 @@ def test_first_cycle_discharge_swaps_all_cycles_globally() -> None:
     for cycle in (1, 2, 3):
         assert out[(cycle, "ch", "電圧")].dropna().tolist() == [3.60, 3.40]
         assert out[(cycle, "dis", "電圧")].dropna().tolist() == [3.40, 3.60]
+
+
+def _raw_with_total_cycle(
+    rows: list[tuple[int, int, str, float, float]],
+    *,
+    lang: str = "ja",
+) -> pd.DataFrame:
+    """Build a frame with both ``サイクル`` and ``総サイクル``.
+
+    Row tuple = (cycle, total_cycle, state, voltage, capacity).
+    """
+    if lang == "ja":
+        columns = ["サイクル", "総サイクル", "状態", "電圧", "電気量"]
+    else:
+        columns = ["cycle", "total_cycle", "state", "voltage", "capacity"]
+    return pd.DataFrame(rows, columns=columns)
+
+
+def test_total_cycle_column_supersedes_cycle() -> None:
+    """When ``総サイクル`` is present it is preferred over ``サイクル`` for grouping.
+
+    Multi-mode TOYO programs reset ``サイクル`` at every mode boundary while
+    ``総サイクル`` keeps counting monotonically. Without this preference, two
+    physically distinct cycles that share ``サイクル=1`` collapse into a
+    single chdis_df group; preferring ``総サイクル`` keeps them separate.
+    """
+    df = _raw_with_total_cycle(
+        [
+            # Mode 1, サイクル=1 → 総サイクル=1
+            (1, 1, "充電", 3.50, 0.0),
+            (1, 1, "充電", 3.60, 500.0),
+            (1, 1, "放電", 3.60, 0.0),
+            (1, 1, "放電", 3.40, 500.0),
+            # Mode 2 boundary: cycler resets サイクル to 1 again
+            # but 総サイクル continues to 2.
+            (1, 2, "充電", 3.55, 0.0),
+            (1, 2, "充電", 3.65, 600.0),
+            (1, 2, "放電", 3.65, 0.0),
+            (1, 2, "放電", 3.45, 600.0),
+        ]
+    )
+    out = get_chdis_df(df)
+    assert sorted(out.columns.get_level_values("cycle").unique().tolist()) == [1, 2]
+    # First mode's run lands under cycle 1 only.
+    assert out[(1, "ch", "電気量")].dropna().tolist() == [0.0, 500.0]
+    assert out[(1, "dis", "電気量")].dropna().tolist() == [0.0, 500.0]
+    # Second mode's run lands under cycle 2 only — no cross-contamination.
+    assert out[(2, "ch", "電気量")].dropna().tolist() == [0.0, 600.0]
+    assert out[(2, "dis", "電気量")].dropna().tolist() == [0.0, 600.0]
+
+
+def test_no_total_cycle_falls_back_to_cycle() -> None:
+    """Without ``総サイクル`` the per-mode ``サイクル`` is the cycle key (legacy)."""
+    df = _raw(
+        [
+            (1, "充電", 3.50, 0.0),
+            (1, "充電", 3.60, 500.0),
+            (2, "充電", 3.55, 0.0),
+            (2, "充電", 3.65, 600.0),
+        ]
+    )
+    out = get_chdis_df(df)
+    assert sorted(out.columns.get_level_values("cycle").unique().tolist()) == [1, 2]
+    assert out[(1, "ch", "電気量")].dropna().tolist() == [0.0, 500.0]
+    assert out[(2, "ch", "電気量")].dropna().tolist() == [0.0, 600.0]
+
+
+def test_multi_run_within_cycle_no_leakage_regression() -> None:
+    """Regression for the No6 ``98`` cell artifact (cycle 2 leaking into cycle 1).
+
+    Two charge sub-runs share ``サイクル=1`` because the cycler resets the
+    per-mode counter at the mode 1→2 boundary. The second sub-run's tail
+    capacity (1100) exceeds the first sub-run's max (1000); under the legacy
+    ``サイクル``-only grouping the running-max filter would keep the second
+    sub-run's tail and stitch it onto cycle 1's curve as a visible V drop.
+    With ``総サイクル`` as the cycle key the sub-runs become cycles 1 and 2
+    respectively and no leakage is possible.
+    """
+    df = _raw_with_total_cycle(
+        [
+            # Sub-run 1: smooth charge to 1000
+            (1, 1, "充電", 3.00, 0.0),
+            (1, 1, "充電", 3.50, 500.0),
+            (1, 1, "充電", 4.00, 1000.0),
+            # Sub-run 2: cycler reset capacity but kept サイクル=1
+            (1, 2, "充電", 2.50, 0.0),
+            (1, 2, "充電", 3.20, 500.0),
+            (1, 2, "充電", 3.70, 1100.0),  # tail exceeds sub-run 1's max
+        ]
+    )
+    out = get_chdis_df(df)
+    # Cycle 1 must contain ONLY sub-run 1 (no tail of sub-run 2 leaking in).
+    cycle1_cap = out[(1, "ch", "電気量")].dropna().tolist()
+    cycle1_v = out[(1, "ch", "電圧")].dropna().tolist()
+    assert cycle1_cap == [0.0, 500.0, 1000.0]
+    assert cycle1_v == [3.00, 3.50, 4.00]
+    # Cycle 2 must contain sub-run 2's full data, untouched.
+    cycle2_cap = out[(2, "ch", "電気量")].dropna().tolist()
+    cycle2_v = out[(2, "ch", "電圧")].dropna().tolist()
+    assert cycle2_cap == [0.0, 500.0, 1100.0]
+    assert cycle2_v == [2.50, 3.20, 3.70]
+
+
+def test_total_cycle_column_supersedes_cycle_en_mode() -> None:
+    """EN-mode equivalent of test_total_cycle_column_supersedes_cycle."""
+    df = _raw_with_total_cycle(
+        [
+            (1, 1, "charge", 3.50, 0.0),
+            (1, 1, "charge", 3.60, 500.0),
+            (1, 2, "charge", 3.55, 0.0),
+            (1, 2, "charge", 3.65, 600.0),
+        ],
+        lang="en",
+    )
+    out = get_chdis_df(df, column_lang="en")
+    assert sorted(out.columns.get_level_values("cycle").unique().tolist()) == [1, 2]
+    assert out[(1, "ch", "capacity")].dropna().tolist() == [0.0, 500.0]
+    assert out[(2, "ch", "capacity")].dropna().tolist() == [0.0, 600.0]

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -303,6 +303,36 @@ def test_read_raw_6digit_multi_file(tmp_path: Path) -> None:
     assert df["サイクル"].tolist() == [1, 1, 2, 2]
 
 
+def test_read_raw_6digit_canonicalizes_total_cycle_column(tmp_path: Path) -> None:
+    """Raw 6-digit ``総ｻｲｸﾙ`` (half-width) is canonicalized to ``総サイクル``.
+
+    chdis.py prefers the global cycle counter as the cycle key; the reader
+    has to surface it under the full-width canonical spelling so chdis can
+    look it up without knowing the source dialect.
+    """
+    cell_dir = tmp_path / "total_cycle"
+    cell_dir.mkdir()
+    empty_sep = ",,,,,,"
+    header = f"日付,時刻,経過時間[Sec],電圧[V],電流[mA]{empty_sep},状態,ﾓｰﾄﾞ,ｻｲｸﾙ,総ｻｲｸﾙ"
+    rows = [
+        "0,0,0,0,0,0,0",
+        "",
+        header,
+        f"2025/01/01,00:00:00,00000000,+3.5000,1.000000{empty_sep},1, 1,  1,     1",
+        f"2025/01/01,00:30:00,00001800,+3.5500,1.000000{empty_sep},1, 1,  1,     2",
+    ]
+    (cell_dir / "000001").write_text("\n".join(rows) + "\n", encoding="shift_jis")
+    _write_fixed_column_ptn(cell_dir / "pattern.PTN", 0.001)
+    df, _ = read_cell_dir(cell_dir)
+    assert "総サイクル" in df.columns
+    assert "総ｻｲｸﾙ" not in df.columns
+    assert df["総サイクル"].tolist() == [1, 2]
+    # EN-mode rename: 総サイクル → total_cycle via JA_TO_EN.
+    df_en, _ = read_cell_dir(cell_dir, column_lang="en")
+    assert "total_cycle" in df_en.columns
+    assert df_en["total_cycle"].tolist() == [1, 2]
+
+
 def test_read_raw_6digit_mismatched_columns_raises(tmp_path: Path) -> None:
     cell_dir = tmp_path / "mismatch"
     cell_dir.mkdir()


### PR DESCRIPTION
## Summary

- The TOYO No6 dataset `Z:\TOYO\No6\DAT\Nakazawa_c245_L-KMnHCF_DME_CV\98` rendered the comparison_chdis_plot with an unnatural break: in cycle 1's V–Q curve, cycle 2's curve was drawn mid-plot (user report: "1サイクル目の充放電の途中で，2サイクル目の曲線が描画される").
- Root cause: that test program runs mode 1 (formation) followed by mode 2 (regular cycling), and the cycler resets `ｻｲｸﾙ` at every mode boundary. `get_chdis_df` groups by `(サイクル, 状態)`, so two physically distinct cycles that both ended up tagged `サイクル=1` were collapsed into a single group. After `pd.concat`, the running-max filter (`cap == cap.cummax()`) kept the first sub-run's data plus the **tail** of the second sub-run (where its capacity exceeded the first sub-run's max), producing a visible drop in V near the end of cycle 1.
- Fix: prefer the global cycle counter `総サイクル` over `サイクル` as the chdis cycle key when it is present in the input. With `総サイクル` as the key, each `(cycle, side)` group becomes a single contiguous sub-run and the existing running-max filter handles within-segment CV transitions cleanly. Falls back to `サイクル` when `総サイクル` is missing (older firmware / hand-crafted inputs), so legacy behaviour is preserved.

## Files changed

- `src/echemplot/io/schema.py` — add `総サイクル → total_cycle` to `JA_TO_EN`, expose `COL_TOTAL_CYCLE_JA` constant.
- `src/echemplot/io/reader.py` — extend `_RAW_TO_CANONICAL` so the half-width source spelling `総ｻｲｸﾙ` is canonicalized to the full-width `総サイクル`.
- `src/echemplot/core/chdis.py` — add `_resolve_cycle_col()` that prefers `総サイクル` (or its EN form `total_cycle`) when present in `df.columns`, otherwise falls back to `サイクル`. Module docstring updated to document the new cycle-key sourcing.
- `tests/test_chdis.py` — 4 new tests:
  - `test_total_cycle_column_supersedes_cycle` — basic preference behaviour.
  - `test_no_total_cycle_falls_back_to_cycle` — fallback path stays legacy.
  - `test_multi_run_within_cycle_no_leakage_regression` — synthetic regression for the No6 `98` failure mode (sub-run 2's tail capacity exceeds sub-run 1's max).
  - `test_total_cycle_column_supersedes_cycle_en_mode` — EN-mode parity.
- `tests/test_reader.py` — `test_read_raw_6digit_canonicalizes_total_cycle_column` covers the half-width → full-width rename and EN-mode column rename.

## Out of scope

- The running-max filter itself (`chdis.py:156-157`) is left as-is. With `総サイクル` as the cycle key each group is a single contiguous run, so the filter has no cross-run interaction to mishandle and the existing `test_capacity_step_boundary_within_charge_state_dropped` regression remains valid.
- The `サイクル` column is left untouched in the reader output (only the cycle key chdis uses changes), so any external consumer reading `サイクル` directly keeps the per-mode-reset semantics.

## Test plan

- [x] `uv run pytest` — 271 passed, 3 skipped (skips are unrelated env issues: typer/plotly extras not installed and Tk display unavailable on this host).
- [x] End-to-end check on the actual `98` directory: `cell.chdis_df.columns.get_level_values("cycle").unique()` returns `[1, 2, 3]` (was `[1, 2]` before the fix).
- [x] `plot_chdis([cell])` (matplotlib backend) produces three smooth V–Q curves on cell `98` with no mid-curve V drop — verified by saving a PNG and visually inspecting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)