### PR TITLE
fix(io): parse PTN mass by byte offset 45, not char offset 44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `read_ptn_mass` now locates the active-material mass by **byte** offset on
+  the raw Shift-JIS line (the 9-byte `<flag><mass>` composite at byte 45)
+  instead of by character offset 44 on the decoded string. The previous
+  fixed-column parser (introduced in v0.2.0, PR #122) misread real TOYO data
+  two ways: (1) a multi-byte Japanese operator name shifted the
+  decoded-string position and the composite was sliced mid-number, silently
+  returning a mass off by ~10⁶ (e.g. `784.0` g for a `0.000784` g cell); and
+  (2) a right-justified two-digit count field pushed the composite one column
+  right, so the slice contained an embedded space and `float()` raised —
+  surfacing as the visible "mass could not be read" error on cells such as
+  `Z:\TOYO\No1\DAT\ss_281_NaMnHCF_NaPF6ECPC\73`. Byte-offset slicing is
+  immune to multi-byte and space-containing operator names; it was validated
+  against ~2400 real `.PTN` files across cyclers No0-No6, agreeing with the
+  legacy whitespace parser on every well-formed file and reading correctly
+  even the files where the whitespace parser was itself wrong. A composite
+  that no longer starts with a flag digit now raises loudly instead of
+  returning a mis-sliced number, so future layout drift fails fast rather
+  than corrupting capacities silently. ([#129])
+
 ## [0.2.2] - 2026-04-29
 
 ### Fixed
@@ -403,6 +423,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#108]: https://github.com/tomooki/toyo-battery/pull/108
 [#125]: https://github.com/tomooki/toyo-battery/pull/125
 [#127]: https://github.com/tomooki/toyo-battery/pull/127
+[#129]: https://github.com/tomooki/toyo-battery/issues/129
 [0.0.3]: https://github.com/tomooki/toyo-battery/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/tomooki/toyo-battery/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/tomooki/toyo-battery/releases/tag/v0.0.1

--- a/src/echemplot/io/reader.py
+++ b/src/echemplot/io/reader.py
@@ -38,9 +38,10 @@ The active-material mass (grams) is resolved in this priority order:
 
 1. Explicit ``mass=`` argument (grams)
 2. ``重量[mg]`` from ``連続データ.csv`` metadata row 3 (converted mg → g)
-3. A ``*.PTN`` file whose first line's 3rd whitespace-separated token parses
-   as float (grams). Other ``.PTN`` files (e.g. ``*_OPTION.PTN`` config
-   files shipped alongside the main pattern file) are skipped automatically.
+3. A ``*.PTN`` file whose first line carries a 9-byte ``<flag><mass>``
+   composite at *byte* offset 45 (grams). Other ``.PTN`` files (e.g.
+   ``*_OPTION.PTN`` config files shipped alongside the main pattern file)
+   are skipped automatically. See :func:`read_ptn_mass`.
 
 On the raw 6-digit path the formula is::
 
@@ -200,25 +201,35 @@ _METADATA_MASS_KEY = "重量[mg]"
 _METADATA_SCAN_ROWS = 4
 
 # Fixed-column layout for the PTN mass field on line 0. The TOYO PTN format
-# always places a 9-character ``<flag><mass>`` composite at character offset
-# 44 (after a 42-char operator field + the literal ``"2 "`` electrode-count
-# prefix). The 9-char composite is one of two known dialects:
+# is fixed-column **in Shift-JIS bytes**: the 9-byte ``<flag><mass>``
+# composite always begins at *byte* offset 45 (a 42-byte operator/electrode
+# field, a right-justified numeric count field ending at byte 43, and a
+# single separator space at byte 44 precede it). The 9-byte composite is one
+# of two known dialects:
 #
 # * "concat" (cyclers No5 / No1):  ``flag(1) + mass(%.6f, 8 chars)``
-#                                  e.g. ``"00.000358"`` — flag at index 0,
+#                                  e.g. ``b"00.000358"`` — flag at index 0,
 #                                  mass at index 1..8.
 # * "spaced" (cycler No6):         ``flag(1) + " "(1) + mass(%.5f, 7 chars)``
-#                                  e.g. ``"0 0.00116"`` — mass at index 2..8.
+#                                  e.g. ``b"0 0.00116"`` — mass at index 2..8.
 #
-# Detection: examine the byte at index 1 of the 9-char composite. ``" "`` →
-# spaced dialect; otherwise concat. ``tests/conftest.py:write_ptn_main`` is
-# the synthetic-fixture truth source; real-data validation against No1 / No5
-# / No6 cyclers is recorded in PR #90 (issue #90). Character indexing is safe
-# even when the operator field contains multi-byte JP names because the file
-# is decoded Shift-JIS first and ``str.ljust`` pads in characters.
-_PTN_MASS_FIELD_START = 44
+# Detection: examine the byte at index 1 of the 9-byte composite. ``" "`` →
+# spaced dialect; otherwise concat.
+#
+# Indexing must be done on the **raw bytes**, not the Shift-JIS-decoded
+# string: a multi-byte operator name (e.g. a Japanese technician name) takes
+# two bytes but one character, so decoded-string indexing shifts the mass
+# field left and silently misreads it. The offset was 44 against the decoded
+# string in v0.2.x (PR #122); validation against ~2400 real PTN files across
+# cyclers No0-No6 showed the composite sits at byte 45 (the count field is
+# right-justified, so its width does not move the mass), and that byte-offset
+# indexing is the only layout robust to multi-byte and space-containing
+# operator names. See issue #129. ``tests/conftest.py:write_ptn_main`` is the
+# synthetic-fixture truth source and now assembles line 0 in bytes to mirror
+# this layout.
+_PTN_MASS_FIELD_START = 45
 _PTN_MASS_FIELD_LEN = 9
-_PTN_MASS_FIELD_END = _PTN_MASS_FIELD_START + _PTN_MASS_FIELD_LEN  # 53
+_PTN_MASS_FIELD_END = _PTN_MASS_FIELD_START + _PTN_MASS_FIELD_LEN  # 54
 
 # Escape hatch: when this env var is set to a truthy value the legacy
 # ``TOYO_Origin_2.01`` heuristic (``str.split()`` + ``token[2] / token[3]``
@@ -232,22 +243,50 @@ def _is_legacy_ptn_mode() -> bool:
     return val in {"1", "true", "yes", "on"}
 
 
-def _parse_ptn_mass_fixed_column(first_line: str, path: Path) -> float:
-    """Parse the 9-char fixed-column mass field on line 0.
+def _parse_ptn_mass_fixed_column(raw_line: bytes, path: Path) -> float:
+    """Parse the 9-byte fixed-column mass field at byte offset 45 of line 0.
 
-    Detects the dialect by inspecting index 1 of the 9-char composite. Raises
-    ``ValueError`` on a short line, a non-numeric mass, or a non-positive
-    parsed value — :func:`_resolve_mass_from_ptn` relies on this to skip
-    auxiliary PTN files (e.g. ``*_OPTION.PTN``).
+    ``raw_line`` is the **raw bytes** of line 0 (Shift-JIS, undecoded). The
+    mass field is ASCII (digits, ``.``, ``" "``, and a leading flag digit),
+    so the 9-byte composite is sliced positionally and decoded as ASCII.
+    Slicing on bytes — rather than the Shift-JIS-decoded string — is what
+    makes the position correct regardless of whether the preceding operator
+    field holds a single-byte or multi-byte (Japanese) name.
+
+    Dialect is detected by inspecting index 1 of the composite. Raises
+    ``ValueError`` on a short line, a non-ASCII composite, a flag byte that
+    is not a digit (the layout-mismatch signature), a non-numeric mass, or a
+    non-positive value — :func:`_resolve_mass_from_ptn` relies on this to
+    skip auxiliary PTN files (e.g. ``*_OPTION.PTN``).
     """
-    if len(first_line) < _PTN_MASS_FIELD_END:
+    composite_bytes = raw_line[_PTN_MASS_FIELD_START:_PTN_MASS_FIELD_END]
+    if len(composite_bytes) < _PTN_MASS_FIELD_LEN:
         raise ValueError(
             f"{path} line 0 is too short for the fixed-column PTN format "
-            f"(need {_PTN_MASS_FIELD_END} chars, got {len(first_line)}); "
+            f"(need {_PTN_MASS_FIELD_END} bytes, got {len(raw_line)}); "
             f"set {_PTN_LEGACY_ENV_VAR}=1 to fall back to the legacy "
             "whitespace-split parser if your file uses a different layout."
         )
-    composite = first_line[_PTN_MASS_FIELD_START:_PTN_MASS_FIELD_END]
+    try:
+        composite = composite_bytes.decode("ascii")
+    except UnicodeDecodeError as e:
+        raise ValueError(
+            f"{path} fixed-column mass field at byte "
+            f"{_PTN_MASS_FIELD_START}..{_PTN_MASS_FIELD_END} is not ASCII "
+            f"({composite_bytes!r}); set {_PTN_LEGACY_ENV_VAR}=1 to fall back "
+            "to the legacy parser if needed."
+        ) from e
+    # The composite always opens with a flag digit (0 for the primary
+    # electrode block). A non-digit here means the fixed-column window does
+    # not line up with the mass field — fail loudly instead of silently
+    # returning a mis-sliced number (the v0.2.x byte/char-offset bug).
+    if not composite[0].isdigit():
+        raise ValueError(
+            f"{path} fixed-column mass field {composite!r} does not start with "
+            f"a flag digit at byte {_PTN_MASS_FIELD_START}; line 0 does not "
+            f"match the expected TOYO PTN layout. Pass `mass=<grams>` or set "
+            f"{_PTN_LEGACY_ENV_VAR}=1 to use the legacy whitespace-split parser."
+        )
     if composite[1] == " ":
         dialect = "spaced"
         mass_str = composite[2:].strip()
@@ -258,13 +297,13 @@ def _parse_ptn_mass_fixed_column(first_line: str, path: Path) -> float:
         mass = float(mass_str)
     except ValueError as e:
         raise ValueError(
-            f"{path} line 0 fixed-column mass field {composite!r} (dialect={dialect!r}) "
+            f"{path} fixed-column mass field {composite!r} (dialect={dialect!r}) "
             f"is not a valid float; "
             f"set {_PTN_LEGACY_ENV_VAR}=1 to fall back to the legacy parser if needed."
         ) from e
     if not math.isfinite(mass) or mass <= 0:
         raise ValueError(
-            f"{path} line 0 fixed-column mass field {composite!r} (dialect={dialect!r}) "
+            f"{path} fixed-column mass field {composite!r} (dialect={dialect!r}) "
             f"parsed as non-positive value {mass!r}"
         )
     return mass
@@ -303,8 +342,8 @@ def read_ptn_mass(ptn_path: str | Path) -> float:
     """Extract active-material mass (grams) from a ``.PTN`` file.
 
     Uses a **fixed-column parser** by default: the TOYO PTN format places a
-    9-char ``<flag><mass>`` composite at character offset 44 of line 0, in
-    one of two known dialects:
+    9-byte ``<flag><mass>`` composite at *byte* offset 45 of line 0, in one
+    of two known dialects:
 
     * "concat" (cyclers No5 / No1): flag glued to a ``%.6f`` mass —
       ``"00.000358"``.
@@ -313,7 +352,8 @@ def read_ptn_mass(ptn_path: str | Path) -> float:
 
     Dialect is auto-detected by the byte at index 1 of the composite (a
     space implies spaced; otherwise concat). Both decode to the same numeric
-    mass.
+    mass. The field is located by **byte** offset (not decoded-string
+    offset) so a multi-byte Shift-JIS operator name does not shift it.
 
     The previous :data:`TOYO_Origin_2.01`-derived whitespace-split heuristic
     (``tokens[2]``, falling back to ``tokens[3]`` when ``tokens[2]==0``) is
@@ -326,17 +366,25 @@ def read_ptn_mass(ptn_path: str | Path) -> float:
     and whose tokens don't form a positive mass; calling this on them will
     raise ``ValueError``, which :func:`_resolve_mass_from_ptn` relies on to
     skip them.
+
+    Genuinely undecodable Shift-JIS bytes anywhere in line 0 raise
+    :class:`EncodingError` (a ``ValueError`` subclass) rather than a
+    downstream parse error.
     """
     path = Path(ptn_path)
     encoding = "shift_jis"
+    with path.open("rb") as f:
+        raw_line = f.readline().rstrip(b"\r\n")
+    # Validate that line 0 decodes cleanly so corrupt Shift-JIS bytes surface
+    # as EncodingError (issue #96). The decoded form also feeds the legacy
+    # whitespace parser; the fixed-column parser slices the raw bytes.
     try:
-        with path.open(encoding=encoding) as f:
-            first_line = f.readline()
+        decoded = raw_line.decode(encoding)
     except UnicodeDecodeError as e:
         raise EncodingError(path, expected_encoding=encoding, original=e) from e
     if _is_legacy_ptn_mode():
-        return _parse_ptn_mass_legacy(first_line, path)
-    return _parse_ptn_mass_fixed_column(first_line, path)
+        return _parse_ptn_mass_legacy(decoded, path)
+    return _parse_ptn_mass_fixed_column(raw_line, path)
 
 
 def read_cell_dir(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,23 +282,43 @@ def write_ptn_main(
     dialect: PtnDialect = "concat",
     operator: str = "Synthetic",
     sample: str = "TestCell",
+    count: int = 2,
 ) -> None:
     """Write a single main ``.PTN`` first-line in the requested TOYO dialect.
 
+    The line is assembled in **Shift-JIS bytes** to faithfully reproduce the
+    real TOYO fixed-column layout. The parser slices the mass field by *byte*
+    offset, so a character-based fixture would not exercise multi-byte
+    operator names (the v0.2.x byte/char-offset bug, issue #129):
+
+      * bytes ``[0:42]``  operator/electrode field, byte-padded (may be JP)
+      * bytes ``[42:44]`` sample/electrode count, right-justified ASCII digits
+      * byte  ``[44]``    separator space
+      * bytes ``[45:54]`` 9-byte ``<flag><mass>`` composite
+      * then 7 spaces, the companion (flag ``1``) composite, and the sample name
+
     ``concat`` is the newer dialect (cyclers No5/No1) where the per-electrode
-    flag is glued to the mass: ``"00.001000"``. ``spaced`` is the older
+    flag is glued to the mass: ``b"00.001000"``. ``spaced`` is the older
     dialect (cycler No6) where flag and mass are space-separated and the
-    mass uses ``%.5f``: ``"0 0.00100"``. Both occupy a 9-char composite
-    field and the surrounding fixed-width layout is otherwise identical.
+    mass uses ``%.5f``: ``b"0 0.00100"``.
     """
-    operator_field = f" 1{operator}".ljust(42)
+    operator_field = (" 1" + operator).encode("shift_jis").ljust(42)
+    count_field = str(count).encode("ascii").rjust(2)
     if dialect == "concat":
-        field1 = f"0{mass_g:.6f}".rjust(9)
-        field2 = f"1{mass_g:.6f}".rjust(9)
+        field1 = f"0{mass_g:.6f}".encode("ascii").rjust(9)
+        field2 = f"1{mass_g:.6f}".encode("ascii").rjust(9)
     elif dialect == "spaced":
-        field1 = f"0 {mass_g:.5f}".rjust(9)
-        field2 = f"1 {mass_g:.5f}".rjust(9)
+        field1 = f"0 {mass_g:.5f}".encode("ascii").rjust(9)
+        field2 = f"1 {mass_g:.5f}".encode("ascii").rjust(9)
     else:
         raise ValueError(f"unknown dialect: {dialect}")
-    line0 = f"{operator_field}2 {field1}       {field2}{sample}"
-    path.write_text(line0 + "\n", encoding="shift_jis")
+    line0 = (
+        operator_field
+        + count_field
+        + b" "
+        + field1
+        + b"       "
+        + field2
+        + sample.encode("shift_jis")
+    )
+    path.write_bytes(line0 + b"\n")

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -24,18 +24,19 @@ from echemplot.io.schema import CANONICAL_COLUMNS_EN, CANONICAL_COLUMNS_JA
 
 
 def _write_fixed_column_ptn(path: Path, mass_g: float) -> None:
-    """Write a TOYO-style fixed-column PTN whose first line has the mass at token[2].
+    """Write a TOYO-style fixed-column PTN (concat dialect) with the mass at byte 45.
 
-    Layout matches ``conftest.write_ptn_main`` (concat dialect): a 42-char
-    operator/electrode field, the literal ``"2 "`` electrode-count prefix,
-    a 9-char ``<flag><mass>`` composite at columns 44..52, 7 spaces, then a
-    9-char companion electrode block.
+    Byte layout mirrors ``conftest.write_ptn_main``: a 42-byte operator field,
+    a right-justified count ending at byte 43, a separator space at byte 44,
+    then the 9-byte ``<flag><mass>`` composite at bytes 45..53, 7 spaces, and
+    the companion electrode block.
     """
-    operator_field = " 1TestName".ljust(42)
-    field1 = f"0{mass_g:.6f}".rjust(9)
-    field2 = f"1{mass_g:.6f}".rjust(9)
-    line = f"{operator_field}2 {field1}       {field2}TestCell"
-    path.write_text(line + "\n", encoding="shift_jis")
+    operator_field = " 1TestName".encode("shift_jis").ljust(42)
+    count_field = b" 2"
+    field1 = f"0{mass_g:.6f}".encode("ascii").rjust(9)
+    field2 = f"1{mass_g:.6f}".encode("ascii").rjust(9)
+    line = operator_field + count_field + b" " + field1 + b"       " + field2 + b"TestCell"
+    path.write_bytes(line + b"\n")
 
 
 # ---- renzoku (native 連続データ.csv) path ----------------------------------
@@ -776,14 +777,27 @@ def test_read_ptn_mass_legacy_short_line_raises(
 
 
 def test_read_ptn_mass_non_numeric_field_raises(tmp_path: Path) -> None:
-    """A 53+-char line whose 9-char composite field at columns 44..52 contains
-    non-numeric content raises ``ValueError`` mentioning the dialect."""
+    """A line whose 9-byte composite at bytes 45..53 holds a digit flag but
+    non-numeric mass bytes raises ``ValueError`` mentioning the dialect."""
     ptn = tmp_path / "x.PTN"
-    # 44 leading chars (canonical operator+"2 " block) followed by a 9-char
-    # garbage composite at the mass position.
-    junk = "X" * 44 + "0XXNOTANUM" + "extra"
+    # 45 leading bytes, then a composite that opens with a flag digit (passes
+    # the alignment guard) but whose mass bytes are non-numeric.
+    junk = "X" * 45 + "0XXNOTANU" + "extra"
     ptn.write_text(junk + "\n", encoding="shift_jis")
     with pytest.raises(ValueError, match="not a valid float"):
+        read_ptn_mass(ptn)
+
+
+def test_read_ptn_mass_misaligned_flag_byte_raises(tmp_path: Path) -> None:
+    """A composite that does not open with a flag digit (the layout-mismatch
+    signature of the v0.2.x byte/char-offset bug) fails loudly rather than
+    silently returning a mis-sliced number."""
+    ptn = tmp_path / "x.PTN"
+    # Byte 45 is a space, not a flag digit — e.g. a layout where the mass
+    # field landed one column off.
+    junk = "X" * 45 + " 0.000784" + "extra"
+    ptn.write_text(junk + "\n", encoding="shift_jis")
+    with pytest.raises(ValueError, match="does not start with"):
         read_ptn_mass(ptn)
 
 
@@ -820,9 +834,13 @@ def test_read_ptn_mass_spaced_dialect(tmp_path: Path) -> None:
 
 
 def test_read_ptn_mass_japanese_operator_name(tmp_path: Path) -> None:
-    """Multi-byte JP operator names don't shift the fixed-column position
-    because the file is decoded Shift-JIS first and ``ljust`` pads in
-    characters, not bytes."""
+    """Multi-byte JP operator names don't shift the mass field because it is
+    sliced by *byte* offset on the raw Shift-JIS bytes.
+
+    Regression for issue #129: the v0.2.x parser sliced the decoded string at
+    char offset 44, so a Japanese technician name (2 bytes / 1 char each)
+    shifted the field left and silently misread the mass — the symptom that
+    surfaced as ``ss_281_NaMnHCF_NaPF6ECPC/73`` failing to read its weight."""
     from .conftest import write_ptn_main
 
     ptn = tmp_path / "x.PTN"
@@ -830,12 +848,33 @@ def test_read_ptn_mass_japanese_operator_name(tmp_path: Path) -> None:
     assert read_ptn_mass(ptn) == pytest.approx(0.00116)
 
 
+def test_read_ptn_mass_japanese_operator_name_concat(tmp_path: Path) -> None:
+    """Real No1/No2 cells pair a multi-byte JP operator name with the concat
+    dialect (e.g. ``00.000784``); the byte-offset parser must read it exactly."""
+    from .conftest import write_ptn_main
+
+    ptn = tmp_path / "x.PTN"
+    write_ptn_main(ptn, mass_g=0.000784, dialect="concat", operator="田とも", count=35)
+    assert read_ptn_mass(ptn) == pytest.approx(0.000784)
+
+
+def test_read_ptn_mass_two_digit_count_does_not_shift_field(tmp_path: Path) -> None:
+    """A 2-digit right-justified count must not shift the mass field. Mirrors
+    real cell ``ss_281_NaMnHCF_NaPF6ECPC/73`` (count ``55``, spaced dialect,
+    mass ``0.00014``) which raised the original weight-read error."""
+    from .conftest import write_ptn_main
+
+    ptn = tmp_path / "x.PTN"
+    write_ptn_main(ptn, mass_g=0.00014, dialect="spaced", operator="Sugayama2", count=55)
+    assert read_ptn_mass(ptn) == pytest.approx(0.00014)
+
+
 def test_read_ptn_mass_negative_mass_field_raises(tmp_path: Path) -> None:
     """A composite that parses but yields a non-positive mass raises so the
     file is skipped (defensive against malformed flag bytes)."""
     ptn = tmp_path / "x.PTN"
-    # 44-char prefix + composite "0-0.00100" (concat-shape, parses to -0.00100).
-    junk = "X" * 44 + "0-0.00100" + "tail"
+    # 45-byte prefix + composite "0-0.00100" (concat-shape, parses to -0.00100).
+    junk = "X" * 45 + "0-0.00100" + "tail"
     ptn.write_text(junk + "\n", encoding="shift_jis")
     with pytest.raises(ValueError, match="non-positive"):
         read_ptn_mass(ptn)


### PR DESCRIPTION
@
## Summary

The fixed-column PTN parser (#102 / PR #122) sliced the 9-char `<flag><mass>` composite from the **Shift-JIS-decoded string at character offset 44**. Real TOYO data breaks both assumptions:

- **Multi-byte JP operator name**: 2 bytes = 1 char, so decoded-string indexing shifts the mass field left and the composite is sliced mid-number — **silently** returning a mass off by ~10⁶ (e.g. `0.000784 g` → `784.0 g`), corrupting every per-cycle capacity.
- **Right-justified 2-digit count field**: pushes the composite one column right; the slice then carries an embedded space and `float()` raises — the visible "mass could not be read" error (e.g. `Z:\TOYO\No1\DAT\ss_281_NaMnHCF_NaPF6ECPC\73`).

The TOYO PTN format is fixed-column **in bytes**: the composite always begins at **byte 45**. This PR slices the raw bytes and decodes the 9-byte ASCII window — immune to multi-byte and space-containing operator names. A composite that no longer opens with a flag digit now **raises loudly** instead of returning a mis-sliced number, so future layout drift fails fast rather than corrupting capacities silently.

## Validation

Checked against **~2400 real `.PTN` files across cyclers No0-No6**:
- byte-45 agrees with the legacy whitespace parser on every well-formed file;
- byte-45 reads correctly even the files where whitespace tokenization was itself wrong (operator names containing spaces);
- the user-reported cell `ss_281_NaMnHCF_NaPF6ECPC/73` now reads `mass = 0.00014 g` (19503 rows).

## Tests

The synthetic fixtures (`write_ptn_main`, `_write_fixed_column_ptn`) were character-based and so **never exercised the byte/char divergence** — which is why the bug shipped. They now assemble line 0 in Shift-JIS bytes to mirror the real layout. New regression tests:

- JP operator name + concat dialect (the `田と…` / No1-No2 case)
- 2-digit right-justified count (the cell-73 case)
- misaligned-flag guard (loud failure on layout mismatch)

The #96 `EncodingError` contract and the `tests/legacy_v201/` parity suite are preserved. `ruff` / `ruff format` / `mypy --strict` / `pytest` (301 passed) all green.

## Out of scope

A separate, pre-existing case (1 file in No3) has a non-Shift-JIS byte in the operator name and raises `EncodingError` (unchanged behavior, not a regression); the mass is recoverable via `mass=`/`encoding=`.

Closes #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@